### PR TITLE
Immutable array

### DIFF
--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -15,7 +15,6 @@ trait Seq[+A] extends Iterable[A] with SeqLike[A, Seq] with ArrayLike[A]
   */
 trait LinearSeq[+A]
   extends Seq[A]
-    with LinearSeqLike[A, LinearSeq]
     with SeqMonoTransforms[A, LinearSeq[A]] { self =>
 
   /** To be overridden in implementations: */
@@ -23,7 +22,7 @@ trait LinearSeq[+A]
   def head: A
   def tail: LinearSeq[A]
 
-  /** `iterator` is overridden in terms of `head` and `tail` */
+  /** `iterator` is defined in terms of `head` and `tail` */
   def iterator() = new Iterator[A] {
     private[this] var current: Seq[A] = self
     def hasNext = !current.isEmpty
@@ -36,7 +35,7 @@ trait LinearSeq[+A]
   /** `apply` is defined in terms of `drop`, which is in turn defined in
     *  terms of `tail`.
     */
-  override def apply(n: Int): A = {
+  def apply(n: Int): A = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val skipped = drop(n)
     if (skipped.isEmpty) throw new IndexOutOfBoundsException(n.toString)
@@ -62,8 +61,8 @@ trait SeqLikeFromIterable[+A, +C[X] <: Seq[X]]
     with IterableLikeFromIterable[A, C]
     with SeqMonoTransformsFromIterable[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
 
-/** Base trait for linear Seq operations */
-trait LinearSeqLike[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {
+/** Base trait for linear Seq optimizations */
+trait LinearSeqLikeOpt[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {
 
   /** Optimized version of `drop` that avoids copying
     *  Note: `drop` is defined here, rather than in a trait like `LinearSeqMonoTransforms`,

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -1,8 +1,8 @@
 package strawman.collection
 
-import scala.{Any, Boolean, Int, IndexOutOfBoundsException}
+import scala.{Any, Boolean, IndexOutOfBoundsException, Int}
 import strawman.collection.mutable.Iterator
-import strawman.collection.immutable.{List, Nil}
+import strawman.collection.immutable.{IndexedView, List, Nil}
 
 import scala.annotation.unchecked.uncheckedVariance
 
@@ -13,7 +13,11 @@ trait Seq[+A] extends Iterable[A] with SeqLike[A, Seq] with ArrayLike[A]
   *  `tail` operations.
   *  Known subclasses: List, LazyList
   */
-trait LinearSeq[+A] extends Seq[A] with LinearSeqLike[A, LinearSeq] { self =>
+trait LinearSeq[+A]
+  extends Seq[A]
+    with LinearSeqLike[A, LinearSeq]
+    with IterableLikeFromIterable[A, LinearSeq]
+    with SeqMonoTransformsFromIterable[A, LinearSeq[A @uncheckedVariance]] { self =>  // sound bcs of VarianceNote
 
   /** To be overridden in implementations: */
   def isEmpty: Boolean
@@ -78,6 +82,10 @@ trait LinearSeqLike[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {
 
 /** Type-preserving transforms over sequences. */
 trait SeqMonoTransforms[+A, +Repr] extends Any with IterableMonoTransforms[A, Repr] {
+  def reverse: Repr
+}
+
+trait SeqMonoTransformsFromIterable[+A, +Repr] extends Any with IterableMonoTransformsFromIterable[A, Repr] {
   def reverse: Repr = coll.view match {
     case v: IndexedView[A] => fromIterableWithSameElemType(v.reverse)
     case _ =>

--- a/src/main/scala/strawman/collection/immutable/Array.scala
+++ b/src/main/scala/strawman/collection/immutable/Array.scala
@@ -3,7 +3,7 @@ package strawman.collection.immutable
 import strawman.collection.mutable.{ArrayBuffer, ArrayBufferView, Iterator}
 import strawman.collection.{Iterable, IterableFactory, IterableOnce, IndexedSeq, Seq, SeqLike}
 
-import scala.{AnyRef, Boolean, Int}
+import scala.{Any, Boolean, Int}
 import scala.Predef.{???, intWrapper}
 
 /**
@@ -11,13 +11,13 @@ import scala.Predef.{???, intWrapper}
   *
   * Supports efficient indexed access and has a small memory footprint.
   */
-class Array[+A] private (private val elements: scala.Array[AnyRef]) extends IndexedSeq[A] with SeqLike[A, Array] {
+class Array[+A] private (private val elements: scala.Array[Any]) extends IndexedSeq[A] with SeqLike[A, Array] {
 
   def length: Int = elements.length
 
   override def knownSize: Int = elements.length
 
-  def apply(i: Int): A = elements(i).asInstanceOf[A]
+  def apply(i: Int): A = scala.runtime.ScalaRunTime.array_apply(elements, i).asInstanceOf[A]
 
   def iterator(): Iterator[A] = view.iterator()
 
@@ -28,7 +28,7 @@ class Array[+A] private (private val elements: scala.Array[AnyRef]) extends Inde
   def ++[B >: A](xs: IterableOnce[B]): Array[B] =
     xs match {
       case bs: Array[B] =>
-        val dest = scala.Array.ofDim[AnyRef](length + bs.length)
+        val dest = scala.Array.ofDim[Any](length + bs.length)
         java.lang.System.arraycopy(elements, 0, dest, 0, length)
         java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
         new Array(dest)
@@ -67,15 +67,15 @@ class Array[+A] private (private val elements: scala.Array[AnyRef]) extends Inde
 object Array extends IterableFactory[Array] {
 
   def fromIterable[A](it: Iterable[A]): Array[A] =
-    new Array(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[AnyRef]].toArray)
+    new Array(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[Any]].toArray)
 
   def fill[A](n: Int)(elem: => A): Array[A] = tabulate(n)(_ => elem)
 
   def tabulate[A](n: Int)(f: Int => A): Array[A] = {
-    val elements = scala.Array.ofDim[AnyRef](n)
+    val elements = scala.Array.ofDim[Any](n)
     var i = 0
     while (i < n) {
-      elements(i) = f(i).asInstanceOf[AnyRef]
+      elements(i) = f(i).asInstanceOf[Any]
       i = i + 1
     }
     new Array(elements)

--- a/src/main/scala/strawman/collection/immutable/Array.scala
+++ b/src/main/scala/strawman/collection/immutable/Array.scala
@@ -1,0 +1,84 @@
+package strawman.collection.immutable
+
+import strawman.collection.mutable.{ArrayBuffer, ArrayBufferView, Iterator}
+import strawman.collection.{Iterable, IterableFactory, IterableOnce, IndexedSeq, Seq, SeqLike}
+
+import scala.{AnyRef, Boolean, Int}
+import scala.Predef.{???, intWrapper}
+
+/**
+  * An immutable array.
+  *
+  * Supports efficient indexed access and has a small memory footprint.
+  */
+class Array[+A] private (private val elements: scala.Array[AnyRef]) extends IndexedSeq[A] with SeqLike[A, Array] {
+
+  def length: Int = elements.length
+
+  override def knownSize: Int = elements.length
+
+  def apply(i: Int): A = elements(i).asInstanceOf[A]
+
+  def iterator(): Iterator[A] = view.iterator()
+
+  def map[B](f: A => B): Array[B] = Array.tabulate(length)(i => f(apply(i)))
+
+  def flatMap[B](f: A => IterableOnce[B]): Array[B] = Array.fromIterable(View.FlatMap(coll, f))
+
+  def ++[B >: A](xs: IterableOnce[B]): Array[B] =
+    xs match {
+      case bs: Array[B] =>
+        val dest = scala.Array.ofDim[AnyRef](length + bs.length)
+        java.lang.System.arraycopy(elements, 0, dest, 0, length)
+        java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
+        new Array(dest)
+      case _ =>
+        Array.fromIterable(View.Concat(coll, xs))
+    }
+
+  def zip[B](xs: IterableOnce[B]): Array[(A, B)] =
+    xs match {
+      case bs: Array[B] =>
+        Array.tabulate(length min bs.length) { i =>
+          (apply(i), bs(i))
+        }
+      case _ =>
+        Array.fromIterable(View.Zip(coll, xs))
+    }
+
+  def filter(p: A => Boolean): Array[A] = Array.fromIterable(View.Filter(coll, p))
+
+  def partition(p: A => Boolean): (Array[A], Array[A]) = {
+    val pn = View.Partition(coll, p)
+    (Array.fromIterable(pn.left), Array.fromIterable(pn.right))
+  }
+
+  def take(n: Int): Array[A] = Array.tabulate(n)(apply)
+
+  def drop(n: Int): Array[A] = Array.tabulate((length - n) max 0)(i => apply(n + i))
+
+  def tail: Array[A] =
+    if (length > 0) Array.tabulate(length - 1)(i => apply(i + 1))
+    else ???
+
+  def reverse: Array[A] = Array.tabulate(length)(i => apply(length - 1 - i))
+}
+
+object Array extends IterableFactory[Array] {
+
+  def fromIterable[A](it: Iterable[A]): Array[A] =
+    new Array(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[AnyRef]].toArray)
+
+  def fill[A](n: Int)(elem: => A): Array[A] = tabulate(n)(_ => elem)
+
+  def tabulate[A](n: Int)(f: Int => A): Array[A] = {
+    val elements = scala.Array.ofDim[AnyRef](n)
+    var i = 0
+    while (i < n) {
+      elements(i) = f(i).asInstanceOf[AnyRef]
+      i = i + 1
+    }
+    new Array(elements)
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,11 +1,12 @@
 package strawman.collection.immutable
 
-import scala.{Option, Some, None, Nothing, StringContext}
-import strawman.collection.{IterableFactory, Iterable, LinearSeq, SeqLike}
+import scala.{Int, None, Nothing, Option, Some, StringContext}
+import strawman.collection.{Iterable, IterableFactory, IterableLikeFromIterable, LinearSeq, SeqLike, SeqLikeFromIterable, SeqMonoTransformsFromIterable}
 import strawman.collection.mutable.Iterator
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
-  extends LinearSeq[A] with SeqLike[A, LazyList] {
+  extends LinearSeq[A]
+    with SeqLikeFromIterable[A, LazyList] {
   private[this] var evaluated = false
   private[this] var result: LazyList.Evaluated[A] = _
 
@@ -34,6 +35,10 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
         case Some((hd, tl)) => s"$hd #:: $tl"
       }
     else "LazyList(?)"
+
+  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
+  override def drop(n: Int): LazyList[A] = super.drop(n)
+
 }
 
 object LazyList extends IterableFactory[LazyList] {

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -36,9 +36,6 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
       }
     else "LazyList(?)"
 
-  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
-  override def drop(n: Int): LazyList[A] = super.drop(n)
-
 }
 
 object LazyList extends IterableFactory[LazyList] {

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -1,16 +1,16 @@
 package strawman.collection.immutable
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.Nothing
+import scala.{Int, Nothing}
 import scala.Predef.???
-import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, LinearSeqLike, SeqLikeFromIterable}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
 /** Concrete collection type: List */
 sealed trait List[+A]
   extends LinearSeq[A]
-    with SeqLike[A, List]
+    with SeqLikeFromIterable[A, List]
     with Buildable[A, List[A]] {
 
   def fromIterable[B](c: Iterable[B]): List[B] = List.fromIterable(c)
@@ -32,6 +32,10 @@ sealed trait List[+A]
   }
 
   override def className = "List"
+
+  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
+  override def drop(n: Int): List[A] = super.drop(n)
+
 }
 
 case class :: [+A](x: A, private[collection] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -3,7 +3,7 @@ package strawman.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.{Int, Nothing}
 import scala.Predef.???
-import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, LinearSeqLike, SeqLikeFromIterable}
+import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, LinearSeqLikeOpt, SeqLikeFromIterable}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
@@ -11,7 +11,8 @@ import strawman.collection.mutable.{Buildable, ListBuffer}
 sealed trait List[+A]
   extends LinearSeq[A]
     with SeqLikeFromIterable[A, List]
-    with Buildable[A, List[A]] {
+    with Buildable[A, List[A]]
+    with LinearSeqLikeOpt[A, List] { // We put the optimizations at the end
 
   def fromIterable[B](c: Iterable[B]): List[B] = List.fromIterable(c)
 
@@ -33,7 +34,8 @@ sealed trait List[+A]
 
   override def className = "List"
 
-  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
+  // We need to disambiguate which implementation of `drop` we want to use because we inherit
+  // from two implementations (one from LinearSeqLikeOpt and one from SeqLikeFromIterable)
   override def drop(n: Int): List[A] = super.drop(n)
 
 }

--- a/src/main/scala/strawman/collection/immutable/View.scala
+++ b/src/main/scala/strawman/collection/immutable/View.scala
@@ -1,11 +1,13 @@
-package strawman.collection
+package strawman.collection.immutable
 
-import scala.{Int, Boolean, Nothing, annotation}
-import scala.Predef.intWrapper
 import strawman.collection.mutable.Iterator
+import strawman.collection.{ArrayLike, Iterable, IterableLikeFromIterable, IterableOnce}
+
+import scala.Predef.intWrapper
+import scala.{Boolean, Int, Nothing}
 
 /** Concrete collection type: View */
-trait View[+A] extends Iterable[A] with IterableLike[A, View] {
+trait View[+A] extends Iterable[A] with IterableLikeFromIterable[A, View] {
   override def view = this
 
   /** Avoid copying if source collection is already a view. */

--- a/src/main/scala/strawman/collection/javaSupport.scala
+++ b/src/main/scala/strawman/collection/javaSupport.scala
@@ -1,8 +1,8 @@
 package strawman.collection
 
-import strawman.collection.immutable.List
+import strawman.collection.immutable.{IndexedView, List, View}
 
-import scala.{Array, Char, Int, AnyVal}
+import scala.{AnyVal, Array, Char, Int}
 import scala.Predef.String
 import strawman.collection.mutable.{ArrayBuffer, Buildable, StringBuilder}
 
@@ -10,8 +10,8 @@ import scala.reflect.ClassTag
 
 class StringOps(val s: String)
   extends AnyVal with IterableOps[Char]
-    with SeqMonoTransforms[Char, String]
-    with IterablePolyTransforms[Char, List]
+    with SeqMonoTransformsFromIterable[Char, String]
+    with IterablePolyTransformsFromIterable[Char, List]
     with Buildable[Char, String]
     with ArrayLike[Char] {
 
@@ -75,7 +75,7 @@ case class StringView(s: String) extends IndexedView[Char] {
 
 class ArrayOps[A](val xs: Array[A])
   extends AnyVal with IterableOps[A]
-    with SeqMonoTransforms[A, Array[A]]
+    with SeqMonoTransformsFromIterable[A, Array[A]]
     with Buildable[A, Array[A]]
     with ArrayLike[A] {
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -1,13 +1,17 @@
 package strawman.collection.mutable
 
-import scala.{Array, Int, Boolean, Unit, AnyRef}
+import strawman.collection.immutable.IndexedView
+
+import scala.{AnyRef, Array, Boolean, Int, Unit}
 import scala.Predef.intWrapper
-import strawman.collection.{IndexedView, Iterable, IterableFactory, IterableOnce, Seq, SeqLike}
+import strawman.collection.{Iterable, IterableFactory, IterableLikeFromIterable, IterableOnce, Seq, SeqLike, SeqMonoTransformsFromIterable}
 
 /** Concrete collection type: ArrayBuffer */
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   extends Seq[A]
     with SeqLike[A, ArrayBuffer]
+    with IterableLikeFromIterable[A, ArrayBuffer]
+    with SeqMonoTransformsFromIterable[A, ArrayBuffer[A]]
     with Buildable[A, ArrayBuffer[A]]
     with Builder[A, ArrayBuffer[A]] {
 

--- a/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import scala.{Boolean, Any, Char}
 import java.lang.String
-import strawman.collection.{IterableMonoTransforms, IterableOnce}
+import strawman.collection.{IterableMonoTransformsFromIterable, IterableOnce}
 
 /** Base trait for collection builders */
 trait Builder[-A, +To] { self =>
@@ -31,7 +31,7 @@ trait Builder[-A, +To] { self =>
   * @tparam  A    the element type of the collection
   * @tparam Repr  the type of the underlying collection
   */
-trait Buildable[+A, +Repr] extends Any with IterableMonoTransforms[A, Repr]  {
+trait Buildable[+A, +Repr] extends Any with IterableMonoTransformsFromIterable[A, Repr]  {
 
   /** Creates a new builder. */
   protected[this] def newBuilder: Builder[A, Repr]

--- a/src/main/scala/strawman/collection/mutable/Iterator.scala
+++ b/src/main/scala/strawman/collection/mutable/Iterator.scala
@@ -1,7 +1,8 @@
 package strawman.collection.mutable
 
-import scala.{Boolean, Int, Unit, Nothing, NoSuchElementException}
-import strawman.collection.{IndexedView, IterableOnce}
+import scala.{Boolean, Int, NoSuchElementException, Nothing, Unit}
+import strawman.collection.IterableOnce
+import strawman.collection.immutable.IndexedView
 
 /** A core Iterator class */
 trait Iterator[+A] { self =>

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -1,13 +1,13 @@
 package strawman.collection.mutable
 
 import scala.{Int, Unit}
-import strawman.collection.{SeqLike, IterableFactory, Iterable, Seq}
-import strawman.collection.immutable.{List, Nil, ::}
+import strawman.collection.{Iterable, IterableFactory, Seq, SeqLikeFromIterable}
+import strawman.collection.immutable.{::, List, Nil}
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
   extends Seq[A]
-    with SeqLike[A, ListBuffer]
+    with SeqLikeFromIterable[A, ListBuffer]
     with Buildable[A, ListBuffer[A]]
     with Builder[A, ListBuffer[A]] {
 

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -5,8 +5,7 @@ import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
 import scala.Predef.{println, charWrapper}
 
 import strawman.collection._
-import strawman.collection.immutable._
-import strawman.collection.mutable._
+import strawman.collection.immutable.{List, Nil, ::, View, LazyList}
 import org.junit.Test
 
 class StrawmanTest {
@@ -215,6 +214,57 @@ class StrawmanTest {
     println(xs16.view)
   }
 
+  def immutableArrayOps(xs: immutable.Array[Int]): Unit = {
+    val x1 = xs.foldLeft("")(_ + _)
+    val y1: String = x1
+    val x2 = xs.foldRight("")(_ + _)
+    val y2: String = x2
+    val x3 = xs.indexWhere(_ % 2 == 0)
+    val y3: Int = x3
+    val x4 = xs.head
+    val y4: Int = x4
+    val x5 = xs.to(List)
+    val y5: List[Int] = x5
+    val (xs6, xs7) = xs.partition(_ % 2 == 0)
+    val ys6: immutable.Array[Int] = xs6
+    val ys7: immutable.Array[Int] = xs7
+    val xs8 = xs.drop(2)
+    val ys8: immutable.Array[Int] = xs8
+    val xs9 = xs.map(_ >= 0)
+    val ys9: immutable.Array[Boolean] = xs9
+    val xs10 = xs.flatMap(x => x :: -x :: Nil)
+    val ys10: immutable.Array[Int] = xs10
+    val xs11 = xs ++ xs
+    val ys11: immutable.Array[Int] = xs11
+    val xs12 = xs ++ Nil
+    val ys12: immutable.Array[Int] = xs12
+    val xs13 = Nil ++ xs
+    val ys13: List[Int] = xs13
+    val xs14 = xs ++ ("a" :: Nil)
+    val ys14: immutable.Array[Any] = xs14
+    val xs15 = xs.zip(xs9)
+    val ys15: immutable.Array[(Int, Boolean)] = xs15
+    val xs16 = xs.reverse
+    val ys16: immutable.Array[Int] = xs16
+    println("-------")
+    println(x1)
+    println(x2)
+    println(x3)
+    println(x4)
+    println(x5)
+    println(xs6)
+    println(xs7)
+    println(xs8)
+    println(xs9)
+    println(xs10)
+    println(xs11)
+    println(xs12)
+    println(xs13)
+    println(xs14)
+    println(xs15)
+    println(xs16)
+  }
+
   def lazyListOps(xs: Seq[Int]): Unit = {
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
@@ -291,8 +341,8 @@ class StrawmanTest {
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)
-    val intsBuf = ints.to(ArrayBuffer)
-    val intsListBuf = ints.to(ListBuffer)
+    val intsBuf = ints.to(mutable.ArrayBuffer)
+    val intsListBuf = ints.to(mutable.ListBuffer)
     val intsView = ints.view
     seqOps(ints)
     seqOps(intsBuf)
@@ -301,5 +351,6 @@ class StrawmanTest {
     stringOps("abc")
     arrayOps(Array(1, 2, 3))
     lazyListOps(LazyList(1, 2, 3))
+    immutableArrayOps(immutable.Array.tabulate(3)(identity))
   }
 }

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -2,7 +2,7 @@ package strawman.collection.test
 
 import java.lang.String
 import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
-import scala.Predef.{println, charWrapper}
+import scala.Predef.{println, charWrapper, identity}
 
 import strawman.collection._
 import strawman.collection.immutable.{List, Nil, ::, View, LazyList}


### PR DESCRIPTION
I introduce immutable arrays, a concrete collection that uses an `Array` as internal representation. It supports fast indexed access and has a compact in-memory representation.

The implementations of the collections operations (`filter`, `map`, etc.) were originally provided by the `IterableLike` trait, and these implementations were all based on iterators, and thus were **not** appropriate for working with arrays (where, most of the time we know *a priori* the size of the resulting array).

Instead of inheriting from these “default” implementations and then overriding them, I decided to move the “default” implementations of collection operations into separate traits. As a consequence, `IterableMonoTransforms` and `IterablePolyTransforms` are now completely abstract.

Most of the operations on immutable arrays are based on `tabulate`.