### PR TITLE
Equality between collections

### DIFF
--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -48,7 +48,6 @@ trait IndexedSeq[+A] extends Seq[A] { self =>
   }
 }
 
-
 /** Base trait for Seq operations */
 trait SeqLike[+A, +C[X] <: Seq[X]]
   extends IterableLike[A, C]

--- a/src/main/scala/strawman/collection/immutable/Iterable.scala
+++ b/src/main/scala/strawman/collection/immutable/Iterable.scala
@@ -1,0 +1,40 @@
+package strawman.collection.immutable
+
+import scala.{Any, Boolean, Int}
+import scala.util.hashing.MurmurHash3
+
+/**
+  * Base class of immutable collections. (Must *not* be inherited by mutable collections)
+  */
+trait Iterable[+A]
+  extends strawman.collection.Iterable[A]
+  with strawman.collection.IterableLike[A, Iterable] {
+
+  override def equals(o: Any): Boolean = {
+    o match {
+      case iterable: Iterable[A] => sameElements(iterable)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int =
+    IterableUtils.orderedHash(this, IterableUtils.iterableSeed)
+
+}
+
+// Temporary: TODO move to MurmurHash3.scala
+object IterableUtils {
+
+  val iterableSeed: Int = "Iterable".##
+
+  final def orderedHash(xs: Iterable[_], seed: Int): Int = {
+    var n = 0
+    var h = seed
+    xs foreach { x =>
+      h = MurmurHash3.mix(h, x.##)
+      n += 1
+    }
+    MurmurHash3.finalizeHash(h, n)
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,11 +1,11 @@
 package strawman.collection.immutable
 
 import scala.{Option, Some, None, Nothing, StringContext}
-import strawman.collection.{IterableFactory, Iterable, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactory, LinearSeq, SeqLike}
 import strawman.collection.mutable.Iterator
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
-  extends LinearSeq[A] with SeqLike[A, LazyList] {
+  extends Seq[A] with LinearSeq[A] with SeqLike[A, LazyList] {
   private[this] var evaluated = false
   private[this] var result: LazyList.Evaluated[A] = _
 
@@ -23,7 +23,7 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
-  def fromIterable[B](c: Iterable[B]): LazyList[B] = LazyList.fromIterable(c)
+  def fromIterable[B](c: strawman.collection.Iterable[B]): LazyList[B] = LazyList.fromIterable(c)
 
   override def className = "LazyList"
 
@@ -46,7 +46,7 @@ object LazyList extends IterableFactory[LazyList] {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force
   }
 
-  def fromIterable[B](coll: Iterable[B]): LazyList[B] = coll match {
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): LazyList[B] = coll match {
     case coll: LazyList[B] => coll
     case _ => fromIterator(coll.iterator())
   }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -3,17 +3,18 @@ package strawman.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.Nothing
 import scala.Predef.???
-import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
 /** Concrete collection type: List */
 sealed trait List[+A]
-  extends LinearSeq[A]
+  extends Seq[A]
+    with LinearSeq[A]
     with SeqLike[A, List]
     with Buildable[A, List[A]] {
 
-  def fromIterable[B](c: Iterable[B]): List[B] = List.fromIterable(c)
+  def fromIterable[B](c: strawman.collection.Iterable[B]): List[B] = List.fromIterable(c)
 
   protected[this] def newBuilder = new ListBuffer[A].mapResult(_.toList)
 
@@ -48,7 +49,7 @@ case object Nil extends List[Nothing] {
 }
 
 object List extends IterableFactory[List] {
-  def fromIterable[B](coll: Iterable[B]): List[B] = coll match {
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.fromIterable(coll).toList
   }

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -1,0 +1,5 @@
+package strawman.collection.immutable
+
+/** Immutable `Seq` */
+trait Seq[+A] extends Iterable[A] with strawman.collection.Seq[A] with strawman.collection.SeqLike[A, Seq]
+

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -2,10 +2,10 @@ package strawman.collection.test
 
 import java.lang.String
 import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
-import scala.Predef.{println, charWrapper}
+import scala.Predef.{assert, println, charWrapper}
 
-import strawman.collection._
-import strawman.collection.immutable._
+import strawman.collection.{arrayToArrayOps, stringToStringOps, View, Seq}
+import strawman.collection.immutable.{List, Nil, LazyList}
 import strawman.collection.mutable._
 import org.junit.Test
 
@@ -288,6 +288,13 @@ class StrawmanTest {
     println(xs17.to(List))
   }
 
+  def equality(): Unit = {
+    assert(List(1, 2, 3) == LazyList(1, 2, 3))
+    assert(List(1, 2, 3).## == LazyList(1, 2, 3).##)
+    assert(List(1, 2, 3) != ArrayBuffer(1, 2, 3))
+    assert(List(1, 2, 3).## != ArrayBuffer(1, 2, 3).##)
+  }
+
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)
@@ -301,5 +308,6 @@ class StrawmanTest {
     stringOps("abc")
     arrayOps(Array(1, 2, 3))
     lazyListOps(LazyList(1, 2, 3))
+    equality()
   }
 }


### PR DESCRIPTION
- Override equals in the immutable hierarchy to compare the collections’ elements.

This introduces a change compared to the current collections. Indeed, the current collections always compare their elements, even mutable collections:

~~~ scala
scala> List(1, 2, 3) == Vector(1, 2, 3)
res0: Boolean = true

scala> List(1, 2, 3) == collection.mutable.ListBuffer(1, 2, 3)
res1: Boolean = true
~~~

I think it would be better to compare the elements only in the case of immutable collections.

To achieve this change, I introduced an immutable hierarchy (a base `immutable.Iterable` trait, etc.) that is not shared with mutable collections. The main drawback is that now we have `collection.Iterable` and `collection.immutable.Iterable` (and same for `Seq`), which might be confusing. I’d like to find distinct names.