### PR TITLE
Add base traits of collection hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 .history
 .DS_Store
 /tmp/
+/bin/

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -54,7 +54,7 @@ trait IterableOps[+A] extends Any {
   protected def coll: Iterable[A]
   private def iterator() = coll.iterator()
 
-  /** Apply `f` to each element for tis side effects
+  /** Apply `f` to each element for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
   def foreach[U](f: A => U): Unit = iterator().foreach(f)

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -1,4 +1,5 @@
-package strawman.collection
+package strawman
+package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
@@ -54,8 +55,10 @@ trait IterableOps[+A] extends Any {
   protected def coll: Iterable[A]
   private def iterator() = coll.iterator()
 
-  /** Apply `f` to each element for tis side effects */
-  def foreach(f: A => Unit): Unit = iterator().foreach(f)
+  /** Apply `f` to each element for tis side effects
+   *  Note: [U] parameter needed to help scalac's type inference. 
+   */
+  def foreach[U](f: A => U): Unit = iterator().foreach(f)
 
   /** Fold left */
   def foldLeft[B](z: B)(op: (B, A) => B): B = iterator().foldLeft(z)(op)

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -4,8 +4,7 @@ package collection
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
 import scala.{Int, Boolean, Array, Any, Unit, StringContext}
-import java.lang.String
-
+import java.lang.{String, UnsupportedOperationException}
 import strawman.collection.mutable.{ArrayBuffer, StringBuilder}
 
 /** Base trait for generic collections */
@@ -56,7 +55,7 @@ trait IterableOps[+A] extends Any {
   private def iterator() = coll.iterator()
 
   /** Apply `f` to each element for tis side effects
-   *  Note: [U] parameter needed to help scalac's type inference. 
+   *  Note: [U] parameter needed to help scalac's type inference.
    */
   def foreach[U](f: A => U): Unit = iterator().foreach(f)
 
@@ -169,7 +168,9 @@ trait IterableMonoTransforms[+A, +Repr] extends Any {
   def drop(n: Int): Repr = fromIterableWithSameElemType(View.Drop(coll, n))
 
   /** The rest of the collection without its first element. */
-  def tail: Repr = drop(1)
+  def tail: Repr =
+    if (coll.isEmpty) drop(1)
+    else throw new UnsupportedOperationException
 }
 
 /** Transforms over iterables that can return collections of different element types.

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -168,9 +168,10 @@ trait IterableMonoTransforms[+A, +Repr] extends Any {
   def drop(n: Int): Repr = fromIterableWithSameElemType(View.Drop(coll, n))
 
   /** The rest of the collection without its first element. */
-  def tail: Repr =
-    if (coll.isEmpty) drop(1)
-    else throw new UnsupportedOperationException
+  def tail: Repr = {
+    if (coll.isEmpty) throw new UnsupportedOperationException
+    drop(1)
+  }
 }
 
 /** Transforms over iterables that can return collections of different element types.

--- a/src/main/scala/strawman/collection/IterableOnce.scala
+++ b/src/main/scala/strawman/collection/IterableOnce.scala
@@ -1,4 +1,5 @@
-package strawman.collection
+package strawman
+package collection
 
 import strawman.collection.mutable.Iterator
 

--- a/src/main/scala/strawman/collection/IterableOnce.scala
+++ b/src/main/scala/strawman/collection/IterableOnce.scala
@@ -1,8 +1,6 @@
 package strawman
 package collection
 
-import strawman.collection.mutable.Iterator
-
 trait IterableOnce[+A] {
   /** Iterator can be used only once */
   def iterator(): Iterator[A]

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -1,7 +1,6 @@
-package strawman.collection.mutable
+package strawman.collection
 
 import scala.{Boolean, Int, Unit, Nothing, NoSuchElementException}
-import strawman.collection.{IndexedView, IterableOnce}
 
 /** A core Iterator class */
 trait Iterator[+A] extends IterableOnce[A] { self =>
@@ -12,7 +11,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     if (hasNext) foldLeft(op(z, next()))(op) else z
   def foldRight[B](z: B)(op: (A, B) => B): B =
     if (hasNext) op(next(), foldRight(z)(op)) else z
-  def foreach(f: A => Unit): Unit =
+  def foreach[U](f: A => U): Unit =
     while (hasNext) f(next())
   def indexWhere(p: A => Boolean): Int = {
     var i = 0

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -1,7 +1,6 @@
 package strawman.collection
 
 import scala.{Any, Boolean, Int, IndexOutOfBoundsException}
-import strawman.collection.mutable.Iterator
 import strawman.collection.immutable.{List, Nil}
 
 import scala.annotation.unchecked.uncheckedVariance

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -47,7 +47,6 @@ trait IndexedSeq[+A] extends Seq[A] { self =>
   }
 }
 
-
 /** Base trait for Seq operations */
 trait SeqLike[+A, +C[X] <: Seq[X]]
   extends IterableLike[A, C]

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,0 +1,4 @@
+package strawman
+package collection
+
+trait Set[A] extends Iterable[A] {}

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -2,7 +2,6 @@ package strawman.collection
 
 import scala.{Int, Boolean, Nothing, annotation}
 import scala.Predef.intWrapper
-import strawman.collection.mutable.Iterator
 
 /** Concrete collection type: View */
 trait View[+A] extends Iterable[A] with IterableLike[A, View] {

--- a/src/main/scala/strawman/collection/immutable/Iterable.scala
+++ b/src/main/scala/strawman/collection/immutable/Iterable.scala
@@ -1,0 +1,5 @@
+package strawman.collection.immutable
+import strawman.collection
+
+trait Iterable[+A] extends collection.Iterable[A]
+                      with collection.IterableLike[A, Iterable]

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,10 +1,11 @@
 package strawman.collection.immutable
 
 import scala.{Option, Some, None, Nothing, StringContext}
-import strawman.collection.{IterableFactory, Iterable, LinearSeq, SeqLike, Iterator}
+import strawman.collection
+import strawman.collection.{IterableFactory, LinearSeq, SeqLike, Iterator}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
-  extends LinearSeq[A] with SeqLike[A, LazyList] {
+  extends Seq[A] with SeqLike[A, LazyList] with LinearSeq[A] {
   private[this] var evaluated = false
   private[this] var result: LazyList.Evaluated[A] = _
 
@@ -22,7 +23,7 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
-  def fromIterable[B](c: Iterable[B]): LazyList[B] = LazyList.fromIterable(c)
+  def fromIterable[B](c: collection.Iterable[B]): LazyList[B] = LazyList.fromIterable(c)
 
   override def className = "LazyList"
 
@@ -45,7 +46,7 @@ object LazyList extends IterableFactory[LazyList] {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force
   }
 
-  def fromIterable[B](coll: Iterable[B]): LazyList[B] = coll match {
+  def fromIterable[B](coll: collection.Iterable[B]): LazyList[B] = coll match {
     case coll: LazyList[B] => coll
     case _ => fromIterator(coll.iterator())
   }

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,8 +1,7 @@
 package strawman.collection.immutable
 
 import scala.{Option, Some, None, Nothing, StringContext}
-import strawman.collection.{IterableFactory, Iterable, LinearSeq, SeqLike}
-import strawman.collection.mutable.Iterator
+import strawman.collection.{IterableFactory, Iterable, LinearSeq, SeqLike, Iterator}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
   extends LinearSeq[A] with SeqLike[A, LazyList] {

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -3,17 +3,19 @@ package strawman.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.Nothing
 import scala.Predef.???
-import strawman.collection.{Iterable, IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection
+import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
 /** Concrete collection type: List */
 sealed trait List[+A]
-  extends LinearSeq[A]
-    with SeqLike[A, List]
-    with Buildable[A, List[A]] {
+  extends Seq[A]
+     with SeqLike[A, List]
+     with LinearSeq[A]
+     with Buildable[A, List[A]] {
 
-  def fromIterable[B](c: Iterable[B]): List[B] = List.fromIterable(c)
+  def fromIterable[B](c: collection.Iterable[B]): List[B] = List.fromIterable(c)
 
   protected[this] def newBuilder = new ListBuffer[A].mapResult(_.toList)
 
@@ -48,7 +50,7 @@ case object Nil extends List[Nothing] {
 }
 
 object List extends IterableFactory[List] {
-  def fromIterable[B](coll: Iterable[B]): List[B] = coll match {
+  def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.fromIterable(coll).toList
   }

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -1,0 +1,9 @@
+package strawman.collection.immutable
+
+import strawman.collection
+
+trait Seq[+A] extends collection.Seq[A]
+                 with collection.SeqLike[A, Seq]
+                 with Iterable[A]
+
+

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -1,28 +1,40 @@
 package strawman.collection.mutable
 
-import scala.{Array, Int, Boolean, Unit, AnyRef}
+import java.lang.IndexOutOfBoundsException
+import scala.{Array, Int, Long, Boolean, Unit, AnyRef}
+import strawman.collection.{IterableFactory, Iterable, IterableOnce, SeqLike, IndexedView}
 import scala.Predef.intWrapper
-import strawman.collection.{IndexedView, Iterable, IterableFactory, IterableOnce, Seq, SeqLike}
 
 /** Concrete collection type: ArrayBuffer */
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
-  extends Seq[A]
+  extends IndexedOptimizedGrowableSeq[A]
     with SeqLike[A, ArrayBuffer]
     with Buildable[A, ArrayBuffer[A]]
     with Builder[A, ArrayBuffer[A]] {
 
   def this() = this(new Array[AnyRef](16), 0)
 
-  private var elems: Array[AnyRef] = initElems
-  private var start = 0
+  private var array: Array[AnyRef] = initElems
   private var end = initLength
 
-  def apply(n: Int) = elems(start + n).asInstanceOf[A]
+  /** Ensure that the internal array has at least `n` cells. */
+  private def ensureSize(n: Int): Unit =
+    array = RefArrayUtils.ensureSize(array, end, n)
 
-  def length = end - start
+  /** Reduce length to `n`, nulling out all dropped elements */
+  private def reduceToSize(n: Int): Unit = {
+    RefArrayUtils.nullElems(array, n, end)
+    end = n
+  }
+
+  def apply(n: Int) = array(n).asInstanceOf[A]
+
+  def update(n: Int, elem: A): Unit = array(n) = elem.asInstanceOf[AnyRef]
+
+  def length = end
   override def knownSize = length
 
-  override def view = new ArrayBufferView(elems, start, end)
+  override def view = new ArrayBufferView(array, end)
 
   def iterator() = view.iterator()
 
@@ -31,44 +43,75 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   protected[this] def newBuilder = new ArrayBuffer[A]
 
+  def clear() =
+    end = 0
+
   def +=(elem: A): this.type = {
-    if (end == elems.length) {
-      if (start > 0) {
-        Array.copy(elems, start, elems, 0, length)
-        end -= start
-        start = 0
-      }
-      else {
-        val newelems = new Array[AnyRef](end * 2)
-        Array.copy(elems, 0, newelems, 0, end)
-        elems = newelems
-      }
-    }
-    elems(end) = elem.asInstanceOf[AnyRef]
+    ensureSize(end + 1)
+    this(end) = elem
     end += 1
+    this
+  }
+
+  /** Overridden to use array copying for efficiency where possible. */
+  override def ++=(elems: IterableOnce[A]): this.type = {
+    elems match {
+      case elems: ArrayBuffer[_] =>
+        ensureSize(length + elems.length)
+        Array.copy(elems.array, 0, array, length, elems.length)
+        end = length + elems.length
+      case _ => super.++=(elems)
+    }
     this
   }
 
   def result = this
 
-  /** New operation: destructively drop elements at start of buffer. */
-  def trimStart(n: Int): Unit = start += (n max 0)
-
-  /** Overridden to use array copying for efficiency where possible. */
-  override def ++[B >: A](xs: IterableOnce[B]): ArrayBuffer[B] = xs match {
-    case xs: ArrayBuffer[B] =>
-      val elems = new Array[AnyRef](length + xs.length)
-      Array.copy(this.elems, this.start, elems, 0, this.length)
-      Array.copy(xs.elems, xs.start, elems, this.length, xs.length)
-      new ArrayBuffer(elems, elems.length)
-    case _ => super.++(xs)
+  def insert(idx: Int, elem: A): Unit = {
+    if (idx < 0 || idx > end) throw new IndexOutOfBoundsException
+    ensureSize(end + 1)
+    Array.copy(array, idx, array, idx + 1, end - idx)
+    this(idx) = elem
   }
 
-  override def take(n: Int) = {
-    val elems = new Array[AnyRef](n min length)
-    Array.copy(this.elems, this.start, elems, 0, elems.length)
-    new ArrayBuffer(elems, elems.length)
+  def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
+    if (idx < 0 || idx > end) throw new IndexOutOfBoundsException
+    elems match {
+      case elems: Iterable[A] =>
+        val elemsLength = elems.size
+        ensureSize(length + elemsLength)
+        Array.copy(array, idx, array, idx + elemsLength, end - idx)
+        elems match {
+          case elems: ArrayBuffer[_] =>
+            Array.copy(elems.array, 0, array, idx, elemsLength)
+          case _ =>
+            var i = 0
+            val it = elems.iterator()
+            while (i < elemsLength) {
+              this(idx + i) = it.next()
+              i += 1
+            }
+        }
+      case _ =>
+        val buf = new ArrayBuffer() ++= elems
+        insertAll(idx, buf)
+    }
   }
+
+  def remove(idx: Int): A = {
+    if (idx < 0 || idx >= end) throw new IndexOutOfBoundsException
+    val res = this(idx)
+    Array.copy(array, idx + 1, array, idx, end - (idx + 1))
+    reduceToSize(end - 1)
+    res
+  }
+
+  def remove(from: Int, n: Int): Unit =
+    if (n > 0) {
+      if (from < 0 || from + n > end) throw new IndexOutOfBoundsException
+      Array.copy(array, from + n, array, from, end - (from + n))
+      reduceToSize(end - n)
+    }
 
   override def className = "ArrayBuffer"
 }
@@ -78,16 +121,46 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
   /** Avoid reallocation of buffer if length is known. */
   def fromIterable[B](coll: Iterable[B]): ArrayBuffer[B] =
     if (coll.knownSize >= 0) {
-      val elems = new Array[AnyRef](coll.knownSize)
+      val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()
-      for (i <- 0 until elems.length) elems(i) = it.next().asInstanceOf[AnyRef]
-      new ArrayBuffer[B](elems, elems.length)
+      for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
+      new ArrayBuffer[B](array, array.length)
     }
     else new ArrayBuffer[B] ++= coll
 }
 
-class ArrayBufferView[A](val elems: Array[AnyRef], val start: Int, val end: Int) extends IndexedView[A] {
-  def length = end - start
-  def apply(n: Int) = elems(start + n).asInstanceOf[A]
+class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {
+  def apply(n: Int) = array(n).asInstanceOf[A]
   override def className = "ArrayBufferView"
+}
+
+/** An object used internally by collections backed by an extensible Array[AnyRef] */
+object RefArrayUtils {
+
+  def ensureSize(array: Array[AnyRef], end: Int, n: Int): Array[AnyRef] = {
+    // Use a Long to prevent overflows
+    val arrayLength: Long = array.length
+    def growArray = {
+      var newSize: Long = arrayLength * 2
+      while (n > newSize)
+        newSize = newSize * 2
+      // Clamp newSize to Int.MaxValue
+      if (newSize > Int.MaxValue) newSize = Int.MaxValue
+
+      val newArray: Array[AnyRef] = new Array(newSize.toInt)
+      Array.copy(array, 0, newArray, 0, end)
+      newArray
+    }
+    if (n <= arrayLength) array else growArray
+  }
+
+  /** Remove elements of this array at indices after `sz`.
+   */
+  def nullElems(array: Array[AnyRef], start: Int, end: Int): Unit = {
+    var i = start
+    while (i < end) {
+      array(i) = null
+      i += 1
+    }
+  }
 }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -28,6 +28,11 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
     end = n
   }
 
+  private def checkWithinBounds(lo: Int, hi: Int) = {
+    if (lo < 0) throw new IndexOutOfBoundsException(lo.toString)
+    if (hi > end) throw new IndexOutOfBoundsException(hi.toString)
+  }
+
   def apply(n: Int) = array(n).asInstanceOf[A]
 
   def update(n: Int, elem: A): Unit = array(n) = elem.asInstanceOf[AnyRef]
@@ -69,14 +74,14 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def result = this
 
   def insert(idx: Int, elem: A): Unit = {
-    if (idx < 0 || idx > end) throw new IndexOutOfBoundsException
+    checkWithinBounds(idx, idx)
     ensureSize(end + 1)
     Array.copy(array, idx, array, idx + 1, end - idx)
     this(idx) = elem
   }
 
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
-    if (idx < 0 || idx > end) throw new IndexOutOfBoundsException
+    checkWithinBounds(idx, idx)
     elems match {
       case elems: collection.Iterable[A] =>
         val elemsLength = elems.size
@@ -100,7 +105,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   }
 
   def remove(idx: Int): A = {
-    if (idx < 0 || idx >= end) throw new IndexOutOfBoundsException
+    checkWithinBounds(idx, idx + 1)
     val res = this(idx)
     Array.copy(array, idx + 1, array, idx, end - (idx + 1))
     reduceToSize(end - 1)
@@ -109,7 +114,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def remove(from: Int, n: Int): Unit =
     if (n > 0) {
-      if (from < 0 || from + n > end) throw new IndexOutOfBoundsException
+      checkWithinBounds(from, from + n)
       Array.copy(array, from + n, array, from, end - (from + n))
       reduceToSize(end - n)
     }
@@ -158,6 +163,7 @@ object RefArrayUtils {
   /** Remove elements of this array at indices after `sz`.
    */
   def nullElems(array: Array[AnyRef], start: Int, end: Int): Unit = {
+    // Maybe use `fill` instead?
     var i = start
     while (i < end) {
       array(i) = null

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -2,7 +2,8 @@ package strawman.collection.mutable
 
 import java.lang.IndexOutOfBoundsException
 import scala.{Array, Int, Long, Boolean, Unit, AnyRef}
-import strawman.collection.{IterableFactory, Iterable, IterableOnce, SeqLike, IndexedView}
+import strawman.collection
+import strawman.collection.{IterableFactory, IterableOnce, SeqLike, IndexedView}
 import scala.Predef.intWrapper
 
 /** Concrete collection type: ArrayBuffer */
@@ -38,7 +39,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def iterator() = view.iterator()
 
-  def fromIterable[B](it: Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](it: collection.Iterable[B]): ArrayBuffer[B] =
     ArrayBuffer.fromIterable(it)
 
   protected[this] def newBuilder = new ArrayBuffer[A]
@@ -77,7 +78,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
     if (idx < 0 || idx > end) throw new IndexOutOfBoundsException
     elems match {
-      case elems: Iterable[A] =>
+      case elems: collection.Iterable[A] =>
         val elemsLength = elems.size
         ensureSize(length + elemsLength)
         Array.copy(array, idx, array, idx + elemsLength, end - idx)
@@ -119,7 +120,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
-  def fromIterable[B](coll: Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
     if (coll.knownSize >= 0) {
       val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()

--- a/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -1,27 +1,27 @@
 package strawman.collection.mutable
 
-import scala.{Boolean, Any, Char}
+import scala.{Boolean, Any, Char, Unit}
 import java.lang.String
 import strawman.collection.{IterableMonoTransforms, IterableOnce}
 
 /** Base trait for collection builders */
-trait Builder[-A, +To] { self =>
+trait Builder[-A, +To] extends Growable[A] { self =>
 
   /** Append an element */
   def +=(x: A): this.type
 
+  /** Clears the contents of this builder.
+   *  After execution of this method the builder will contain no elements.
+   */
+  def clear(): Unit
+
   /** Result collection consisting of all elements appended so far. */
   def result: To
-
-  /** Bulk append. Can be overridden if specialized implementations are available. */
-  def ++=(xs: IterableOnce[A]): this.type = {
-    xs.iterator().foreach(+=)
-    this
-  }
 
   /** A builder resulting from this builder my mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo) = new Builder[A, NewTo] {
     def +=(x: A): this.type = { self += x; this }
+    def clear(): Unit = self.clear()
     override def ++=(xs: IterableOnce[A]): this.type = { self ++= xs; this }
     def result: NewTo = f(self.result)
   }
@@ -51,6 +51,8 @@ class StringBuilder extends Builder[Char, String] {
   private val sb = new java.lang.StringBuilder
 
   def += (x: Char) = { sb.append(x); this }
+
+  def clear() = sb.setLength(0)
 
   /** Overloaded version of `++=` that takes a string */
   def ++= (s: String) = { sb.append(s); this }

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -1,11 +1,3 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
 package strawman.collection.mutable
 
 import strawman.collection.IterableOnce
@@ -16,14 +8,6 @@ import strawman.collection.{toOldSeq, toNewSeq}
 /** This trait forms part of collections that can be augmented
  *  using a `+=` operator and that can be cleared of all elements using
  *  a `clear` method.
- *
- *  @author   Martin Odersky
- *  @version 2.8
- *  @since   2.8
- *  @define coll growable collection
- *  @define Coll `Growable`
- *  @define add  add
- *  @define Add  add
  */
 trait Growable[-A] {
 
@@ -59,6 +43,8 @@ trait Growable[-A] {
       case xs: scala.collection.LinearSeq[_] => loop(xs.asInstanceOf[scala.collection.LinearSeq[A]])
       case xs => xs.iterator() foreach += // Deviation: IterableOnce does not define `foreach`.
     }
+    // @ichoran writes: Right now, this actually isn't any faster than using an iterator
+    // for List. Maybe we should just simplify the code by deferring to iterator foreach?
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -1,0 +1,68 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package mutable
+
+import scala.annotation.tailrec
+
+/** This trait forms part of collections that can be augmented
+ *  using a `+=` operator and that can be cleared of all elements using
+ *  a `clear` method.
+ *
+ *  @author   Martin Odersky
+ *  @version 2.8
+ *  @since   2.8
+ *  @define coll growable collection
+ *  @define Coll `Growable`
+ *  @define add  add
+ *  @define Add  add
+ */
+trait Growable[-A] {
+
+  /** ${Add}s a single element to this $coll.
+   *
+   *  @param elem  the element to $add.
+   *  @return the $coll itself
+   */
+  def +=(elem: A): this.type
+
+  /** ${Add}s two or more elements to this $coll.
+   *
+   *  @param elem1 the first element to $add.
+   *  @param elem2 the second element to $add.
+   *  @param elems the remaining elements to $add.
+   *  @return the $coll itself
+   */
+  def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= elems.toStrawman
+
+  /** ${Add}s all elements produced by a TraversableOnce to this $coll.
+   *
+   *  @param xs   the TraversableOnce producing the elements to $add.
+   *  @return  the $coll itself.
+   */
+  def ++=(xs: IterableOnce[A]): this.type = {
+    @tailrec def loop(xs: scala.collection.LinearSeq[A]): Unit = {
+      if (xs.nonEmpty) {
+        this += xs.head
+        loop(xs.tail)
+      }
+    }
+    xs match {
+      case xs: scala.collection.LinearSeq[_] => loop(xs.asInstanceOf[scala.collection.LinearSeq[A]])
+      case xs                                => xs.iterator() foreach += // Deviation: IterableOnce does not support Iterator.
+    }
+    this
+  }
+
+  /** Clears the $coll's contents. After this operation, the
+   *  $coll is empty.
+   */
+  def clear(): Unit
+}

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -6,11 +6,12 @@
 **                          |/                                          **
 \*                                                                      */
 
-package strawman
-package collection
-package mutable
+package strawman.collection.mutable
 
+import strawman.collection.IterableOnce
+import scala.Unit
 import scala.annotation.tailrec
+import strawman.collection.{toOldSeq, toNewSeq}
 
 /** This trait forms part of collections that can be augmented
  *  using a `+=` operator and that can be cleared of all elements using
@@ -40,7 +41,7 @@ trait Growable[-A] {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
-  def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= elems.toStrawman
+  def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems.toStrawman: IterableOnce[A])
 
   /** ${Add}s all elements produced by a TraversableOnce to this $coll.
    *
@@ -56,7 +57,7 @@ trait Growable[-A] {
     }
     xs match {
       case xs: scala.collection.LinearSeq[_] => loop(xs.asInstanceOf[scala.collection.LinearSeq[A]])
-      case xs                                => xs.iterator() foreach += // Deviation: IterableOnce does not support Iterator.
+      case xs => xs.iterator() foreach += // Deviation: IterableOnce does not define `foreach`.
     }
     this
   }

--- a/src/main/scala/strawman/collection/mutable/Iterable.scala
+++ b/src/main/scala/strawman/collection/mutable/Iterable.scala
@@ -1,0 +1,5 @@
+package strawman.collection.mutable
+import strawman.collection
+
+trait Iterable[A] extends collection.Iterable[A]
+                     with collection.IterableLike[A, Iterable]

--- a/src/main/scala/strawman/collection/mutable/Iterator.scala
+++ b/src/main/scala/strawman/collection/mutable/Iterator.scala
@@ -4,9 +4,10 @@ import scala.{Boolean, Int, Unit, Nothing, NoSuchElementException}
 import strawman.collection.{IndexedView, IterableOnce}
 
 /** A core Iterator class */
-trait Iterator[+A] { self =>
+trait Iterator[+A] extends IterableOnce[A] { self =>
   def hasNext: Boolean
   def next(): A
+  def iterator() = this
   def foldLeft[B](z: B)(op: (B, A) => B): B =
     if (hasNext) foldLeft(op(z, next()))(op) else z
   def foldRight[B](z: B)(op: (A, B) => B): B =

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -3,7 +3,7 @@ package strawman.collection.mutable
 import scala.{Int, Unit, Boolean}
 import scala.Int._
 import strawman.collection
-import strawman.collection.{Iterator, Iterable, IterableOnce, IterableFactory, SeqLike}
+import strawman.collection.{Iterator, IterableOnce, IterableFactory, SeqLike}
 import strawman.collection.immutable.{List, Nil, ::}
 import scala.annotation.tailrec
 import java.lang.IndexOutOfBoundsException
@@ -25,7 +25,7 @@ class ListBuffer[A]
 
   def iterator() = first.iterator()
 
-  def fromIterable[B](coll: Iterable[B]) = ListBuffer.fromIterable(coll)
+  def fromIterable[B](coll: collection.Iterable[B]) = ListBuffer.fromIterable(coll)
 
   def apply(i: Int) = first.apply(i)
 
@@ -199,5 +199,5 @@ class ListBuffer[A]
 }
 
 object ListBuffer extends IterableFactory[ListBuffer] {
-  def fromIterable[B](coll: Iterable[B]): ListBuffer[B] = new ListBuffer[B] ++= coll
+  def fromIterable[B](coll: collection.Iterable[B]): ListBuffer[B] = new ListBuffer[B] ++= coll
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -1,8 +1,11 @@
-package strawman.collection.mutable
+package strawman
+package collection
+package mutable
 
 import scala.{Int, Unit}
-import strawman.collection.{SeqLike, IterableFactory, Iterable, Seq}
+import strawman.collection.{SeqLike, IterableFactory, Iterable, Seq, IterableOnce}
 import strawman.collection.immutable.{List, Nil, ::}
+import scala.annotation.tailrec
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
@@ -11,9 +14,12 @@ class ListBuffer[A]
     with Buildable[A, ListBuffer[A]]
     with Builder[A, ListBuffer[A]] {
 
-  private var first, last: List[A] = Nil
+  private var first: List[A] = Nil
+  private var last: ::[A] = null
   private var aliased = false
   private var len = 0
+
+  private type Predecessor[A] = ::[A] /*| Null*/
 
   def iterator() = first.iterator()
 
@@ -33,21 +39,155 @@ class ListBuffer[A]
     aliased = false
   }
 
+  private def ensureUnaliased() = if (aliased) copyElems()
+
   /** Convert to list; avoids copying where possible. */
   def toList = {
     aliased = true
     first
   }
 
+  def clear(): Unit = {
+    first = Nil
+  }
+
   def +=(elem: A) = {
-    if (aliased) copyElems()
-    val last1 = elem :: Nil
-    last match {
-      case last: ::[A] => last.next = last1
-      case _ => first = last1
-    }
+    ensureUnaliased()
+    val last1 = (elem :: Nil).asInstanceOf[::[A]]
+    if (len == 0) first = last1 else last.next = last1
     last = last1
     len += 1
+    this
+  }
+
+  private def locate(i: Int): Predecessor[A] =
+    if (i == 0) null
+    else if (i == len) last
+    else {
+      assert(i > 0 && i < len)
+      var j = i - 1
+      var p = first
+      while (j > 0) {
+        p = p.tail
+        j -= 1
+      }
+      p.asInstanceOf[Predecessor[A]]
+    }
+
+  private def getNext(p: Predecessor[A]): List[A] =
+    if (p == null) first else p.next
+
+  private def setNext(p: Predecessor[A], nx: List[A]): Unit =
+    if (p == null) first = nx else p.next = nx
+
+  def update(idx: Int, elem: A): Unit = {
+    ensureUnaliased()
+    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException
+    val p = locate(idx)
+    setNext(p, elem :: getNext(p).tail)
+  }
+
+  def insert(idx: Int, elem: A): Unit = {
+    ensureUnaliased()
+    if (idx < 0 || idx > len) throw new IndexOutOfBoundsException
+    if (idx == len) +=(elem)
+    else {
+      val p = locate(idx)
+      setNext(p, elem :: getNext(p))
+      len += 1
+    }
+  }
+
+  private def insertAfter(p: Predecessor[A], it: Iterator[A]) = {
+    var prev = p
+    val follow = getNext(prev)
+    while (it.hasNext) {
+      len += 1
+      val next = (it.next :: follow).asInstanceOf[::[A]]
+      setNext(prev, next)
+      prev = next
+    }
+  }
+
+  def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
+    ensureUnaliased()
+    val it = elems.iterator()
+    if (it.hasNext) {
+      ensureUnaliased()
+      if (idx < 0 || idx > len) throw new IndexOutOfBoundsException
+      if (idx == len) ++=(elems)
+      else insertAfter(locate(idx), it)
+    }
+  }
+
+  def remove(idx: Int): A = {
+    ensureUnaliased()
+    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException
+    len -= 1
+    val p = locate(idx)
+    val nx = getNext(p)
+    setNext(p, nx.tail)
+    nx.head
+  }
+
+  def remove(idx: Int, n: Int): Unit = 
+    if (n > 0) {
+      ensureUnaliased()
+      if (idx < 0 || idx + n > len) throw new IndexOutOfBoundsException
+      removeAfter(locate(idx), n)
+    }
+
+  private def removeAfter(prev: Predecessor[A], n: Int) = {
+    @tailrec def ahead(p: List[A], n: Int): List[A] =
+      if (n == 0) p else ahead(p.tail, n - 1)
+    setNext(prev, ahead(getNext(prev), n))
+    len -= n
+  }
+
+  def mapInPlace(f: A => A): this.type = {
+    ensureUnaliased()
+    val buf = new ListBuffer[A]
+    for (elem <- this) buf += f(elem)
+    first = buf.first
+    last = buf.last
+    this
+  }
+
+  def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
+    ensureUnaliased()
+    val prev: Predecessor[A] = null
+    var cur: List[A] = first
+    while (!cur.isEmpty) {
+      val follow = cur.tail
+      setNext(prev, follow)
+      len -= 1
+      insertAfter(prev, f(cur.head).iterator())
+      cur = follow
+    }
+    this
+  }
+
+  def filterInPlace(p: A => Boolean): this.type = {
+    ensureUnaliased()
+    var prev: Predecessor[A] = null
+    var cur: List[A] = first
+    while (!cur.isEmpty) {
+      val follow = cur.tail
+      if (!p(cur.head)) {
+        setNext(prev, follow)
+        len -= 1
+      }
+      prev = cur.asInstanceOf[Predecessor[A]]
+      cur = follow
+    }
+    this
+  }
+
+  def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
+    ensureUnaliased()
+    val p = locate(from)
+    removeAfter(p, replaced `min` length - from)
+    insertAfter(p, patch.iterator())
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -1,11 +1,13 @@
-package strawman
-package collection
-package mutable
+package strawman.collection.mutable
 
-import scala.{Int, Unit}
-import strawman.collection.{SeqLike, IterableFactory, Iterable, Seq, IterableOnce}
+import scala.{Int, Unit, Boolean}
+import scala.Int._
+import strawman.collection
+import strawman.collection.{Iterator, Iterable, IterableOnce, IterableFactory, SeqLike}
 import strawman.collection.immutable.{List, Nil, ::}
 import scala.annotation.tailrec
+import java.lang.IndexOutOfBoundsException
+import scala.Predef.{assert, intWrapper}
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
@@ -130,7 +132,7 @@ class ListBuffer[A]
     nx.head
   }
 
-  def remove(idx: Int, n: Int): Unit = 
+  def remove(idx: Int, n: Int): Unit =
     if (n > 0) {
       ensureUnaliased()
       if (idx < 0 || idx + n > len) throw new IndexOutOfBoundsException

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -66,7 +66,6 @@ class ListBuffer[A]
     if (i == 0) null
     else if (i == len) last
     else {
-      assert(i > 0 && i < len)
       var j = i - 1
       var p = first
       while (j > 0) {
@@ -188,7 +187,7 @@ class ListBuffer[A]
   def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
     ensureUnaliased()
     val p = locate(from)
-    removeAfter(p, replaced `min` length - from)
+    removeAfter(p, replaced `min` (length - from))
     insertAfter(p, patch.iterator())
     this
   }

--- a/src/main/scala/strawman/collection/mutable/Seq.scala
+++ b/src/main/scala/strawman/collection/mutable/Seq.scala
@@ -1,0 +1,76 @@
+package strawman
+package collection
+package mutable
+
+trait Seq[A] extends strawman.collection.Seq[A] with Growable[A] {
+  def update(idx: Int, elem: A): Unit
+  def insert(idx: Int, elem: A): Unit
+  def insertAll(idx: Int, elems: IterableOnce[A]): Unit
+  def remove(idx: Int): Option[A]
+  def remove(from: Int, n: Int): Unit
+  def mapInPlace(f: A => A): this.type
+  def flatMapInPlace(f: A => IterableOnce[A]): this.type
+  def filterInPlace(p: A => Boolean): this.type
+  def patchInPlace(from: Int, patch: collection.Seq[Int], replaced: Int): this.type
+
+  // +=, ++=, clear inherited from Growable
+  def +=:(elem: A): this.type = { insert(0, elem); this }
+  def +=:(elem1: A, elem2: A, elems: A*): this.type = elem1 +=: elem2 +=: elems.toStrawman ++=: this
+  def ++=:(elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
+
+  def dropInPlace(n: Int): this.type = { remove(0, n); this }
+  def dropRightInPlace(n: Int): this.type = { remove(length - n, n); this }
+  def takeInPlace(n: Int): this.type = { remove(n, length); this }
+  def takeRightInPlace(n: Int): this.type = { remove(0, length - n); this }
+  def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
+  def dropWhileInPlace(p: A => Boolean): this.type = {
+    val idx = indexWhere(!p(_))
+    if (idx < 0) { clear(); this } else dropInPlace(idx)
+  }
+  def takeWhileInPlace(p: A => Boolean): this.type = {
+    val idx = indexWhere(!p(_))
+    if (idx < 0) this else takeInPlace(idx)
+  }
+  def padToInPlace(len: Int, elem: A): this.type = {
+    while (length < len) +=(elem)
+    this
+  }
+}
+
+trait IndexedOptimizedSeq[A] extends Seq[A] {
+  def mapInPlace(f: A => A): this.type = {
+    var i = 0
+    while (i < size) { this(i) = f(this(i)); i += 1 }
+    this
+  }
+  def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
+    var i = 0
+    val newElemss = new Array[IterableOnce[A]](size)
+    while (i < size) { newElemss(i) = f(this(i)); i += 1 }
+    clear()
+    i = 0
+    while (i < size) { ++=(newElemss(i)); i += 1 }
+    this
+  }
+  def filterInPlace(p: A => Boolean): this.type = {
+    var i = 0
+    var j = 0
+    while (i < size) {
+      if (p(apply(i))) {
+        this(j) = this(i)
+        j += 1
+      }
+      i += 1
+    }
+    takeInPlace(j)
+  }
+  def patchInPlace(from: Int, patch: Seq[A], replaced: Int): this.type = {
+    val n = patch.length min replaced
+    var i = 0
+    while (i < n) { update(from + i, patch(i)); i += 1 }
+    if (i < patch.length) insertAll(from + i, patch.iterator().drop(i))
+    else if (i < replaced) remove(from + i, replaced - i)
+    this
+  }
+}
+

--- a/src/main/scala/strawman/collection/mutable/Seq.scala
+++ b/src/main/scala/strawman/collection/mutable/Seq.scala
@@ -6,12 +6,16 @@ import strawman.collection
 import strawman.collection.{IterableOnce, toNewSeq, toOldSeq}
 import scala.Predef.intWrapper
 
-trait Seq[A] extends strawman.collection.Seq[A] {
+trait Seq[A] extends collection.Seq[A]
+                with collection.SeqLike[A, Seq]
+                with Iterable[A] {
   def update(idx: Int, elem: A): Unit
   def mapInPlace(f: A => A): this.type
 }
 
-trait GrowableSeq[A] extends Seq[A] with Growable[A] {
+trait GrowableSeq[A] extends Seq[A]
+                        with collection.SeqLike[A, Seq]
+                        with Growable[A] {
   def insert(idx: Int, elem: A): Unit
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit
   def remove(idx: Int): A

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -1,6 +1,9 @@
-package strawman
-package collection
-package mutable
+package strawman.collection.mutable
+
+import strawman.collection
+import strawman.collection.IterableOnce
+import scala.{Int, Boolean, Unit, Option, Some, None}
+import scala.Predef.???
 
 trait Set[A] extends collection.Set[A] with Growable[A] {
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -1,0 +1,59 @@
+package strawman
+package collection
+package mutable
+
+trait Set[A] extends collection.Set[A] with Growable[A] {
+
+  def +=(elem: A): this.type
+  def -=(elem: A): this.type
+
+  def contains(elem: A): Boolean
+  def get(elem: A): Option[A]
+
+  def insert(elem: A): Boolean =
+    !contains(elem) && { +=(elem); true }
+
+  def remove(elem: A): Option[A] = {
+    val res = get(elem)
+    -=(elem)
+    res
+  }
+
+  def mapInPlace(f: A => A): Unit = {
+    val toAdd = Set[A]()
+    val toRemove = Set[A]()
+    for (elem <- this) {
+      val mapped = f(elem)
+      if (!contains(mapped)) {
+        toAdd += mapped
+        toRemove -= elem
+      }
+    }
+    for (elem <- toRemove) +=(elem)
+    for (elem <- toAdd) -=(elem)
+  }
+
+  def flatMapInPlace(f: A => IterableOnce[A]): Unit = {
+    val toAdd = Set[A]()
+    val toRemove = Set[A]()
+    for (elem <- this)
+      for (mapped <- f(elem).iterator())
+        if (!contains(mapped)) {
+          toAdd += mapped
+          toRemove -= elem
+        }
+    for (elem <- toRemove) -=(elem)
+    for (elem <- toAdd) +=(elem)
+  }
+
+  def filterInPlace(p: A => Boolean): Unit = {
+    val toRemove = Set[A]()
+    for (elem <- this)
+      if (!p(elem)) toRemove += elem
+    for (elem <- toRemove)
+      -=(elem)
+  }
+}
+object Set {
+  def apply[A](xs: A*): Set[A] = ???
+}

--- a/src/main/scala/strawman/collection/package.scala
+++ b/src/main/scala/strawman/collection/package.scala
@@ -92,6 +92,14 @@ package object collection extends LowPriority {
 
   /** Decorator to add collection operations to arrays. */
   implicit def arrayToArrayOps[A](as: Array[A]): ArrayOps[A] = new ArrayOps[A](as)
+
+  implicit class toNew[A](val s: scala.collection.Seq[A]) extends AnyVal {
+    def toStrawman: strawman.collection.Seq[A] = ???
+  }
+
+  implicit class toOld[A](val s: strawman.collection.Seq[A]) extends AnyVal {
+    def toClassic: scala.collection.Seq[A] = ???
+  }
 }
 
 class LowPriority {

--- a/src/main/scala/strawman/collection/package.scala
+++ b/src/main/scala/strawman/collection/package.scala
@@ -3,8 +3,6 @@ package strawman
 import scala.{AnyVal, Array, Char, Int, Unit}
 import scala.Predef.String
 import scala.reflect.ClassTag
-import strawman.collection.immutable.List
-import strawman.collection.mutable.{ArrayBuffer, Buildable}
 
 /** A strawman architecture for new collections. It contains some
  *  example collection classes and methods with the intent to expose
@@ -93,12 +91,28 @@ package object collection extends LowPriority {
   /** Decorator to add collection operations to arrays. */
   implicit def arrayToArrayOps[A](as: Array[A]): ArrayOps[A] = new ArrayOps[A](as)
 
-  implicit class toNew[A](val s: scala.collection.Seq[A]) extends AnyVal {
-    def toStrawman: strawman.collection.Seq[A] = ???
+  implicit class toNewIterator[A](val it: scala.Iterator[A]) extends AnyVal {
+    def toStrawman = new strawman.collection.Iterator[A] {
+      def hasNext = it.hasNext
+      def next() = it.next()
+    }
   }
 
-  implicit class toOld[A](val s: strawman.collection.Seq[A]) extends AnyVal {
-    def toClassic: scala.collection.Seq[A] = ???
+  implicit class toOldIterator[A](val it: strawman.collection.Iterator[A]) extends AnyVal {
+    def toClassic = new scala.Iterator[A] {
+      def hasNext = it.hasNext
+      def next() = it.next()
+    }
+  }
+
+  implicit class toNewSeq[A](val s: scala.collection.Seq[A]) extends AnyVal {
+    def toStrawman: strawman.collection.Seq[A] =
+      new strawman.collection.mutable.ArrayBuffer() ++= s.iterator.toStrawman
+  }
+
+  implicit class toOldSeq[A](val s: strawman.collection.Seq[A]) extends AnyVal {
+    def toClassic: scala.collection.Seq[A] =
+      new scala.collection.mutable.ArrayBuffer ++= s.iterator().toClassic
   }
 }
 

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -4,9 +4,9 @@ import java.lang.String
 import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
 import scala.Predef.{println, charWrapper}
 
-import strawman.collection._
 import strawman.collection.immutable._
 import strawman.collection.mutable._
+import strawman.collection.{Seq, View, _}
 import org.junit.Test
 
 class StrawmanTest {


### PR DESCRIPTION
 - adds {mutable,immutable}.Iterable
 - adds immutable.Seq
 - fleshes out inheritance of ...Like traits so that all collection
   base traits transform to themselves.

The design is similar to current collections, in that `map` and other transformers are supported on all collections. I wanted to create that as a baseline first. We can then see what it would take to remove some of this functionality for strict mutable collections and general collections.

It's based on the "add mutable collections" PR.