### PR TITLE
make JOL work

### DIFF
--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -2,13 +2,13 @@ package strawman.collection
 
 import strawman.collection.immutable.{LazyList, List}
 
-import scala.{Any, AnyRef, App, Int, Long}
-import scala.Predef.{ArrowAssoc, println}
+import scala.{Unit, Array, Any, AnyRef, App, Int, Long}
+import scala.Predef.{ArrowAssoc, String, println}
 
 import org.openjdk.jol.info.GraphLayout
 import strawman.collection.mutable.{ArrayBuffer, ListBuffer}
 
-object MemoryFootprint extends App {
+object MemoryFootprint {
 
   val sizes = scala.List(8, 64/*, 512, 4096, 32768, 262144, 2097152*/)
 
@@ -27,11 +27,11 @@ object MemoryFootprint extends App {
       "ArrayBuffer" -> benchmark(ArrayBuffer.fill(_)(obj)),
       "ListBuffer"  -> benchmark(ListBuffer.fill(_)(obj))
     )
-
-  // Print the results as a CSV document
-  println("Collection;" + sizes.mkString(";"))
-  for ((name, values) <- memories) {
-    println(name + ";" + values.mkString(";"))
+  def main(args: Array[String]): Unit = {
+    // Print the results as a CSV document
+    println("Collection;" + sizes.mkString(";"))
+    for ((name, values) <- memories) {
+      println(name + ";" + values.mkString(";"))
+    }
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,5 +31,6 @@ val memoryBenchmark =
   project.in(file("benchmarks/memory"))
     .dependsOn(collections)
     .settings(
-      libraryDependencies += "org.openjdk.jol" % "jol-core" % "0.7.1"
+      libraryDependencies += "org.openjdk.jol" % "jol-core" % "0.7.1",
+      fork in run := true
     )


### PR DESCRIPTION
 - Fork tests using JOL to give it a regular classpath to introspect, rather than the exotic one that SBT in-process running ends up with.
  - Avoid apparent scalac bug with `DelayedInit`, that manifest as:

```
java.lang.IncompatibleClassChangeError: strawman.collection.MemoryFootprint and strawman.collection.MemoryFootprint$delayedInit$body disagree on InnerClasses attribute
```