### PR TITLE
Sketch Set and SortedSet

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -12,7 +12,7 @@ import strawman.collection.mutable.{ArrayBuffer, StringBuilder}
   */
 trait EndoIterable[+A]
   extends IterableOnce[A]
-    with EndoIterableLike[A, EndoIterable] {
+    with EndoIterableLike[A, EndoIterable[A]] {
 
   /** The collection itself */
   protected def coll: this.type = this
@@ -20,9 +20,9 @@ trait EndoIterable[+A]
 }
 
 /** Base trait for endomorphic collection operations */
-trait EndoIterableLike[+A, +C[X] <: EndoIterable[X]]
+trait EndoIterableLike[+A, +Repr]
   extends EndoIterableOps[A]
-    with IterableMonoTransforms[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
+    with IterableMonoTransforms[A, Repr]
 
 /** Base trait for generic collections */
 trait Iterable[+A]
@@ -41,14 +41,14 @@ trait Iterable[+A]
   *
   */
 trait IterableLike[+A, +C[X] <: Iterable[X]]
-  extends EndoIterableLike[A, C]
+  extends EndoIterableLike[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
     with FromIterable[C]
     with IterablePolyTransforms[A, C] {
 
   /** Create a collection of type `C[A]` from the elements of `coll`, which has
     *  the same element type as this collection. Overridden in StringOps and ArrayOps.
     */
-  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): C[A] = fromIterable(coll)
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): C[A]
 }
 
 /** Base trait for instances that can construct a collection from an iterable */

--- a/src/main/scala/strawman/collection/IterableOnce.scala
+++ b/src/main/scala/strawman/collection/IterableOnce.scala
@@ -2,6 +2,5 @@ package strawman
 package collection
 
 trait IterableOnce[+A] {
-  /** Iterator can be used only once */
   def iterator(): Iterator[A]
 }

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -1,0 +1,45 @@
+package strawman.collection
+
+import strawman.collection.mutable.Builder
+
+import scala.Option
+import scala.annotation.unchecked.uncheckedVariance
+import scala.Predef.???
+
+/** Base Map type */
+trait Map[K, +V]
+  extends Iterable[(K, V)]
+    with MapLike[K, V, Map]
+
+/** Base Map implementation type */
+trait MapLike[K, +V, +C[X, Y] <: Map[X, Y]]
+  extends EndoIterableLike[(K, V), C[K, V @uncheckedVariance]]
+    with IterableLike[(K, V), Iterable]
+    with MapPolyTransforms[K, V, C] {
+
+  def get(key: K): Option[V]
+
+}
+
+/** Polymorphic transformation methods */
+trait MapPolyTransforms[K, +V, +C[X, Y] <: Map[X, Y]]
+  extends IterablePolyTransforms[(K, V), Iterable] {
+
+  def map[K2, V2](f: (K, V) => (K2, V2)): C[K2, V2]
+
+  def flatMap[K2, V2](f: (K, V) => IterableOnce[(K2, V2)]): C[K2, V2]
+
+}
+
+/** Factory methods for collections of kind `* −> * -> *` */
+trait MapFactories[C[_, _]] {
+
+  def newBuilder[K, V]: Builder[(K, V), C[K, V]]
+
+  def empty[K, V]: C[K, V] =
+    newBuilder[K, V].result
+
+  def apply[K, V](elems: (K, V)*): C[K, V] =
+    newBuilder[K, V].++=(elems.toStrawman).result
+
+}

--- a/src/main/scala/strawman/collection/OrderingGuidedFactories.scala
+++ b/src/main/scala/strawman/collection/OrderingGuidedFactories.scala
@@ -1,0 +1,20 @@
+package strawman.collection
+
+import strawman.collection.mutable.Builder
+
+import scala.Ordering
+
+/**
+  * Factories for collections whose elements require an ordering
+  */
+trait OrderingGuidedFactories[C[_]] {
+
+  def builder[A](implicit ordering: Ordering[A]): Builder[A, C[A]]
+
+  def empty[A](implicit ordering: Ordering[A]): C[A] =
+    builder[A].result
+
+  def apply[A](as: A*)(implicit ordering: Ordering[A]): C[A] =
+    (builder[A] ++= as.toStrawman).result
+
+}

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -50,7 +50,11 @@ trait IndexedSeq[+A] extends Seq[A] { self =>
 /** Base trait for Seq operations */
 trait SeqLike[+A, +C[X] <: Seq[X]]
   extends IterableLike[A, C]
-    with SeqMonoTransforms[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
+    with SeqMonoTransforms[A, C[A @uncheckedVariance]] { // sound bcs of VarianceNote
+
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): C[A] = fromIterable(coll)
+
+}
 
 /** Base trait for linear Seq operations */
 trait LinearSeqLike[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -15,7 +15,7 @@ trait EndoSet[A]
   * Operations of endomorphic sets.
   */
 trait EndoSetLike[A, +C[X] <: EndoSet[X]]
-  extends EndoIterableLike[A, C]
+  extends EndoIterableLike[A, C[A]]
     with SetMonoTransforms[A, C[A]] {
 
   def contains(elem: A): Boolean
@@ -23,9 +23,8 @@ trait EndoSetLike[A, +C[X] <: EndoSet[X]]
 }
 
 /** Monomorphic transformation operations on sets */
-trait SetMonoTransforms[A, +Repr] {
-
-  def filter(p: A => Boolean): Repr
+trait SetMonoTransforms[A, +Repr]
+  extends IterableMonoTransforms[A, Repr] {
 
   /** Intersection of `this` and `that` */
   def & (that: EndoSet[A]): Repr

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -4,39 +4,44 @@ import scala.Boolean
 
 /** Partial base trait for set collections
   *
-  * Supports only monomorphic transformations.
+  * Supports only operations returning a set with
+  * elements of the same type `A`.
   */
-trait MonoSet[A]
-  extends IterableOnce[A]
-    with MonoSetLike[A, MonoSet]
+trait EndoSet[A]
+  extends EndoIterable[A]
+    with EndoSetLike[A, EndoSet]
 
-trait MonoSetLike[A, +C[X] <: MonoSet[X]]
-  extends MonoSetMonoTransforms[A, C[A]] {
+/**
+  * Operations of endomorphic sets.
+  */
+trait EndoSetLike[A, +C[X] <: EndoSet[X]]
+  extends EndoIterableLike[A, C]
+    with SetMonoTransforms[A, C[A]] {
 
   def contains(elem: A): Boolean
 
 }
 
-/** Monomorphic transformation operations */
-trait MonoSetMonoTransforms[A, +Repr] {
+/** Monomorphic transformation operations on sets */
+trait SetMonoTransforms[A, +Repr] {
 
   def filter(p: A => Boolean): Repr
 
   /** Intersection of `this` and `that` */
-  def & (that: MonoSet[A]): Repr
+  def & (that: EndoSet[A]): Repr
 
   /** Union of `this` and `that` */
-  def ++ (that: MonoSet[A]): Repr
+  def ++ (that: EndoSet[A]): Repr
 
 }
 
 /** Base trait for set collections */
 trait Set[A]
-  extends MonoSet[A]
+  extends EndoSet[A]
     with Iterable[A]
     with SetLike[A, Set]
 
 /** Base trait for set operations */
 trait SetLike[A, +C[X] <: Set[X]]
-  extends MonoSetLike[A, C]
+  extends EndoSetLike[A, C]
     with IterableLike[A, C]

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,4 +1,42 @@
-package strawman
-package collection
+package strawman.collection
 
-trait Set[A] extends Iterable[A] {}
+import scala.Boolean
+
+/** Partial base trait for set collections
+  *
+  * Supports only monomorphic transformations.
+  */
+trait MonoSet[A]
+  extends IterableOnce[A]
+    with MonoSetLike[A, MonoSet]
+
+trait MonoSetLike[A, +C[X] <: MonoSet[X]]
+  extends MonoSetMonoTransforms[A, C[A]] {
+
+  def contains(elem: A): Boolean
+
+}
+
+/** Monomorphic transformation operations */
+trait MonoSetMonoTransforms[A, +Repr] {
+
+  def filter(p: A => Boolean): Repr
+
+  /** Intersection of `this` and `that` */
+  def & (that: MonoSet[A]): Repr
+
+  /** Union of `this` and `that` */
+  def ++ (that: MonoSet[A]): Repr
+
+}
+
+/** Base trait for set collections */
+trait Set[A]
+  extends MonoSet[A]
+    with Iterable[A]
+    with SetLike[A, Set]
+
+/** Base trait for set operations */
+trait SetLike[A, +C[X] <: Set[X]]
+  extends MonoSetLike[A, C]
+    with IterableLike[A, C]

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -1,0 +1,24 @@
+package strawman.collection
+
+import scala.{Ordering}
+
+/** Base trait for sorted collections */
+trait Sorted[A]
+  extends SortedLike[A, Sorted]
+
+trait SortedLike[A, +C[X] <: Sorted[X]] {
+
+  def ordering: Ordering[A]
+
+  /** Ranged projection of this collection with both a lower-bound and an upper-bound */
+  def range(from: A, until: A): C[A]
+
+}
+
+/** Polymorphic transformation methods on sorted collections.
+  */
+trait SortedPolyTransforms[A, +C[X] <: Sorted[X]] {
+
+  def map[B](f: A => B)(implicit ordering: Ordering[B]): C[B]
+
+}

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -7,18 +7,23 @@ import scala.Predef.intWrapper
 trait View[+A] extends Iterable[A] with IterableLike[A, View] {
   override def view = this
 
-  /** Avoid copying if source collection is already a view. */
-  override def fromIterable[B](c: EndoIterable[B]): View[B] = c match {
-    case c: View[B] => c
-    case _ => View.fromIterator(c.iterator())
-  }
+  override def fromIterable[B](c: EndoIterable[B]): View[B] = View.fromIterable(c)
+
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): View[A] = fromIterable(coll)
+
   override def className = "View"
 }
 
 /** This object reifies operations on views as case classes */
-object View {
+object View extends FromIterable[View] {
   def fromIterator[A](it: => Iterator[A]): View[A] = new View[A] {
     def iterator() = it
+  }
+
+  /** Avoid copying if source collection is already a view. */
+  def fromIterable[A](c: EndoIterable[A]): View[A] = c match {
+    case c: View[A] => c
+    case _ => View.fromIterator(c.iterator())
   }
 
   /** The empty view */

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -8,7 +8,7 @@ trait View[+A] extends Iterable[A] with IterableLike[A, View] {
   override def view = this
 
   /** Avoid copying if source collection is already a view. */
-  override def fromIterable[B](c: Iterable[B]): View[B] = c match {
+  override def fromIterable[B](c: EndoIterable[B]): View[B] = c match {
     case c: View[B] => c
     case _ => View.fromIterator(c.iterator())
   }
@@ -34,12 +34,12 @@ object View {
   }
 
   /** A view that filters an underlying collection. */
-  case class Filter[A](underlying: Iterable[A], p: A => Boolean) extends View[A] {
+  case class Filter[A](underlying: EndoIterable[A], p: A => Boolean) extends View[A] {
     def iterator() = underlying.iterator().filter(p)
   }
 
   /** A view that partitions an underlying collection into two views */
-  case class Partition[A](underlying: Iterable[A], p: A => Boolean) {
+  case class Partition[A](underlying: EndoIterable[A], p: A => Boolean) {
 
     /** The view consisting of all elements of the underlying collection
      *  that satisfy `p`.
@@ -58,7 +58,7 @@ object View {
   }
 
   /** A view that drops leading elements of the underlying collection. */
-  case class Drop[A](underlying: Iterable[A], n: Int) extends View[A] {
+  case class Drop[A](underlying: EndoIterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().drop(n)
     protected val normN = n max 0
     override def knownSize =
@@ -66,7 +66,7 @@ object View {
   }
 
   /** A view that takes leading elements of the underlying collection. */
-  case class Take[A](underlying: Iterable[A], n: Int) extends View[A] {
+  case class Take[A](underlying: EndoIterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().take(n)
     protected val normN = n max 0
     override def knownSize =
@@ -74,20 +74,20 @@ object View {
   }
 
   /** A view that maps elements of the underlying collection. */
-  case class Map[A, B](underlying: Iterable[A], f: A => B) extends View[B] {
+  case class Map[A, B](underlying: EndoIterable[A], f: A => B) extends View[B] {
     def iterator() = underlying.iterator().map(f)
     override def knownSize = underlying.knownSize
   }
 
   /** A view that flatmaps elements of the underlying collection. */
-  case class FlatMap[A, B](underlying: Iterable[A], f: A => IterableOnce[B]) extends View[B] {
+  case class FlatMap[A, B](underlying: EndoIterable[A], f: A => IterableOnce[B]) extends View[B] {
     def iterator() = underlying.iterator().flatMap(f)
   }
 
   /** A view that concatenates elements of the underlying collection with the elements
    *  of another collection or iterator.
    */
-  case class Concat[A](underlying: Iterable[A], other: IterableOnce[A]) extends View[A] {
+  case class Concat[A](underlying: EndoIterable[A], other: IterableOnce[A]) extends View[A] {
     def iterator() = underlying.iterator() ++ other
     override def knownSize = other match {
       case other: Iterable[_] if underlying.knownSize >= 0 && other.knownSize >= 0 =>
@@ -100,7 +100,7 @@ object View {
   /** A view that zips elements of the underlying collection with the elements
    *  of another collection or iterator.
    */
-  case class Zip[A, B](underlying: Iterable[A], other: IterableOnce[B]) extends View[(A, B)] {
+  case class Zip[A, B](underlying: EndoIterable[A], other: IterableOnce[B]) extends View[(A, B)] {
     def iterator() = underlying.iterator().zip(other)
     override def knownSize = other match {
       case other: Iterable[_] => underlying.knownSize min other.knownSize

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection.immutable
 
-import strawman.collection.{IterableFactory, Iterator}
+import strawman.collection.{EndoIterable, IterableFactory, Iterator}
 
 import scala.Boolean
 import scala.Predef.???
@@ -11,15 +11,15 @@ final class HashSet[A]
     with SetLike[A, HashSet] {
 
   // from IterablePolyTransforms
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] =
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] =
     HashSet.fromIterable(it)
 
   // from IterableOnce
   def iterator(): Iterator[A] = ???
 
   // from MonoSet
-  def & (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
-  def ++ (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+  def & (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
+  def ++ (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
 
   // from immutable.MonoSet
   def + (elem: A): HashSet[A] = ???
@@ -30,6 +30,6 @@ final class HashSet[A]
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = ???
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] = ???
 
 }

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -17,11 +17,11 @@ final class HashSet[A]
   // from IterableOnce
   def iterator(): Iterator[A] = ???
 
-  // from MonoSet
+  // from EndoSet
   def & (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
   def ++ (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
 
-  // from immutable.MonoSet
+  // from immutable.EndoSet
   def + (elem: A): HashSet[A] = ???
   def - (elem: A): HashSet[A] = ???
   def contains(elem: A): Boolean = ???

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -11,8 +11,9 @@ final class HashSet[A]
     with SetLike[A, HashSet] {
 
   // from IterablePolyTransforms
-  def fromIterable[B](it: EndoIterable[B]): HashSet[B] =
-    HashSet.fromIterable(it)
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] = HashSet.fromIterable(it)
+  // from IterableMonoTransforms
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): HashSet[A] = fromIterable(coll)
 
   // from IterableOnce
   def iterator(): Iterator[A] = ???

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -1,0 +1,35 @@
+package strawman.collection.immutable
+
+import strawman.collection.{IterableFactory, Iterator}
+
+import scala.Boolean
+import scala.Predef.???
+
+/** An immutable Set backed by a hash trie */
+final class HashSet[A]
+  extends Set[A]
+    with SetLike[A, HashSet] {
+
+  // from IterablePolyTransforms
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] =
+    HashSet.fromIterable(it)
+
+  // from IterableOnce
+  def iterator(): Iterator[A] = ???
+
+  // from MonoSet
+  def & (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+  def ++ (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+
+  // from immutable.MonoSet
+  def + (elem: A): HashSet[A] = ???
+  def - (elem: A): HashSet[A] = ???
+  def contains(elem: A): Boolean = ???
+
+}
+
+object HashSet extends IterableFactory[HashSet] {
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = ???
+
+}

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,8 +1,7 @@
 package strawman.collection.immutable
 
-import scala.{Option, Some, None, Nothing, StringContext}
-import strawman.collection
-import strawman.collection.{IterableFactory, LinearSeq, SeqLike, Iterator}
+import scala.{None, Nothing, Option, Some, StringContext}
+import strawman.collection.{EndoIterable, IterableFactory, Iterator, LinearSeq, SeqLike}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
   extends Seq[A] with SeqLike[A, LazyList] with LinearSeq[A] {
@@ -23,7 +22,7 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
-  def fromIterable[B](c: collection.Iterable[B]): LazyList[B] = LazyList.fromIterable(c)
+  def fromIterable[B](c: EndoIterable[B]): LazyList[B] = LazyList.fromIterable(c)
 
   override def className = "LazyList"
 
@@ -46,7 +45,7 @@ object LazyList extends IterableFactory[LazyList] {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force
   }
 
-  def fromIterable[B](coll: collection.Iterable[B]): LazyList[B] = coll match {
+  def fromIterable[B](coll: EndoIterable[B]): LazyList[B] = coll match {
     case coll: LazyList[B] => coll
     case _ => fromIterator(coll.iterator())
   }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -3,8 +3,7 @@ package strawman.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.Nothing
 import scala.Predef.???
-import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{EndoIterable, IterableFactory, IterableOnce, LinearSeq, SeqLike}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
@@ -15,7 +14,7 @@ sealed trait List[+A]
      with LinearSeq[A]
      with Buildable[A, List[A]] {
 
-  def fromIterable[B](c: collection.Iterable[B]): List[B] = List.fromIterable(c)
+  def fromIterable[B](c: EndoIterable[B]): List[B] = List.fromIterable(c)
 
   protected[this] def newBuilder = new ListBuffer[A].mapResult(_.toList)
 
@@ -50,7 +49,7 @@ case object Nil extends List[Nothing] {
 }
 
 object List extends IterableFactory[List] {
-  def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
+  def fromIterable[B](coll: EndoIterable[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.fromIterable(coll).toList
   }

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -5,12 +5,12 @@ import strawman.collection.IterableLike
 import scala.Any
 
 /** Base trait for immutable set operations supporting only monomorphic transformations */
-trait MonoSet[A]
-  extends strawman.collection.MonoSet[A]
-    with MonoSetLike[A, MonoSet]
+trait EndoSet[A]
+  extends strawman.collection.EndoSet[A]
+    with EndoSetLike[A, EndoSet]
 
-trait MonoSetLike[A, +C[X] <: MonoSet[X]]
-  extends strawman.collection.MonoSetLike[A, C] {
+trait EndoSetLike[A, +C[X] <: EndoSet[X]]
+  extends strawman.collection.EndoSetLike[A, C] {
 
   def + (elem: A): C[A]
 
@@ -22,10 +22,11 @@ trait MonoSetLike[A, +C[X] <: MonoSet[X]]
 trait Set[A]
   extends strawman.collection.Set[A]
     with Iterable[A]
-    with MonoSet[A]
+    with EndoSet[A]
     with SetLike[A, Set]
 
 
 /** Base trait for immutable set operations */
 trait SetLike[A, +C[X] <: Set[X]]
   extends strawman.collection.SetLike[A, C]
+    with EndoSetLike[A, C]

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -1,0 +1,31 @@
+package strawman.collection.immutable
+
+import strawman.collection.IterableLike
+
+import scala.Any
+
+/** Base trait for immutable set operations supporting only monomorphic transformations */
+trait MonoSet[A]
+  extends strawman.collection.MonoSet[A]
+    with MonoSetLike[A, MonoSet]
+
+trait MonoSetLike[A, +C[X] <: MonoSet[X]]
+  extends strawman.collection.MonoSetLike[A, C] {
+
+  def + (elem: A): C[A]
+
+  def - (elem: A): C[A]
+
+}
+
+/** Base trait for immutable set collections */
+trait Set[A]
+  extends strawman.collection.Set[A]
+    with Iterable[A]
+    with MonoSet[A]
+    with SetLike[A, Set]
+
+
+/** Base trait for immutable set operations */
+trait SetLike[A, +C[X] <: Set[X]]
+  extends strawman.collection.SetLike[A, C]

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -5,10 +5,10 @@ import strawman.collection.{Sorted, SortedLike, SortedPolyTransforms}
 /** Base trait for immutable sets whose values have an ordering */
 trait SortedSet[A]
   extends Sorted[A]
-    with MonoSet[A]
+    with EndoSet[A]
     with SortedSetLike[A, SortedSet]
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends SortedLike[A, C]
-    with MonoSetLike[A, C]
+    with EndoSetLike[A, C]
     with SortedPolyTransforms[A, C]

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -1,0 +1,14 @@
+package strawman.collection.immutable
+
+import strawman.collection.{Sorted, SortedLike, SortedPolyTransforms}
+
+/** Base trait for immutable sets whose values have an ordering */
+trait SortedSet[A]
+  extends Sorted[A]
+    with MonoSet[A]
+    with SortedSetLike[A, SortedSet]
+
+trait SortedSetLike[A, +C[X] <: SortedSet[X]]
+  extends SortedLike[A, C]
+    with MonoSetLike[A, C]
+    with SortedPolyTransforms[A, C]

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -1,7 +1,7 @@
 package strawman.collection.immutable
 
 import strawman.collection.mutable.Builder
-import strawman.collection.{Iterator, OrderingGuidedFactories}
+import strawman.collection.{EndoIterable, Iterator, OrderingGuidedFactories}
 
 import scala.{Boolean, Ordering}
 import scala.Predef.???
@@ -15,8 +15,8 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
   def iterator(): Iterator[A] = ???
 
   // from MonoSet
-  def & (that: strawman.collection.MonoSet[A]): TreeSet[A] = ???
-  def ++ (that: strawman.collection.MonoSet[A]): TreeSet[A] = ???
+  def & (that: strawman.collection.EndoSet[A]): TreeSet[A] = ???
+  def ++ (that: strawman.collection.EndoSet[A]): TreeSet[A] = ???
   def contains(elem: A): Boolean = ???
 
   // from immutable.MonoSet
@@ -26,11 +26,11 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
   // from Sorted
   def range(from: A, until: A): TreeSet[A] = ???
 
-  // from MonoSetMonoTransforms
-  def filter(p: A => Boolean): TreeSet[A] = ???
-
   // from SortedPolyTransforms
   def map[B](f: A => B)(implicit ordering: Ordering[B]): TreeSet[B] = ???
+
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): TreeSet[A] =
+    (TreeSet.builder[A] ++= coll).result
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -1,0 +1,41 @@
+package strawman.collection.immutable
+
+import strawman.collection.mutable.Builder
+import strawman.collection.{Iterator, OrderingGuidedFactories}
+
+import scala.{Boolean, Ordering}
+import scala.Predef.???
+
+/** Immutable sorted set backed by a tree */
+final class TreeSet[A]()(implicit val ordering: Ordering[A])
+  extends SortedSet[A]
+    with SortedSetLike[A, TreeSet] {
+
+  // from IterableOnce
+  def iterator(): Iterator[A] = ???
+
+  // from MonoSet
+  def & (that: strawman.collection.MonoSet[A]): TreeSet[A] = ???
+  def ++ (that: strawman.collection.MonoSet[A]): TreeSet[A] = ???
+  def contains(elem: A): Boolean = ???
+
+  // from immutable.MonoSet
+  def +(elem: A): TreeSet[A] = ???
+  def -(elem: A): TreeSet[A] = ???
+
+  // from Sorted
+  def range(from: A, until: A): TreeSet[A] = ???
+
+  // from MonoSetMonoTransforms
+  def filter(p: A => Boolean): TreeSet[A] = ???
+
+  // from SortedPolyTransforms
+  def map[B](f: A => B)(implicit ordering: Ordering[B]): TreeSet[B] = ???
+
+}
+
+object TreeSet extends OrderingGuidedFactories[TreeSet] {
+
+  def builder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = ???
+
+}

--- a/src/main/scala/strawman/collection/javaSupport.scala
+++ b/src/main/scala/strawman/collection/javaSupport.scala
@@ -9,7 +9,7 @@ import strawman.collection.mutable.{ArrayBuffer, Buildable, StringBuilder}
 import scala.reflect.ClassTag
 
 class StringOps(val s: String)
-  extends AnyVal with IterableOps[Char]
+  extends AnyVal with EndoIterableOps[Char]
     with SeqMonoTransforms[Char, String]
     with IterablePolyTransforms[Char, List]
     with Buildable[Char, String]
@@ -18,13 +18,13 @@ class StringOps(val s: String)
   protected def coll = new StringView(s)
   def iterator() = coll.iterator()
 
-  protected def fromIterableWithSameElemType(coll: Iterable[Char]): String = {
+  protected def fromIterableWithSameElemType(coll: EndoIterable[Char]): String = {
     val sb = new StringBuilder
     for (ch <- coll) sb += ch
     sb.result
   }
 
-  def fromIterable[B](coll: Iterable[B]): List[B] = List.fromIterable(coll)
+  def fromIterable[B](coll: EndoIterable[B]): List[B] = List.fromIterable(coll)
 
   protected[this] def newBuilder = new StringBuilder
 
@@ -74,7 +74,7 @@ case class StringView(s: String) extends IndexedView[Char] {
 
 
 class ArrayOps[A](val xs: Array[A])
-  extends AnyVal with IterableOps[A]
+  extends AnyVal with EndoIterableOps[A]
     with SeqMonoTransforms[A, Array[A]]
     with Buildable[A, Array[A]]
     with ArrayLike[A] {
@@ -89,9 +89,9 @@ class ArrayOps[A](val xs: Array[A])
 
   def elemTag: ClassTag[A] = ClassTag(xs.getClass.getComponentType)
 
-  protected def fromIterableWithSameElemType(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
+  protected def fromIterableWithSameElemType(coll: EndoIterable[A]): Array[A] = coll.toArray[A](elemTag)
 
-  def fromIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
+  def fromIterable[B: ClassTag](coll: EndoIterable[B]): Array[B] = coll.toArray[B]
 
   protected[this] def newBuilder = new ArrayBuffer[A].mapResult(_.toArray(elemTag))
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -1,9 +1,11 @@
 package strawman.collection.mutable
 
 import java.lang.IndexOutOfBoundsException
-import scala.{Array, Int, Long, Boolean, Unit, AnyRef}
+
+import scala.{AnyRef, Array, Boolean, Int, Long, Unit}
 import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, SeqLike, IndexedView}
+import strawman.collection.{EndoIterable, IndexedView, IterableFactory, IterableOnce, SeqLike}
+
 import scala.Predef.intWrapper
 
 /** Concrete collection type: ArrayBuffer */
@@ -44,7 +46,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def iterator() = view.iterator()
 
-  def fromIterable[B](it: collection.Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](it: EndoIterable[B]): ArrayBuffer[B] =
     ArrayBuffer.fromIterable(it)
 
   protected[this] def newBuilder = new ArrayBuffer[A]
@@ -125,7 +127,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
-  def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](coll: EndoIterable[B]): ArrayBuffer[B] =
     if (coll.knownSize >= 0) {
       val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -1,0 +1,42 @@
+package strawman.collection.mutable
+
+import strawman.collection.{EndoIterable, IterableOnce, Iterator, MapFactories}
+
+import scala.{Option, Unit}
+import scala.Predef.???
+
+final class HashMap[K, V]
+  extends Map[K, V]
+    with MapLike[K, V, HashMap] {
+
+  // From IterableOnce
+  def iterator(): Iterator[(K, V)] = ???
+
+  // From MapLike
+  def get(key: K): Option[V] = ???
+
+  // From Growable
+  def +=(elem: (K, V)): this.type = ???
+  def clear(): Unit = ???
+
+  // From mutable.MapLike
+  def -=(elem: (K, V)): this.type = ???
+  def put(key: K, value: V): Option[V] = ???
+
+  // From MapPolyTransforms
+  def map[K2, V2](f: (K, V) => (K2, V2)): HashMap[K2, V2] = ???
+  def flatMap[K2, V2](f: (K, V) => IterableOnce[(K2, V2)]): HashMap[K2, V2] = ???
+
+  // From IterableMonoTransforms
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[(K, V)]): HashMap[K, V] = ???
+
+  // From IterablePolyTransforms
+  def fromIterable[B](coll: EndoIterable[B]): Iterable[B] = ??? // Note that here we have to return a mutable Iterable. Does that really make sense?
+
+}
+
+object HashMap extends MapFactories[HashMap] {
+
+  def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = ???
+
+}

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection.mutable
 
-import strawman.collection.{IterableFactory, IterableLike, Iterator}
+import strawman.collection.{EndoIterable, IterableFactory, IterableLike, Iterator}
 
 import scala.{Boolean, Unit}
 import scala.Predef.???
@@ -18,7 +18,7 @@ final class HashSet[A]
 
   def contains(elem: A): Boolean = ???
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] =
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] =
     HashSet.fromIterable(it)
 
   def newBuilder: Builder[A, HashSet[A]] = new HashSet[A]
@@ -29,15 +29,15 @@ final class HashSet[A]
 
   def clear(): Unit = ???
 
-  def & (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+  def & (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
 
-  def ++ (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+  def ++ (that: strawman.collection.EndoSet[A]): HashSet[A] = ???
 
 }
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = {
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] = {
     val result = new HashSet[B]
     for (elem <- it) {
       result += elem

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -17,8 +17,8 @@ final class HashSet[A]
   def contains(elem: A): Boolean = ???
   def get(elem: A): Option[A] = ???
 
-  def fromIterable[B](it: EndoIterable[B]): HashSet[B] =
-    HashSet.fromIterable(it)
+  def fromIterable[B](it: EndoIterable[B]): HashSet[B] = HashSet.fromIterable(it)
+  protected[this] def fromIterableWithSameElemType(coll: EndoIterable[A]): HashSet[A] = fromIterable(coll)
 
   def newBuilder: Builder[A, HashSet[A]] = new HashSet[A]
 

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import strawman.collection.{EndoIterable, IterableFactory, IterableLike, Iterator}
 
-import scala.{Boolean, Unit}
+import scala.{Boolean, Option, Unit}
 import scala.Predef.???
 
 /** Mutable set backed by a hash trie */
@@ -13,10 +13,9 @@ final class HashSet[A]
     with Builder[A, HashSet[A]] {
 
   def +=(elem: A): this.type = ???
-
   def -=(elem: A): this.type = ???
-
   def contains(elem: A): Boolean = ???
+  def get(elem: A): Option[A] = ???
 
   def fromIterable[B](it: EndoIterable[B]): HashSet[B] =
     HashSet.fromIterable(it)

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -1,0 +1,48 @@
+package strawman.collection.mutable
+
+import strawman.collection.{IterableFactory, IterableLike, Iterator}
+
+import scala.{Boolean, Unit}
+import scala.Predef.???
+
+/** Mutable set backed by a hash trie */
+final class HashSet[A]
+  extends Set[A]
+    with IterableLike[A, HashSet]
+    with Buildable[A, HashSet[A]]
+    with Builder[A, HashSet[A]] {
+
+  def +=(elem: A): this.type = ???
+
+  def -=(elem: A): this.type = ???
+
+  def contains(elem: A): Boolean = ???
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] =
+    HashSet.fromIterable(it)
+
+  def newBuilder: Builder[A, HashSet[A]] = new HashSet[A]
+
+  def result: HashSet[A] = this
+
+  def iterator(): Iterator[A] = ???
+
+  def clear(): Unit = ???
+
+  def & (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+
+  def ++ (that: strawman.collection.MonoSet[A]): HashSet[A] = ???
+
+}
+
+object HashSet extends IterableFactory[HashSet] {
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = {
+    val result = new HashSet[B]
+    for (elem <- it) {
+      result += elem
+    }
+    result
+  }
+
+}

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -1,12 +1,14 @@
 package strawman.collection.mutable
 
-import scala.{Int, Unit, Boolean}
+import scala.{Boolean, Int, Unit}
 import scala.Int._
 import strawman.collection
-import strawman.collection.{Iterator, IterableOnce, IterableFactory, SeqLike}
-import strawman.collection.immutable.{List, Nil, ::}
+import strawman.collection.{EndoIterable, IterableFactory, IterableOnce, Iterator, SeqLike}
+import strawman.collection.immutable.{::, List, Nil}
+
 import scala.annotation.tailrec
 import java.lang.IndexOutOfBoundsException
+
 import scala.Predef.{assert, intWrapper}
 
 /** Concrete collection type: ListBuffer */
@@ -25,7 +27,7 @@ class ListBuffer[A]
 
   def iterator() = first.iterator()
 
-  def fromIterable[B](coll: collection.Iterable[B]) = ListBuffer.fromIterable(coll)
+  def fromIterable[B](coll: EndoIterable[B]) = ListBuffer.fromIterable(coll)
 
   def apply(i: Int) = first.apply(i)
 
@@ -198,5 +200,5 @@ class ListBuffer[A]
 }
 
 object ListBuffer extends IterableFactory[ListBuffer] {
-  def fromIterable[B](coll: collection.Iterable[B]): ListBuffer[B] = new ListBuffer[B] ++= coll
+  def fromIterable[B](coll: EndoIterable[B]): ListBuffer[B] = new ListBuffer[B] ++= coll
 }

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -1,0 +1,18 @@
+package strawman.collection.mutable
+
+import scala.Option
+
+trait Map[K, V]
+  extends strawman.collection.Map[K, V]
+    with MapLike[K, V, Map]
+
+trait MapLike[K, V, +C[X, Y] <: Map[X, Y]]
+  extends strawman.collection.MapLike[K, V, C]
+    with Iterable[(K, V)]
+    with Growable[(K, V)] {
+
+  def -= (elem: (K, V)): this.type
+
+  def put(key: K, value: V): Option[V]
+
+}

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -14,7 +14,7 @@ trait Set[A]
   def +=(elem: A): this.type
   def -=(elem: A): this.type
 
-  def get(elem: A): Option[A] = if (contains(elem)) Some(elem) else None
+  def get(elem: A): Option[A]
 
   def insert(elem: A): Boolean =
     !contains(elem) && { +=(elem); true }

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -5,13 +5,16 @@ import strawman.collection.IterableOnce
 import scala.{Int, Boolean, Unit, Option, Some, None}
 import scala.Predef.???
 
-trait Set[A] extends collection.Set[A] with Growable[A] {
+/** Base trait for mutable sets */
+trait Set[A]
+  extends collection.Set[A]
+    with collection.SetLike[A, Set]
+    with Growable[A] {
 
   def +=(elem: A): this.type
   def -=(elem: A): this.type
 
-  def contains(elem: A): Boolean
-  def get(elem: A): Option[A]
+  def get(elem: A): Option[A] = if (contains(elem)) Some(elem) else None
 
   def insert(elem: A): Boolean =
     !contains(elem) && { +=(elem); true }
@@ -57,6 +60,7 @@ trait Set[A] extends collection.Set[A] with Growable[A] {
       -=(elem)
   }
 }
+
 object Set {
-  def apply[A](xs: A*): Set[A] = ???
+  def apply[A](xs: A*): Set[A] = HashSet(xs: _*)
 }

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -130,7 +130,7 @@ class StrawmanTest {
     val ys9: Seq[Int] = xs9
     val xs9a = xs.map(_.toUpper)
     val ys9a: String = xs9a
-    val xs10 = xs.flatMap((x: Char) => s"$x,$x")
+    val xs10 = xs.flatMap(x => s"$x,$x")
     val ys10: String = xs10
     val xs11 = xs ++ xs
     val ys11: String = xs11
@@ -317,6 +317,18 @@ class StrawmanTest {
     val xs6: strawman.collection.immutable.TreeSet[String] = xs5
     val xs7 = xs5 + "foo"
     val xs8: strawman.collection.immutable.TreeSet[String] = xs7
+  }
+
+  def mapOps(xs: strawman.collection.Map[Int, String]): Unit = {
+    val xs1 = xs.map((k, v) => (v, k))
+//    val xs1Bis = xs.map { case (k, v) => (v, k) } // See https://github.com/scala/scala/pull/5698
+    val xs2: strawman.collection.Map[String, Int] = xs1
+    val xs3 = xs.map(kv => (kv._2, kv._1))
+    val xs4: strawman.collection.Iterable[(String, Int)] = xs3
+    println(xs1)
+    println(xs2)
+    println(xs3)
+    println(xs4)
   }
 
   @Test

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -6,7 +6,7 @@ import scala.Predef.{println, charWrapper}
 
 import strawman.collection.immutable._
 import strawman.collection.mutable._
-import strawman.collection.{Seq, View, _}
+import strawman.collection.{Seq, Set, View, _}
 import org.junit.Test
 
 class StrawmanTest {
@@ -286,6 +286,37 @@ class StrawmanTest {
     }
     println(xs17)
     println(xs17.to(List))
+  }
+
+  def setOps(xs: Set[Int]): Unit = {
+    val xs1 = xs.foldLeft("")(_ + _)
+    val xs2: String = xs1
+    val xs3 = xs.map(x => x + 1)
+    val xs4: Set[Int] = xs3
+    val xs5 = xs3 & xs4
+    val xs6: Set[Int] = xs5
+  }
+
+  def hashSetOps(xs: strawman.collection.immutable.HashSet[Int]): Unit = {
+    val xs1 = xs.foldLeft("")(_ + _)
+    val xs2: String = xs1
+    val xs3 = xs.map(x => x.toString)
+    val xs4: strawman.collection.immutable.HashSet[String] = xs3
+    val xs5 = xs3 & xs4
+    val xs6: strawman.collection.immutable.HashSet[String] = xs5
+    val xs7 = xs5 + "foo"
+    val xs8: strawman.collection.immutable.HashSet[String] = xs7
+  }
+
+  def treeSetOps(xs: strawman.collection.immutable.TreeSet[Int]): Unit = {
+    val xs1 = xs.foldLeft("")(_ + _)
+    val xs2: String = xs1
+    val xs3 = xs.map(x => x.toString)
+    val xs4: strawman.collection.immutable.TreeSet[String] = xs3
+    val xs5 = xs3 & xs4
+    val xs6: strawman.collection.immutable.TreeSet[String] = xs5
+    val xs7 = xs5 + "foo"
+    val xs8: strawman.collection.immutable.TreeSet[String] = xs7
   }
 
   @Test


### PR DESCRIPTION
`SortedSet[A]` can not inherit from `Iterable[A]` because it would have to implement a `fromIterable[B](it: Iterable[B]): SortedSet[B]` , which is not possible because we miss an `Ordering[B]`.

Therefore, the LUB of `SortedSet[A]` and `List[A]` is not `Iterable[A]` but `IterableOnce[A]`. Note that we could pull up a lot of method definitions which are identical in both `SortedSet` and `List` in an intermediate trait, which would sit in between `IterableOnce` and `Iterable`, and which would basically contain all the operations provided by `IterableOps` and `IterableMonoTransforms`. I applied this idea to the `Set` hierarchy only but we could generalize it to `Iterable`.

Before going further, maybe someone has a better idea?

Also, here are some questions about our current design:
- Should we keep both `Buildable` and `FromIterable`? It seems that they overlap. I do prefer the more general `Buildable` thing over `FromIterable` ;
- Should we pull up `mapInPlace` and friends in a `GrowableLike` trait? (currently they are defined in both `mutable.Set` and `mutable.Seq` but they are unrelated inheritance-wise ;
- Should we keep both `XxxOps` and `XxxLike`? I’d be in favor of putting everything in `XxxLike` traits and discard `XxxOps`.