### PR TITLE
Overloading based implementation of Set, TreeSet, Map and TreeMap

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -34,7 +34,7 @@ trait IterableLike[+A, +C[X] <: Iterable[X]]
   /** Create a collection of type `C[A]` from the elements of `coll`, which has
     *  the same element type as this collection. Overridden in StringOps and ArrayOps.
     */
-  protected[this] def fromIterableWithSameElemType(coll: Iterable[A]): C[A] = fromIterable(coll)
+  protected[this] def fromIterableWithSameElemType(coll: Iterable[A]): C[A]
 }
 
 /** Base trait for instances that can construct a collection from an iterable */

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -1,0 +1,44 @@
+package strawman.collection
+
+import strawman.collection.mutable.Builder
+
+import scala.Option
+import scala.annotation.unchecked.uncheckedVariance
+import scala.Predef.???
+
+/** Base Map type */
+trait Map[K, +V]
+  extends Iterable[(K, V)]
+    with MapLike[K, V, Map]
+
+/** Base Map implementation type */
+trait MapLike[K, +V, +C[X, Y] <: Map[X, Y]]
+  extends IterableLike[(K, V), Iterable]
+    with IterableMonoTransforms[(K, V), C[K, V @uncheckedVariance]]
+    with MapPolyTransforms[K, V, C] {
+
+  def get(key: K): Option[V]
+
+}
+
+/** Polymorphic transformation methods */
+trait MapPolyTransforms[K, +V, +C[X, Y] <: Map[X, Y]] extends IterablePolyTransforms[(K, V), Iterable] {
+
+  def map[K2, V2](f: (K, V) => (K2, V2)): C[K2, V2]
+
+  def flatMap[K2, V2](f: (K, V) => IterableOnce[(K2, V2)]): C[K2, V2]
+
+}
+
+/** Factory methods for collections of kind `* −> * -> *` */
+trait MapFactories[C[_, _]] {
+
+  def newBuilder[K, V]: Builder[(K, V), C[K, V]]
+
+  def empty[K, V]: C[K, V] =
+    newBuilder[K, V].result
+
+  def apply[K, V](elems: (K, V)*): C[K, V] =
+    newBuilder[K, V].++=(elems.toStrawman).result
+
+}

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -56,6 +56,8 @@ trait SeqLike[+A, +C[X] <: Seq[X]]
 
   protected def coll: C[A @uncheckedVariance]
 
+  protected[this] def fromIterableWithSameElemType(coll: Iterable[A]): C[A] = fromIterable(coll)
+
   /** Do the elements of this collection are the same (and in the same order)
     * as those of `that`?
     */

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -39,7 +39,8 @@ trait SetLike[A, +C[X] <: Set[X]]
 }
 
 /** Monomorphic transformation operations */
-trait SetMonoTransforms[A, +Repr] {
+trait SetMonoTransforms[A, +Repr]
+  extends IterableMonoTransforms[A, Repr] {
 
   def & (that: Set[A]): Repr
 

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -4,15 +4,23 @@ package collection
 import scala.{Any, Boolean, Equals, Int}
 import scala.util.hashing.MurmurHash3
 
+
+/** Base trait for set collections */
 trait Set[A]
   extends Iterable[A]
     with SetLike[A, Set]
 
+/** Base trait for set operations */
 trait SetLike[A, +C[X] <: Set[X]]
-  extends SetOps[A]
+  extends IterableLike[A, C]
+    with SetMonoTransforms[A, C[A]]
     with Equals {
 
   protected def coll: C[A]
+
+  def contains(elem: A): Boolean
+
+  def subsetOf(that: Set[A]): Boolean
 
   def canEqual(that: Any) = true
 
@@ -20,9 +28,9 @@ trait SetLike[A, +C[X] <: Set[X]]
     that match {
       case set: Set[A] =>
         (this eq set) ||
-        (set canEqual this) &&
-        (coll.size == set.size) &&
-        (this subsetOf set)
+          (set canEqual this) &&
+            (coll.size == set.size) &&
+            (this subsetOf set)
       case _ => false
     }
 
@@ -30,11 +38,12 @@ trait SetLike[A, +C[X] <: Set[X]]
 
 }
 
-trait SetOps[A] extends Any {
+/** Monomorphic transformation operations */
+trait SetMonoTransforms[A, +Repr] {
 
-  protected def coll: Set[A]
+  def & (that: Set[A]): Repr
 
-  def subsetOf(that: Set[A]): Boolean
+  def ++ (that: Set[A]): Repr
 
 }
 

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -1,0 +1,37 @@
+package strawman.collection
+
+import strawman.collection.mutable.Builder
+
+import scala.Ordering
+
+/** Base trait for sorted collections */
+trait Sorted[A] extends SortedLike[A, Sorted]
+
+trait SortedLike[A, +C[X] <: Sorted[X]]
+  extends SortedPolyTransforms[A, C] {
+
+  def ordering: Ordering[A]
+
+  def range(from: A, until: A): C[A]
+
+}
+
+/** Polymorphic transformation methods on sorted collections */
+trait SortedPolyTransforms[A, +C[X] <: Sorted[X]] {
+
+  def map[B](f: A => B)(implicit ordering: Ordering[B]): C[B]
+
+}
+
+/**
+  * Factories for collections whose elements require an ordering
+  */
+trait OrderingGuidedFactories[C[_]] {
+
+  def builder[A](implicit ordering: Ordering[A]): Builder[A, C[A]]
+
+  def empty[A : Ordering]: C[A] = builder[A].result
+
+  def apply[A : Ordering](as: A*): C[A] = (builder[A] ++= as.toStrawman).result
+
+}

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -5,14 +5,13 @@ import strawman.collection.mutable.Builder
 import scala.Ordering
 
 /** Base trait for sorted collections */
-trait Sorted[A] extends SortedLike[A, Sorted]
+trait Sorted[A] extends SortedLike[A, Sorted[A]]
 
-trait SortedLike[A, +C[X] <: Sorted[X]]
-  extends SortedPolyTransforms[A, C] {
+trait SortedLike[A, +Repr] {
 
   def ordering: Ordering[A]
 
-  def range(from: A, until: A): C[A]
+  def range(from: A, until: A): Repr
 
 }
 

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -17,7 +17,8 @@ trait SortedLike[A, +C[X] <: Sorted[X]]
 }
 
 /** Polymorphic transformation methods on sorted collections */
-trait SortedPolyTransforms[A, +C[X] <: Sorted[X]] {
+trait SortedPolyTransforms[A, +C[X] <: Sorted[X]]
+  extends IterablePolyTransforms[A, Iterable] {
 
   def map[B](f: A => B)(implicit ordering: Ordering[B]): C[B]
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -13,6 +13,9 @@ trait View[+A] extends Iterable[A] with IterableLike[A, View] {
     case _ => View.fromIterator(c.iterator())
   }
   override def className = "View"
+
+  protected[this] def fromIterableWithSameElemType(coll: Iterable[A]): View[A] = fromIterable(coll)
+
 }
 
 /** This object reifies operations on views as case classes */

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -13,6 +13,7 @@ class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
 
   // From IterablePolyTransforms
   def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] = ???
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
   // From SetLike
   def contains(elem: A): Boolean = ???

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -1,0 +1,35 @@
+package strawman.collection.immutable
+
+import strawman.collection.{IterableFactory, Iterator}
+
+import scala.Boolean
+import scala.Predef.???
+
+/** An immutable Set backed by a hash trie */
+class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
+
+  // From IterableOnce
+  def iterator(): Iterator[A] = ???
+
+  // From IterablePolyTransforms
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] = ???
+
+  // From SetLike
+  def contains(elem: A): Boolean = ???
+  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
+
+  // From SetMonoTransforms
+  def & (that: strawman.collection.Set[A]): HashSet[A] = ???
+  def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
+
+  // From immutable.SetLike
+  def + (elem: A): HashSet[A] = ???
+  def - (elem: A): HashSet[A] = ???
+
+}
+
+object HashSet extends IterableFactory[HashSet] {
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = ???
+
+}

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -1,6 +1,8 @@
 package strawman
 package collection.immutable
 
+import strawman.collection.IterableMonoTransforms
+
 /** Base type of immutable Maps */
 trait Map[K, +V]
   extends collection.Map[K, V]
@@ -9,20 +11,12 @@ trait Map[K, +V]
 /** Base trait of immutable Maps implementations */
 trait MapLike[K, +V, +C[X, +Y] <: Map[X, Y]]
   extends collection.MapLike[K, V, C]
-    with MapOps[K, V, C]
+    with MapMonoTransforms[K, V, C[K, V]]
     with Iterable[(K, V)]
 
 /** Immutable Map operations returning a self-like Map */
-trait MapOps[K, +V, +C[X, +Y] <: Map[X, Y]] {
-
-  /**
-    * Add a key/value pair to this map, returning a new map.
-    *
-    * @param kv the key/value pair.
-    * @tparam V1 the type of the value in the key/value pair.
-    * @return A new map with the new binding added to this map.
-    */
-  def + [V1 >: V](kv: (K, V1)): C[K, V1]
+trait MapMonoTransforms[K, +V, +Repr <: Map[K, V]]
+  extends IterableMonoTransforms[(K, V), Repr] {
 
   /**
     * Removes a key from this map, returning a new map.
@@ -30,6 +24,6 @@ trait MapOps[K, +V, +C[X, +Y] <: Map[X, Y]] {
     * @param key the key to be removed
     * @return a new map without a binding for ''key''
     */
-  def - (key: K): C[K, V]
+  def - (key: K): Repr
 
 }

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -9,7 +9,11 @@ trait Map[K, +V]
 /** Base trait of immutable Maps implementations */
 trait MapLike[K, +V, +C[X, +Y] <: Map[X, Y]]
   extends collection.MapLike[K, V, C]
-    with Iterable[(K, V)] {
+    with MapOps[K, V, C]
+    with Iterable[(K, V)]
+
+/** Immutable Map operations returning a self-like Map */
+trait MapOps[K, +V, +C[X, +Y] <: Map[X, Y]] {
 
   /**
     * Add a key/value pair to this map, returning a new map.

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -1,0 +1,31 @@
+package strawman
+package collection.immutable
+
+/** Base type of immutable Maps */
+trait Map[K, +V]
+  extends collection.Map[K, V]
+    with MapLike[K, V, Map]
+
+/** Base trait of immutable Maps implementations */
+trait MapLike[K, +V, +C[X, +Y] <: Map[X, Y]]
+  extends collection.MapLike[K, V, C]
+    with Iterable[(K, V)] {
+
+  /**
+    * Add a key/value pair to this map, returning a new map.
+    *
+    * @param kv the key/value pair.
+    * @tparam V1 the type of the value in the key/value pair.
+    * @return A new map with the new binding added to this map.
+    */
+  def + [V1 >: V](kv: (K, V1)): C[K, V1]
+
+  /**
+    * Removes a key from this map, returning a new map.
+    *
+    * @param key the key to be removed
+    * @return a new map without a binding for ''key''
+    */
+  def - (key: K): C[K, V]
+
+}

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -1,0 +1,20 @@
+package strawman.collection.immutable
+
+/** Base trait for immutable set collections */
+trait Set[A]
+  extends strawman.collection.Set[A]
+    with Iterable[A]
+    with SetLike[A, Set]
+
+/** Base trait for immutable set operations */
+trait SetLike[A, +C[X] <: Set[X]]
+  extends strawman.collection.SetLike[A, C]
+    with SetOps[A, C[A]]
+
+trait SetOps[A, +Repr] {
+
+  def + (elem: A): Repr
+
+  def - (elem: A): Repr
+
+}

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -1,17 +1,22 @@
-package strawman.collection.immutable
+package strawman
+package collection.immutable
 
 /** Base trait for immutable set collections */
 trait Set[A]
-  extends strawman.collection.Set[A]
+  extends collection.Set[A]
     with Iterable[A]
     with SetLike[A, Set]
 
 /** Base trait for immutable set operations */
 trait SetLike[A, +C[X] <: Set[X]]
-  extends strawman.collection.SetLike[A, C]
-    with SetOps[A, C[A]]
+  extends collection.SetLike[A, C]
+    with SetMonoTransforms[A, C[A]]
 
-trait SetOps[A, +Repr] {
+/** Transformation operations returning a Set containing the same kind of
+  * elements
+  */
+trait SetMonoTransforms[A, +Repr]
+  extends collection.SetMonoTransforms[A, Repr] {
 
   def + (elem: A): Repr
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.immutable
 
-import strawman.collection.{IterableMonoTransforms, IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike}
+import strawman.collection.{IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike}
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.Ordering
@@ -15,8 +15,7 @@ trait SortedMapLike[K, +V, +C[X, +Y] <: SortedMap[X, Y]]
   extends SortedLike[K, C[K, V]]
     with SortedMapPolyTransforms[K, V, C]
     with MapLike[K, V, Map] // Inherited Map operations can only return a `Map` because they don’t take an evidence `Ordering`
-    with MapOps[K, V, C] // Operations that return the same collection type can return a `SortedMap`, though
-    with IterableMonoTransforms[(K, V), C[K, V]] // Transformation operations that return the same collection type can return a `SortedMap`, though
+    with MapMonoTransforms[K, V, C[K, V]] // Operations that return the same collection type can return a `SortedMap`, though
 
 /** Polymorphic transformation methods for sorted Maps */
 trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]
@@ -30,6 +29,15 @@ trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]
 
   // And finally, we add new overloads taking an ordering
   def map[K2, V2](f: (K, V) => (K2, V2))(implicit ordering: Ordering[K2]): C[K2, V2]
+
+  /**
+    * Add a key/value pair to this map, returning a new map.
+    *
+    * @param kv the key/value pair.
+    * @tparam V1 the type of the value in the key/value pair.
+    * @return A new map with the new binding added to this map.
+    */
+  def + [V1 >: V](kv: (K, V1)): C[K, V1]
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -1,0 +1,35 @@
+package strawman
+package collection.immutable
+
+import strawman.collection.{IterableMonoTransforms, IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike}
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.Ordering
+
+trait SortedMap[K, +V]
+  extends Map[K, V]
+    with Sorted[K]
+    with SortedMapLike[K, V, SortedMap]
+
+trait SortedMapLike[K, +V, +C[X, +Y] <: SortedMap[X, Y]]
+  extends SortedLike[K, C[K, V]]
+    with SortedMapPolyTransforms[K, V, C]
+    with MapLike[K, V, Map] // Inherited Map operations can only return a `Map` because they don’t take an evidence `Ordering`
+    with MapOps[K, V, C] // Operations that return the same collection type can return a `SortedMap`, though
+    with IterableMonoTransforms[(K, V), C[K, V]] // Transformation operations that return the same collection type can return a `SortedMap`, though
+
+/** Polymorphic transformation methods for sorted Maps */
+trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]
+  // We inherit polymorphic transformations returning an Iterable (e.g. to
+  // support the following use case `kvs.map((k, v) => v)`)
+  extends IterablePolyTransforms[(K, V), Iterable]
+  // Then we also inherit polymorphic transformations returning a Map, just
+  // to get inheritance linearization right and disambiguate between
+  // overloaded methods
+    with MapPolyTransforms[K, V, Map] {
+
+  // And finally, we add new overloads taking an ordering
+  def map[K2, V2](f: (K, V) => (K2, V2))(implicit ordering: Ordering[K2]): C[K2, V2]
+
+}
+

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -1,0 +1,21 @@
+package strawman.collection.immutable
+
+import strawman.collection.{SetMonoTransforms, Sorted, SortedLike}
+
+/** Base trait for sorted sets */
+trait SortedSet[A]
+  extends Set[A]
+    with Sorted[A]
+    with SortedSetLike[A, SortedSet] // Inherited SortedSet operations return a `SortedSet`
+
+trait SortedSetLike[A, +C[X] <: SortedSet[X]]
+  extends SortedLike[A, C]
+    with SetLike[A, Set] // Inherited Set operations return a `Set`
+    with SetOps[A, C[A]] // Override the return type of Set ops to return C[A]
+    with SetMonoTransforms[A, C[A]] {
+
+  // We have to write again the definition of methods inherited from SortedPolyTransforms
+  // so that they take precedence over the one inherited from IterablePolyTransforms
+  def map[B](f: A => B)(implicit ordering: scala.Ordering[B]): C[B]
+
+}

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection.immutable
 
-import strawman.collection.{SetMonoTransforms, Sorted, SortedLike, SortedPolyTransforms}
+import strawman.collection.{Sorted, SortedLike, SortedPolyTransforms}
 
 /** Base trait for sorted sets */
 trait SortedSet[A]
@@ -12,5 +12,4 @@ trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends SortedLike[A, C[A]]
     with SortedPolyTransforms[A, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
-    with SetOps[A, C[A]] // Override the return type of Set ops to return C[A]
-    with SetMonoTransforms[A, C[A]]
+    with SetMonoTransforms[A, C[A]] // Override the return type of Set ops to return C[A]

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -12,10 +12,4 @@ trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends SortedLike[A, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetOps[A, C[A]] // Override the return type of Set ops to return C[A]
-    with SetMonoTransforms[A, C[A]] {
-
-  // We have to write again the definition of methods inherited from SortedPolyTransforms
-  // so that they take precedence over the one inherited from IterablePolyTransforms
-  def map[B](f: A => B)(implicit ordering: scala.Ordering[B]): C[B]
-
-}
+    with SetMonoTransforms[A, C[A]]

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection.immutable
 
-import strawman.collection.{SetMonoTransforms, Sorted, SortedLike}
+import strawman.collection.{SetMonoTransforms, Sorted, SortedLike, SortedPolyTransforms}
 
 /** Base trait for sorted sets */
 trait SortedSet[A]
@@ -9,7 +9,8 @@ trait SortedSet[A]
     with SortedSetLike[A, SortedSet] // Inherited SortedSet operations return a `SortedSet`
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
-  extends SortedLike[A, C]
+  extends SortedLike[A, C[A]]
+    with SortedPolyTransforms[A, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetOps[A, C[A]] // Override the return type of Set ops to return C[A]
     with SetMonoTransforms[A, C[A]]

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -1,0 +1,40 @@
+package strawman
+package collection.immutable
+
+import strawman.collection.SortedLike
+
+import scala.{Option, Ordering}
+import scala.Predef.???
+
+final class TreeMap[K, +V]
+  extends SortedMap[K, V]
+    with SortedMapLike[K, V, TreeMap] {
+
+  // Members declared in collection.IterableLike
+  protected[this] def fromIterableWithSameElemType(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = ???
+
+  // Members declared in collection.IterableOnce
+  def iterator(): collection.Iterator[(K, V)] = ???
+
+  // Members declared in collection.IterablePolyTransforms
+  def fromIterable[B](coll: collection.Iterable[B]): collection.immutable.Iterable[B] = ???
+
+  // Members declared in collection.MapLike
+  def get(key: K): Option[V] = ???
+
+  // Members declared in collection.immutable.MapLike
+  def -(key: K): TreeMap[K,V] = ???
+  def +[V1 >: V](kv: (K, V1)): TreeMap[K,V1] = ???
+
+  // Members declared in collection.MapPolyTransforms
+  def flatMap[K2, V2](f: (K, V) => collection.IterableOnce[(K2, V2)]): collection.immutable.Map[K2,V2] = ???
+  def map[K2, V2](f: (K, V) => (K2, V2)): collection.immutable.Map[K2,V2] = ???
+
+  // Members declared in collection.SortedMapPolyTransforms
+  def map[K2, V2](f: (K, V) => (K2, V2))(implicit ordering: Ordering[K2]): collection.immutable.TreeMap[K2,V2] = ???
+
+  // Members declared in collection.SortedLike
+  def ordering: Ordering[K] = ???
+  def range(from: K,until: K): TreeMap[K,V] = ???
+
+}

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -22,7 +22,7 @@ final class TreeMap[K, +V]
   // Members declared in collection.MapLike
   def get(key: K): Option[V] = ???
 
-  // Members declared in collection.immutable.MapLike
+  // Members declared in collection.immutable.MapMonoTransforms
   def -(key: K): TreeMap[K,V] = ???
   def +[V1 >: V](kv: (K, V1)): TreeMap[K,V1] = ???
 

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -1,0 +1,44 @@
+package strawman.collection.immutable
+
+import strawman.collection.mutable.Builder
+import strawman.collection.{Iterator, OrderingGuidedFactories}
+
+import scala.{Boolean, Ordering}
+import scala.Predef.???
+
+/** Immutable sorted set backed by a tree */
+final class TreeSet[A]()(implicit val ordering: Ordering[A])
+  extends SortedSet[A]
+    with SortedSetLike[A, TreeSet]{
+
+  // From IterableOnce
+  def iterator(): Iterator[A] = ???
+
+  // From IterablePolyTransforms
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = ???
+
+  // From SetLike
+  def contains(elem: A): Boolean = ???
+  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
+
+  // From SetMonoTransforms
+  def & (that: strawman.collection.Set[A]): TreeSet[A] = ???
+  def ++ (that: strawman.collection.Set[A]): TreeSet[A] = ???
+
+  // From SortedLike
+  def range(from: A, until: A): TreeSet[A] = ???
+
+  // From SortedPolyTransforms
+  def map[B](f: (A) => B)(implicit ordering: Ordering[B]): TreeSet[B] = ???
+
+  // From immutable.SetLike
+  def +(elem: A): TreeSet[A] = ???
+  def -(elem: A): TreeSet[A] = ???
+
+}
+
+object TreeSet extends OrderingGuidedFactories[TreeSet] {
+
+  def builder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = ???
+
+}

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -16,6 +16,7 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
 
   // From IterablePolyTransforms
   def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = ???
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): TreeSet[A] = TreeSet.builder[A].++=(coll).result
 
   // From SetLike
   def contains(elem: A): Boolean = ???

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -26,15 +26,15 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
   def & (that: strawman.collection.Set[A]): TreeSet[A] = ???
   def ++ (that: strawman.collection.Set[A]): TreeSet[A] = ???
 
+  // From immutable.SetMonoTransforms
+  def +(elem: A): TreeSet[A] = ???
+  def -(elem: A): TreeSet[A] = ???
+
   // From SortedLike
   def range(from: A, until: A): TreeSet[A] = ???
 
   // From SortedPolyTransforms
   def map[B](f: (A) => B)(implicit ordering: Ordering[B]): TreeSet[B] = ???
-
-  // From immutable.SetLike
-  def +(elem: A): TreeSet[A] = ???
-  def -(elem: A): TreeSet[A] = ???
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -1,0 +1,42 @@
+package strawman.collection.mutable
+
+import strawman.collection.{IterableOnce, Iterator, MapFactories}
+
+import scala.{Option, Unit}
+import scala.Predef.???
+
+/** A mutable map backed by a hashtable */
+final class HashMap[K, V]
+  extends Map[K, V]
+    with MapLike[K, V, HashMap] {
+
+  // From IterableOnce
+  def iterator(): Iterator[(K, V)] = ???
+
+  // From MapLike
+  def get(key: K): Option[V] = ???
+
+  // From Growable
+  def +=(elem: (K, V)): this.type = ???
+  def clear(): Unit = ???
+
+  // From mutable.MapLike
+  def -=(elem: (K, V)): this.type = ???
+  def put(key: K, value: V): Option[V] = ???
+
+  // From MapPolyTransforms
+  def map[K2, V2](f: (K, V) => (K2, V2)): HashMap[K2, V2] = ???
+  def flatMap[K2, V2](f: (K, V) => IterableOnce[(K2, V2)]): HashMap[K2, V2] = ???
+
+  // From IterablePolyTransforms
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): Iterable[B] = ???
+  // From IterableMonoTransforms
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[(K, V)]): HashMap[K, V] = ???
+
+}
+
+object HashMap extends MapFactories[HashMap] {
+
+  def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = ???
+
+}

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -1,0 +1,46 @@
+package strawman.collection.mutable
+
+import strawman.collection.{IterableFactory, Iterator}
+
+import scala.{Boolean, Option, Unit}
+import scala.Predef.???
+
+/** Mutable set backed by a hash trie */
+final class HashSet[A]
+  extends Set[A]
+    with SetLike[A, HashSet]
+    with Buildable[A, HashSet[A]]
+    with Builder[A, HashSet[A]] {
+
+  def iterator(): Iterator[A] = ???
+
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] =
+    HashSet.fromIterable(coll)
+
+  protected[this] def newBuilder: Builder[A, HashSet[A]] = new HashSet[A]
+  def result: HashSet[A] = this
+
+  def +=(elem: A): this.type = ???
+  def -=(elem: A): this.type = ???
+  def clear(): Unit = ???
+
+  def contains(elem: A): Boolean = ???
+  def get(elem: A): Option[A] = ???
+  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
+
+  def & (that: strawman.collection.Set[A]): HashSet[A] = ???
+  def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
+
+}
+
+object HashSet extends IterableFactory[HashSet] {
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = {
+    val result = new HashSet[B]
+    for (elem <- it) {
+      result += elem
+    }
+    result
+  }
+
+}

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -16,7 +16,7 @@ final class HashSet[A]
 
   def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] =
     HashSet.fromIterable(coll)
-
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): HashSet[A] = fromIterable(coll)
   protected[this] def newBuilder: Builder[A, HashSet[A]] = new HashSet[A]
   def result: HashSet[A] = this
 

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -1,0 +1,22 @@
+package strawman.collection.mutable
+
+import strawman.collection.IterableMonoTransforms
+
+import scala.Option
+
+/** Base type of mutable Maps */
+trait Map[K, V]
+  extends strawman.collection.Map[K, V]
+    with MapLike[K, V, Map]
+
+/** Base trait of mutable Maps implementations */
+trait MapLike[K, V, +C[X, Y] <: Map[X, Y]]
+  extends strawman.collection.MapLike[K, V, C]
+    with Iterable[(K, V)]
+    with Growable[(K, V)] {
+
+  def -= (elem: (K, V)): this.type
+
+  def put(key: K, value: V): Option[V]
+
+}

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -5,7 +5,11 @@ import strawman.collection.IterableOnce
 import scala.{Int, Boolean, Unit, Option, Some, None}
 import scala.Predef.???
 
-trait Set[A] extends collection.Set[A] with Growable[A] {
+/** Base trait for mutable sets */
+trait Set[A]
+  extends collection.Set[A]
+    with SetLike[A, Set]
+    with Growable[A] {
 
   def +=(elem: A): this.type
   def -=(elem: A): this.type
@@ -57,6 +61,10 @@ trait Set[A] extends collection.Set[A] with Growable[A] {
       -=(elem)
   }
 }
+
 object Set {
   def apply[A](xs: A*): Set[A] = ???
 }
+
+trait SetLike[A, +C[X] <: Set[X]]
+  extends collection.SetLike[A, C]

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -130,7 +130,7 @@ class StrawmanTest {
     val ys9: Seq[Int] = xs9
     val xs9a = xs.map(_.toUpper)
     val ys9a: String = xs9a
-    val xs10 = xs.flatMap((x: Char) => s"$x,$x")
+    val xs10 = xs.flatMap(x => s"$x,$x")
     val ys10: String = xs10
     val xs11 = xs ++ xs
     val ys11: String = xs11
@@ -305,6 +305,18 @@ class StrawmanTest {
     val xs1 = xs.map((x: Int) => x.toString)
     val xs2: SortedSet[String] = xs1
     val xs3: strawman.collection.immutable.Set[String] = xs.map((x: Int) => x.toString)
+  }
+
+  def mapOps(xs: strawman.collection.Map[Int, String]): Unit = {
+    val xs1 = xs.map((k, v) => (v, k))
+//    val xs1Bis = xs.map { case (k, v) => (v, k) } Does not compile :(
+    val xs2: strawman.collection.Map[String, Int] = xs1
+    val xs3 = xs.map(kv => (kv._2, kv._1))
+    val xs4: strawman.collection.Iterable[(String, Int)] = xs3
+    println(xs1)
+    println(xs2)
+    println(xs3)
+    println(xs4)
   }
 
   @Test

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -1,12 +1,13 @@
-package strawman.collection.test
+package strawman
+package collection.test
 
 import java.lang.String
-import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
+import scala.{Int, Unit, Array, Option, StringContext, Boolean, Any, Char}
 import scala.Predef.{assert, println, charWrapper}
 
-import strawman.collection.immutable._
-import strawman.collection.mutable._
-import strawman.collection.{Seq, View, _}
+import collection.immutable._
+import collection.mutable._
+import collection.{Seq, View, _}
 import org.junit.Test
 
 class StrawmanTest {
@@ -317,6 +318,21 @@ class StrawmanTest {
     println(xs2)
     println(xs3)
     println(xs4)
+  }
+
+  def sortedMaps(xs: collection.immutable.SortedMap[String, Int]): Unit = {
+    val x1 = xs.get("foo")
+    val x2: Option[Int] = x1
+    val xs1 = xs + ("foo", 1)
+    val xs2: SortedMap[String, Int] = xs1
+    val xs3 = xs.map(kv => kv._1)
+    val xs4: collection.immutable.Iterable[String] = xs3
+    val xs5 = xs.map((k: String, v: Int) => (v, k))
+    val xs6: collection.immutable.SortedMap[Int, String] = xs5
+    class Foo
+//    val xs7 = xs.map((k: String, v: Int) => (new Foo, v)) Error: No implicit Ordering defined for Foo
+    val xs7 = (xs: collection.immutable.Map[String, Int]).map((k, v) => (new Foo, v))
+    val xs8: collection.immutable.Map[Foo, Int] = xs7
   }
 
   @Test

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -301,6 +301,12 @@ class StrawmanTest {
     assert(list.## != buffer.##)
   }
 
+  def sortedSets(xs: strawman.collection.immutable.SortedSet[Int]): Unit = {
+    val xs1 = xs.map((x: Int) => x.toString)
+    val xs2: SortedSet[String] = xs1
+    val xs3: strawman.collection.immutable.Set[String] = xs.map((x: Int) => x.toString)
+  }
+
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -5,9 +5,9 @@ import java.lang.String
 import scala.{Int, Unit, Array, Option, StringContext, Boolean, Any, Char}
 import scala.Predef.{assert, println, charWrapper}
 
-import collection.immutable._
-import collection.mutable._
-import collection.{Seq, View, _}
+import collection._
+import collection.immutable.{List, Nil, LazyList}
+import collection.mutable.{ArrayBuffer, ListBuffer}
 import org.junit.Test
 
 class StrawmanTest {
@@ -302,15 +302,13 @@ class StrawmanTest {
     assert(list.## != buffer.##)
   }
 
-  def sortedSets(xs: strawman.collection.immutable.SortedSet[Int]): Unit = {
+  def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
     val xs1 = xs.map((x: Int) => x.toString)
-    val xs2: SortedSet[String] = xs1
-    val xs3: strawman.collection.immutable.Set[String] = xs.map((x: Int) => x.toString)
+    val xs2: immutable.SortedSet[String] = xs1
   }
 
-  def mapOps(xs: strawman.collection.Map[Int, String]): Unit = {
+  def mapOps(xs: Map[Int, String]): Unit = {
     val xs1 = xs.map((k, v) => (v, k))
-//    val xs1Bis = xs.map { case (k, v) => (v, k) } Does not compile :(
     val xs2: strawman.collection.Map[String, Int] = xs1
     val xs3 = xs.map(kv => (kv._2, kv._1))
     val xs4: strawman.collection.Iterable[(String, Int)] = xs3
@@ -320,19 +318,19 @@ class StrawmanTest {
     println(xs4)
   }
 
-  def sortedMaps(xs: collection.immutable.SortedMap[String, Int]): Unit = {
+  def sortedMaps(xs: immutable.SortedMap[String, Int]): Unit = {
     val x1 = xs.get("foo")
     val x2: Option[Int] = x1
     val xs1 = xs + ("foo", 1)
-    val xs2: SortedMap[String, Int] = xs1
+    val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
-    val xs4: collection.immutable.Iterable[String] = xs3
+    val xs4: immutable.Iterable[String] = xs3
     val xs5 = xs.map((k: String, v: Int) => (v, k))
-    val xs6: collection.immutable.SortedMap[Int, String] = xs5
+    val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo
 //    val xs7 = xs.map((k: String, v: Int) => (new Foo, v)) Error: No implicit Ordering defined for Foo
-    val xs7 = (xs: collection.immutable.Map[String, Int]).map((k, v) => (new Foo, v))
-    val xs8: collection.immutable.Map[Foo, Int] = xs7
+    val xs7 = (xs: immutable.Map[String, Int]).map((k, v) => (new Foo, v))
+    val xs8: immutable.Map[Foo, Int] = xs7
   }
 
   @Test

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -303,7 +303,7 @@ class StrawmanTest {
   }
 
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
-    val xs1 = xs.map((x: Int) => x.toString)
+    val xs1 = xs.map((x: Int) => x.toString) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
     val xs2: immutable.SortedSet[String] = xs1
   }
 
@@ -325,7 +325,7 @@ class StrawmanTest {
     val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
     val xs4: immutable.Iterable[String] = xs3
-    val xs5 = xs.map((k: String, v: Int) => (v, k))
+    val xs5 = xs.map((k: String, v: Int) => (v, k)) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
     val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo
 //    val xs7 = xs.map((k: String, v: Int) => (new Foo, v)) Error: No implicit Ordering defined for Foo


### PR DESCRIPTION
I sketched the integration of `Set`, `TreeSet`, `Map` and `TreeMap` collections. They were challenging because `Map` takes two type parameters where previous collections were only taking one type parameter, and also because `TreeSet` and `TreeMap` take an additional implicit `Ordering` parameter.

This is an alternative to #23 that makes `Set` extend `Iterable` and `SortedSet` have two overloads of `map` (one has an additional implicit `Ordering` parameter).