### PR TITLE
Range and NumericRange

### DIFF
--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -1,6 +1,6 @@
 package bench
 
-import strawman.collection.immutable.{LazyList, List}
+import strawman.collection.immutable.{LazyList, List, NumericRange, Range}
 
 import scala.{Any, AnyRef, App, Int, Long}
 import scala.Predef.{println, ArrowAssoc}
@@ -34,11 +34,13 @@ object MemoryFootprint extends App {
 
   val memories =
     scala.Predef.Map(
-      "scala.List"  -> benchmark(scala.List.fill(_)(obj)),
-      "List"        -> benchmark(List.fill(_)(obj)),
-      "LazyList"    -> benchmark(LazyList.fill(_)(obj)),
-      "ArrayBuffer" -> benchmark(ArrayBuffer.fill(_)(obj)),
-      "ListBuffer"  -> benchmark(ListBuffer.fill(_)(obj))
+      "scala.List"   -> benchmark(scala.List.fill(_)(obj)),
+      "List"         -> benchmark(List.fill(_)(obj)),
+      "LazyList"     -> benchmark(LazyList.fill(_)(obj)),
+      "ArrayBuffer"  -> benchmark(ArrayBuffer.fill(_)(obj)),
+      "ListBuffer"   -> benchmark(ListBuffer.fill(_)(obj)),
+      "Range"        -> benchmark(Range(0, _)),
+      "NumericRange" -> benchmark(NumericRange(0, _, 1))
     )
 
   // Print the results as a CSV document

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
@@ -1,0 +1,46 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.{Any, AnyRef, Int, Unit}
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class NumericRangeBenchmark {
+
+  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  var size: Int = _
+
+  var xs: NumericRange[Int] = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    xs = NumericRange(0, size, 1)
+  }
+
+  @Benchmark
+  def uncons(): Any = xs.tail
+
+  @Benchmark
+  def concat(): Any = xs ++ xs
+
+  @Benchmark
+  def foreach(): Any = {
+    var n = 0
+    xs.foreach(x => if (x == 0) n += 1)
+    n
+  }
+
+  @Benchmark
+  def lookup(): Any = xs(size - 1)
+
+  @Benchmark
+  def map(): Any = xs.map(x => if (x == 0) "foo" else "bar")
+
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
@@ -1,0 +1,46 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.{Any, AnyRef, Int, Unit}
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class RangeBenchmark {
+
+  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  var size: Int = _
+
+  var xs: Range = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    xs = Range(0, size)
+  }
+
+  @Benchmark
+  def uncons(): Any = xs.tail
+
+  @Benchmark
+  def concat(): Any = xs ++ xs
+
+  @Benchmark
+  def foreach(): Any = {
+    var n = 0
+    xs.foreach(x => if (x == 0) n += 1)
+    n
+  }
+
+  @Benchmark
+  def lookup(): Any = xs(size - 1)
+
+  @Benchmark
+  def map(): Any = xs.map(x => if (x == 0) "foo" else "bar")
+
+}

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -1,6 +1,7 @@
 package strawman.collection
 
-import scala.{Boolean, Int, Unit, Nothing, NoSuchElementException}
+import scala.{Boolean, Int, NoSuchElementException, Nothing, Unit}
+import strawman.collection.immutable.IndexedView
 
 /** A core Iterator class */
 trait Iterator[+A] extends IterableOnce[A] { self =>

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -43,11 +43,16 @@ trait LinearSeq[+A]
   }
 }
 
-trait IndexedSeq[+A] extends Seq[A] { self =>
+trait IndexedSeq[+A]
+  extends Seq[A]
+    with SeqMonoTransforms[A, IndexedSeq[A]]
+    with IterablePolyTransforms[A, IndexedSeq] { self =>
+
   override def view: IndexedView[A] = new IndexedView[A] {
     def length: Int = self.length
     def apply(i: Int): A = self(i)
   }
+
 }
 
 /** Base trait for Seq operations */

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 
-import scala.{Any, Boolean, Int, IndexOutOfBoundsException}
-import strawman.collection.immutable.{List, Nil}
+import scala.{Any, Boolean, IndexOutOfBoundsException, Int}
+import strawman.collection.immutable.{IndexedView, List, Nil}
 
 import scala.annotation.unchecked.uncheckedVariance
 
@@ -12,7 +12,10 @@ trait Seq[+A] extends Iterable[A] with SeqLike[A, Seq] with ArrayLike[A]
   *  `tail` operations.
   *  Known subclasses: List, LazyList
   */
-trait LinearSeq[+A] extends Seq[A] with LinearSeqLike[A, LinearSeq] { self =>
+trait LinearSeq[+A]
+  extends Seq[A]
+    with LinearSeqLike[A, LinearSeq]
+    with SeqMonoTransforms[A, LinearSeq[A]] { self =>
 
   /** To be overridden in implementations: */
   def isEmpty: Boolean
@@ -52,6 +55,11 @@ trait SeqLike[+A, +C[X] <: Seq[X]]
   extends IterableLike[A, C]
     with SeqMonoTransforms[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
 
+trait SeqLikeFromIterable[+A, +C[X] <: Seq[X]]
+  extends SeqLike[A, C]
+    with IterableLikeFromIterable[A, C]
+    with SeqMonoTransformsFromIterable[A, C[A @uncheckedVariance]] // sound bcs of VarianceNote
+
 /** Base trait for linear Seq operations */
 trait LinearSeqLike[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {
 
@@ -61,21 +69,25 @@ trait LinearSeqLike[+A, +C[X] <: LinearSeq[X]] extends SeqLike[A, C] {
     *  whereas we need to assume here that `Repr` is the same as the underlying
     *  collection type.
     */
-  override def drop(n: Int): C[A @uncheckedVariance] = { // sound bcs of VarianceNote
-  def loop(n: Int, s: Iterable[A]): C[A] =
-    if (n <= 0) s.asInstanceOf[C[A]]
-    // implicit contract to guarantee success of asInstanceOf:
-    //   (1) coll is of type C[A]
-    //   (2) The tail of a LinearSeq is of the same type as the type of the sequence itself
-    // it's surprisingly tricky/ugly to turn this into actual types, so we
-    // leave this contract implicit.
-    else loop(n - 1, s.tail)
+  def drop(n: Int): C[A @uncheckedVariance] = { // sound bcs of VarianceNote
+    def loop(n: Int, s: Iterable[A]): C[A] =
+      if (n <= 0) s.asInstanceOf[C[A]]
+      // implicit contract to guarantee success of asInstanceOf:
+      //   (1) coll is of type C[A]
+      //   (2) The tail of a LinearSeq is of the same type as the type of the sequence itself
+      // it's surprisingly tricky/ugly to turn this into actual types, so we
+      // leave this contract implicit.
+      else loop(n - 1, s.tail)
     loop(n, coll)
   }
 }
 
 /** Type-preserving transforms over sequences. */
 trait SeqMonoTransforms[+A, +Repr] extends Any with IterableMonoTransforms[A, Repr] {
+  def reverse: Repr
+}
+
+trait SeqMonoTransformsFromIterable[+A, +Repr] extends Any with IterableMonoTransformsFromIterable[A, Repr] {
   def reverse: Repr = coll.view match {
     case v: IndexedView[A] => fromIterableWithSameElemType(v.reverse)
     case _ =>

--- a/src/main/scala/strawman/collection/immutable/Array.scala
+++ b/src/main/scala/strawman/collection/immutable/Array.scala
@@ -11,7 +11,9 @@ import scala.Predef.{???, intWrapper}
   *
   * Supports efficient indexed access and has a small memory footprint.
   */
-class Array[+A] private (private val elements: scala.Array[AnyRef]) extends IndexedSeq[A] with SeqLike[A, Array] {
+class Array[+A] private (private val elements: scala.Array[AnyRef])
+  extends IndexedSeq[A]
+    with SeqLike[A, Array] {
 
   def length: Int = elements.length
 

--- a/src/main/scala/strawman/collection/immutable/Array.scala
+++ b/src/main/scala/strawman/collection/immutable/Array.scala
@@ -1,0 +1,84 @@
+package strawman.collection.immutable
+
+import strawman.collection.mutable.ArrayBuffer
+import strawman.collection.{IterableFactory, IterableOnce, IndexedSeq, Iterator, SeqLike}
+
+import scala.{AnyRef, Boolean, Int}
+import scala.Predef.{???, intWrapper}
+
+/**
+  * An immutable array.
+  *
+  * Supports efficient indexed access and has a small memory footprint.
+  */
+class Array[+A] private (private val elements: scala.Array[AnyRef]) extends IndexedSeq[A] with SeqLike[A, Array] {
+
+  def length: Int = elements.length
+
+  override def knownSize: Int = elements.length
+
+  def apply(i: Int): A = elements(i).asInstanceOf[A]
+
+  def iterator(): Iterator[A] = view.iterator()
+
+  def map[B](f: A => B): Array[B] = Array.tabulate(length)(i => f(apply(i)))
+
+  def flatMap[B](f: A => IterableOnce[B]): Array[B] = Array.fromIterable(View.FlatMap(coll, f))
+
+  def ++[B >: A](xs: IterableOnce[B]): Array[B] =
+    xs match {
+      case bs: Array[B] =>
+        val dest = scala.Array.ofDim[AnyRef](length + bs.length)
+        java.lang.System.arraycopy(elements, 0, dest, 0, length)
+        java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
+        new Array(dest)
+      case _ =>
+        Array.fromIterable(View.Concat(coll, xs))
+    }
+
+  def zip[B](xs: IterableOnce[B]): Array[(A, B)] =
+    xs match {
+      case bs: Array[B] =>
+        Array.tabulate(length min bs.length) { i =>
+          (apply(i), bs(i))
+        }
+      case _ =>
+        Array.fromIterable(View.Zip(coll, xs))
+    }
+
+  def filter(p: A => Boolean): Array[A] = Array.fromIterable(View.Filter(coll, p))
+
+  def partition(p: A => Boolean): (Array[A], Array[A]) = {
+    val pn = View.Partition(coll, p)
+    (Array.fromIterable(pn.left), Array.fromIterable(pn.right))
+  }
+
+  def take(n: Int): Array[A] = Array.tabulate(n)(apply)
+
+  def drop(n: Int): Array[A] = Array.tabulate((length - n) max 0)(i => apply(n + i))
+
+  def tail: Array[A] =
+    if (length > 0) Array.tabulate(length - 1)(i => apply(i + 1))
+    else ???
+
+  def reverse: Array[A] = Array.tabulate(length)(i => apply(length - 1 - i))
+}
+
+object Array extends IterableFactory[Array] {
+
+  def fromIterable[A](it: strawman.collection.Iterable[A]): Array[A] =
+    new Array(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[AnyRef]].toArray)
+
+  override def fill[A](n: Int)(elem: => A): Array[A] = tabulate(n)(_ => elem)
+
+  def tabulate[A](n: Int)(f: Int => A): Array[A] = {
+    val elements = scala.Array.ofDim[AnyRef](n)
+    var i = 0
+    while (i < n) {
+      elements(i) = f(i).asInstanceOf[AnyRef]
+      i = i + 1
+    }
+    new Array(elements)
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,11 +1,12 @@
 package strawman.collection.immutable
 
-import scala.{Option, Some, None, Nothing, StringContext}
+import scala.{Int, None, Nothing, Option, Some, StringContext}
 import strawman.collection
-import strawman.collection.{IterableFactory, LinearSeq, SeqLike, Iterator}
+import strawman.collection.{IterableFactory, LinearSeq, SeqLikeFromIterable, Iterator}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
-  extends Seq[A] with SeqLike[A, LazyList] with LinearSeq[A] {
+  extends LinearSeq[A]
+    with SeqLikeFromIterable[A, LazyList] {
   private[this] var evaluated = false
   private[this] var result: LazyList.Evaluated[A] = _
 
@@ -35,6 +36,10 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
         case Some((hd, tl)) => s"$hd #:: $tl"
       }
     else "LazyList(?)"
+
+  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
+  override def drop(n: Int): LazyList[A] = super.drop(n)
+
 }
 
 object LazyList extends IterableFactory[LazyList] {

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -1,19 +1,18 @@
 package strawman.collection.immutable
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.Nothing
+import scala.{Int, Nothing}
 import scala.Predef.???
 import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLikeFromIterable}
 import strawman.collection.mutable.{Buildable, ListBuffer}
 
 
 /** Concrete collection type: List */
 sealed trait List[+A]
-  extends Seq[A]
-     with SeqLike[A, List]
-     with LinearSeq[A]
-     with Buildable[A, List[A]] {
+  extends LinearSeq[A]
+    with SeqLikeFromIterable[A, List]
+    with Buildable[A, List[A]] {
 
   def fromIterable[B](c: collection.Iterable[B]): List[B] = List.fromIterable(c)
 
@@ -34,6 +33,10 @@ sealed trait List[+A]
   }
 
   override def className = "List"
+
+  // HACK Needed because we inherit from two implementations (one from LinearSeq and one from SeqLikeFromIterable)
+  override def drop(n: Int): List[A] = super.drop(n)
+
 }
 
 case class :: [+A](x: A, private[collection] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -3,7 +3,7 @@ package strawman.collection.immutable
 import strawman.collection
 import strawman.collection.{IndexedSeq, IterableFactory, IterablePolyTransformsFromIterable, Iterator, SeqMonoTransformsFromIterable}
 
-import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, inline, Int, Integral, Numeric, Ordering, Serializable, StringContext, Unit}
+import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, inline, Int, Integral, Numeric, Ordering, Serializable, specialized, StringContext, Unit}
 import scala.Predef.{ArrowAssoc, Map}
 
 /** `NumericRange` is a more generic version of the
@@ -75,7 +75,7 @@ final class NumericRange[T](
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange[T](start, end, step, isInclusive)
 
-  @inline override def foreach[U](f: T => U): Unit = {
+  @inline override def foreach[@specialized(Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
     while (count < length) {

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -1,0 +1,402 @@
+package strawman.collection.immutable
+
+import strawman.collection
+import strawman.collection.{IndexedSeq, IterableFactory, IterablePolyTransformsFromIterable, Iterator, SeqMonoTransformsFromIterable}
+
+import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, inline, Int, Integral, Numeric, Ordering, Serializable, StringContext, Unit}
+import scala.Predef.{ArrowAssoc, Map}
+
+/** `NumericRange` is a more generic version of the
+  *  `Range` class which works with arbitrary types.
+  *  It must be supplied with an `Integral` implementation of the
+  *  range type.
+  *
+  *  Factories for likely types include `Range.BigInt`, `Range.Long`,
+  *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
+  *  the `Int`-based `scala.Range` should be more performant.
+  *
+  *  {{{
+  *     val r1 = new Range(0, 100, 1)
+  *     val veryBig = Int.MaxValue.toLong + 1
+  *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
+  *     assert(r1 sameElements r2.map(_ - veryBig))
+  *  }}}
+  *
+  *  @define Coll `NumericRange`
+  *  @define coll numeric range
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+final class NumericRange[T](
+  val start: T,
+  val end: T,
+  val step: T,
+  val isInclusive: Boolean
+)(implicit
+  num: Integral[T]
+)
+  extends IndexedSeq[T]
+    with IterableFactory[IndexedSeq]
+    with IterablePolyTransformsFromIterable[T, IndexedSeq]
+    with SeqMonoTransformsFromIterable[T, IndexedSeq[T]]
+    with Serializable {
+
+  def iterator(): Iterator[T] = new NumericRangeIterator[T](start, step, last, isEmpty)
+
+  def fromIterable[B](it: collection.Iterable[B]): IndexedSeq[B] =
+    strawman.collection.immutable.Array.fromIterable(it)
+
+  protected[this] def fromIterableWithSameElemType(it: collection.Iterable[T]): IndexedSeq[T] = fromIterable(it)
+
+  /** Note that NumericRange must be invariant so that constructs
+    *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
+    */
+  import num._
+
+  override val length: Int = NumericRange.count(start, end, step, isInclusive)
+  override def size: Int = length
+  override def isEmpty = length == 0
+  /*override*/ def last: T =
+    if (length == 0) Nil.head
+    else locationAfterN(length - 1)
+
+  override def head: T = if (isEmpty) Nil.head else start
+  override def tail: NumericRange[T] =
+    if (isEmpty) Nil.tail
+    else new NumericRange(start + step, end, step, isInclusive)
+
+  /** Create a new range with the start and end values of this range and
+    *  a new `step`.
+    */
+  def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
+
+  /** Create a copy of this range.
+    */
+  def copy(start: T, end: T, step: T): NumericRange[T] =
+    new NumericRange[T](start, end, step, isInclusive)
+
+  @inline override def foreach[U](f: T => U): Unit = {
+    var count = 0
+    var current = start
+    while (count < length) {
+      f(current)
+      current += step
+      count += 1
+    }
+  }
+
+  // TODO: these private methods are straight copies from Range, duplicated
+  // to guard against any (most likely illusory) performance drop.  They should
+  // be eliminated one way or another.
+
+  // Tests whether a number is within the endpoints, without testing
+  // whether it is a member of the sequence (i.e. when step > 1.)
+  private def isWithinBoundaries(elem: T) = !isEmpty && (
+    (step > zero && start <= elem && elem <= last ) ||
+      (step < zero &&  last <= elem && elem <= start)
+    )
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int): T = start + (step * fromInt(n))
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: T) = NumericRange(value, value, step)
+
+  final override def take(n: Int): NumericRange[T] = (
+    if (n <= 0 || length == 0) newEmptyRange(start)
+    else if (n >= length) this
+    else new NumericRange(start, locationAfterN(n - 1), step, isInclusive = true)
+    )
+
+  final override def drop(n: Int): NumericRange[T] = (
+    if (n <= 0 || length == 0) this
+    else if (n >= length) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
+    )
+
+  def apply(idx: Int): T = {
+    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    else locationAfterN(idx)
+  }
+
+  import NumericRange.defaultOrdering
+
+//  override def min[T1 >: T](implicit ord: Ordering[T1]): T =
+//    if (ord eq defaultOrdering(num)) {
+//      if (num.signum(step) > 0) start
+//      else last
+//    } else super.min(ord)
+//
+//  override def max[T1 >: T](implicit ord: Ordering[T1]): T =
+//    if (ord eq defaultOrdering(num)) {
+//      if (num.signum(step) > 0) last
+//      else start
+//    } else super.max(ord)
+
+  // Motivated by the desire for Double ranges with BigDecimal precision,
+  // we need some way to map a Range and get another Range.  This can't be
+  // done in any fully general way because Ranges are not arbitrary
+  // sequences but step-valued, so we have a custom method only we can call
+  // which we promise to use responsibly.
+  //
+  // The point of it all is that
+  //
+  //   0.0 to 1.0 by 0.1
+  //
+  // should result in
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+  //
+  // and not
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6000000000000001, 0.7000000000000001, 0.8, 0.9)
+  //
+  // or perhaps more importantly,
+  //
+  //   (0.1 to 0.3 by 0.1 contains 0.3) == true
+  //
+//  private[immutable] def mapRange[A](fm: T => A)(implicit unum: Integral[A]): NumericRange[A] = {
+//    val self = this
+//
+//    // XXX This may be incomplete.
+//    new NumericRange[A](fm(start), fm(end), fm(step), isInclusive) {
+//
+//      private lazy val underlyingRange: NumericRange[T] = self
+//      override def foreach(f: A => Unit) { underlyingRange foreach (x => f(fm(x))) }
+//      override def isEmpty = underlyingRange.isEmpty
+//      override def apply(idx: Int): A = fm(underlyingRange(idx))
+//      override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
+//
+//      override def toString = {
+//        def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
+//        val stepped = simpleOf(underlyingRange.step)
+//        s"${super.toString} (using $underlyingRange of $stepped)"
+//      }
+//    }
+//  }
+
+  // a well-typed contains method.
+  def containsTyped(x: T): Boolean =
+    isWithinBoundaries(x) && (((x - start) % step) == zero)
+
+//  override def contains[A1 >: T](x: A1): Boolean =
+//    try containsTyped(x.asInstanceOf[T])
+//    catch { case _: ClassCastException => false }
+//
+//  final override def sum[B >: T](implicit num: Numeric[B]): B = {
+//    if (isEmpty) num.zero
+//    else if (numRangeElements == 1) head
+//    else {
+//      // If there is no overflow, use arithmetic series formula
+//      //   a + ... (n terms total) ... + b = n*(a+b)/2
+//      if ((num eq scala.math.Numeric.IntIsIntegral)||
+//        (num eq scala.math.Numeric.ShortIsIntegral)||
+//        (num eq scala.math.Numeric.ByteIsIntegral)||
+//        (num eq scala.math.Numeric.CharIsIntegral)) {
+//        // We can do math with no overflow in a Long--easy
+//        val exact = (numRangeElements * ((num toLong head) + (num toInt last))) / 2
+//        num fromInt exact.toInt
+//      }
+//      else if (num eq scala.math.Numeric.LongIsIntegral) {
+//        // Uh-oh, might be overflow, so we have to divide before we overflow.
+//        // Either numRangeElements or (head + last) must be even, so divide the even one before multiplying
+//        val a = head.toLong
+//        val b = last.toLong
+//        val ans =
+//          if ((numRangeElements & 1) == 0) (numRangeElements / 2) * (a + b)
+//          else numRangeElements * {
+//            // Sum is even, but we might overflow it, so divide in pieces and add back remainder
+//            val ha = a/2
+//            val hb = b/2
+//            ha + hb + ((a - 2*ha) + (b - 2*hb)) / 2
+//          }
+//        ans.asInstanceOf[B]
+//      }
+//      else if ((num eq scala.math.Numeric.FloatAsIfIntegral) ||
+//        (num eq scala.math.Numeric.DoubleAsIfIntegral)) {
+//        // Try to compute sum with reasonable accuracy, avoiding over/underflow
+//        val numAsIntegral = num.asInstanceOf[Integral[B]]
+//        import numAsIntegral._
+//        val a = math.abs(head.toDouble)
+//        val b = math.abs(last.toDouble)
+//        val two = num fromInt 2
+//        val nre = num fromInt numRangeElements
+//        if (a > 1e38 || b > 1e38) nre * ((head / two) + (last / two))  // Compute in parts to avoid Infinity if possible
+//        else (nre / two) * (head + last)    // Don't need to worry about infinity; this will be more accurate and avoid underflow
+//      }
+//      else if ((num eq scala.math.Numeric.BigIntIsIntegral) ||
+//        (num eq scala.math.Numeric.BigDecimalIsFractional)) {
+//        // No overflow, so we can use arithmetic series formula directly
+//        // (not going to worry about running out of memory)
+//        val numAsIntegral = num.asInstanceOf[Integral[B]]
+//        import numAsIntegral._
+//        ((num fromInt numRangeElements) * (head + last)) / (num fromInt 2)
+//      }
+//      else {
+//        // User provided custom Numeric, so we cannot rely on arithmetic series formula (e.g. won't work on something like Z_6)
+//        if (isEmpty) num.zero
+//        else {
+//          var acc = num.zero
+//          var i = head
+//          var idx = 0
+//          while(idx < length) {
+//            acc = num.plus(acc, i)
+//            i = i + step
+//            idx = idx + 1
+//          }
+//          acc
+//        }
+//      }
+//    }
+//  }
+
+//  override lazy val hashCode = super.hashCode()
+//  override def equals(other: Any) = other match {
+//    case x: NumericRange[_] =>
+//      (x canEqual this) && (length == x.length) && (
+//        (length == 0) ||                      // all empty sequences are equal
+//          (start == x.start && last == x.last)  // same length and same endpoints implies equality
+//        )
+//    case _ =>
+//      super.equals(other)
+//  }
+
+  override def toString = {
+    val empty = if (isEmpty) "empty " else ""
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    s"${empty}NumericRange $start $preposition $end$stepped"
+  }
+}
+
+/** A companion object for numeric ranges.
+  */
+object NumericRange {
+
+  /** Calculates the number of elements in a range given start, end, step, and
+    *  whether or not it is inclusive.  Throws an exception if step == 0 or
+    *  the number of elements exceeds the maximum Int.
+    */
+  def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
+    val zero    = num.zero
+    val upward  = num.lt(start, end)
+    val posStep = num.gt(step, zero)
+
+    if (step == zero) throw new IllegalArgumentException("step cannot be 0.")
+    else if (start == end) if (isInclusive) 1 else 0
+    else if (upward != posStep) 0
+    else {
+      /* We have to be frightfully paranoid about running out of range.
+       * We also can't assume that the numbers will fit in a Long.
+       * We will assume that if a > 0, -a can be represented, and if
+       * a < 0, -a+1 can be represented.  We also assume that if we
+       * can't fit in Int, we can represent 2*Int.MaxValue+3 (at least).
+       * And we assume that numbers wrap rather than cap when they overflow.
+       */
+      // Check whether we can short-circuit by deferring to Int range.
+      val startint = num.toInt(start)
+      if (start == num.fromInt(startint)) {
+        val endint = num.toInt(end)
+        if (end == num.fromInt(endint)) {
+          val stepint = num.toInt(step)
+          if (step == num.fromInt(stepint)) {
+            return {
+              if (isInclusive) Range.inclusive(startint, endint, stepint).length
+              else             Range          (startint, endint, stepint).length
+            }
+          }
+        }
+      }
+      // If we reach this point, deferring to Int failed.
+      // Numbers may be big.
+      val one = num.one
+      val limit = num.fromInt(Int.MaxValue)
+      def check(t: T): T =
+        if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
+        else t
+      // If the range crosses zero, it might overflow when subtracted
+      val startside = num.signum(start)
+      val endside = num.signum(end)
+      num.toInt{
+        if (startside*endside >= 0) {
+          // We're sure we can subtract these numbers.
+          // Note that we do not use .rem because of different conventions for Long and BigInt
+          val diff = num.minus(end, start)
+          val quotient = check(num.quot(diff, step))
+          val remainder = num.minus(diff, num.times(quotient, step))
+          if (!isInclusive && zero == remainder) quotient else check(num.plus(quotient, one))
+        }
+        else {
+          // We might not even be able to subtract these numbers.
+          // Jump in three pieces:
+          //   * start to -1 or 1, whichever is closer (waypointA)
+          //   * one step, which will take us at least to 0 (ends at waypointB)
+          //   * there to the end
+          val negone = num.fromInt(-1)
+          val startlim  = if (posStep) negone else one
+          val startdiff = num.minus(startlim, start)
+          val startq    = check(num.quot(startdiff, step))
+          val waypointA = if (startq == zero) start else num.plus(start, num.times(startq, step))
+          val waypointB = num.plus(waypointA, step)
+          check {
+            if (num.lt(waypointB, end) != upward) {
+              // No last piece
+              if (isInclusive && waypointB == end) num.plus(startq, num.fromInt(2))
+              else num.plus(startq, one)
+            }
+            else {
+              // There is a last piece
+              val enddiff = num.minus(end,waypointB)
+              val endq    = check(num.quot(enddiff, step))
+              val last    = if (endq == zero) waypointB else num.plus(waypointB, num.times(endq, step))
+              // Now we have to tally up all the pieces
+              //   1 for the initial value
+              //   startq steps to waypointA
+              //   1 step to waypointB
+              //   endq steps to the end (one less if !isInclusive and last==end)
+              num.plus(startq, num.plus(endq, if (!isInclusive && last==end) one else num.fromInt(2)))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def apply[T](start: T, end: T, step: T)(implicit num: Integral[T]): NumericRange[T] =
+    new NumericRange[T](start, end, step, isInclusive = false)
+  def inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T]): NumericRange[T] =
+    new NumericRange[T](start, end, step, isInclusive = true)
+
+  private[collection] val defaultOrdering = Map[Numeric[_], Ordering[_]](
+    Numeric.BigIntIsIntegral -> Ordering.BigInt,
+    Numeric.IntIsIntegral -> Ordering.Int,
+    Numeric.ShortIsIntegral -> Ordering.Short,
+    Numeric.ByteIsIntegral -> Ordering.Byte,
+    Numeric.CharIsIntegral -> Ordering.Char,
+    Numeric.LongIsIntegral -> Ordering.Long,
+    Numeric.FloatAsIfIntegral -> Ordering.Float,
+    Numeric.DoubleAsIfIntegral -> Ordering.Double,
+    Numeric.BigDecimalAsIfIntegral -> Ordering.BigDecimal
+  )
+
+}
+
+private class NumericRangeIterator[T](
+  start: T,
+  step: T,
+  lastElement: T,
+  initiallyEmpty: Boolean
+)(implicit num: Numeric[T]) extends Iterator[T] {
+  private var _hasNext: Boolean = !initiallyEmpty
+  private var _next: T = start
+  def hasNext: Boolean = _hasNext
+  def next(): T = {
+    val value = _next
+    _hasNext = value != lastElement
+    _next = num.plus(value, step)
+    value
+  }
+}

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -2,7 +2,7 @@ package strawman.collection.immutable
 
 import strawman.collection.{IndexedSeq, IterableFactory, Iterator, IterablePolyTransformsFromIterable, SeqMonoTransformsFromIterable}
 
-import scala.{Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, inline, Long, StringContext, Serializable, SerialVersionUID, Unit}
+import scala.{Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, inline, Long, StringContext, Serializable, SerialVersionUID, specialized, Unit}
 import scala.Predef.{???, augmentString}
 import java.lang.String
 
@@ -140,7 +140,7 @@ final class Range(
   protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[Int]): IndexedSeq[Int] =
     fromIterable(coll)
 
-  @inline override def foreach[U](f: Int => U) {
+  @inline override def foreach[@specialized(Unit) U](f: Int => U) {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -1,0 +1,290 @@
+package strawman.collection.immutable
+
+import strawman.collection.{IndexedSeq, IterableFactory, Iterator, IterablePolyTransformsFromIterable, SeqMonoTransformsFromIterable}
+
+import scala.{Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, inline, Long, StringContext, Serializable, SerialVersionUID, Unit}
+import scala.Predef.{???, augmentString}
+import java.lang.String
+
+/** The `Range` class represents integer values in range
+  *  ''[start;end)'' with non-zero step value `step`.
+  *  It's a special case of an indexed sequence.
+  *  For example:
+  *
+  *  {{{
+  *     val r1 = 0 until 10
+  *     val r2 = r1.start until r1.end by r1.step + 1
+  *     println(r2.length) // = 5
+  *  }}}
+  *
+  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+  *  these overfull ranges have only limited capabilities. Any method that
+  *  could require a collection of over `Int.MaxValue` length to be created, or
+  *  could be asked to index beyond `Int.MaxValue` elements will throw an
+  *  exception. Overfull ranges can safely be reduced in size by changing
+  *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
+  *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+  *  `init`) are also permitted on overfull ranges.
+  *
+  *  @param start       the start of this range.
+  *  @param end         the end of the range.  For exclusive ranges, e.g.
+  *                     `Range(0,3)` or `(0 until 3)`, this is one
+  *                     step past the last one in the range.  For inclusive
+  *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+  *                     it may be in the range if it is not skipped by the step size.
+  *                     To find the last element inside a non-empty range,
+  *                     use `last` instead.
+  *  @param step        the step for the range.
+  *  @param isInclusive whether the end of the range is included or not
+  */
+@SerialVersionUID(7618862778670199309L)
+final class Range(
+  val start: Int,
+  val end: Int,
+  val step: Int,
+  val isInclusive: Boolean
+)
+  extends IndexedSeq[Int]
+    with IterableFactory[IndexedSeq]
+    with IterablePolyTransformsFromIterable[Int, IndexedSeq]
+    with SeqMonoTransformsFromIterable[Int, IndexedSeq[Int]]
+    with Serializable { range =>
+
+  def iterator(): Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
+
+  private def gap           = end.toLong - start.toLong
+  private def isExact       = gap % step == 0
+  private def hasStub       = isInclusive || !isExact
+  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
+
+  override val isEmpty: Boolean = (
+    (start > end && step > 0)
+      || (start < end && step < 0)
+      || (start == end && !isInclusive)
+    )
+
+  val length: Int = {
+    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+    else if (isEmpty) 0
+    else {
+      val len = longLength
+      if (len > scala.Int.MaxValue) -1
+      else len.toInt
+    }
+  }
+
+  // This field has a sensible value only for non-empty ranges
+  private val lastElement = step match {
+    case 1  => if (isInclusive) end else end-1
+    case -1 => if (isInclusive) end else end+1
+    case _  =>
+      val remainder = (gap % step).toInt
+      if (remainder != 0) end - remainder
+      else if (isInclusive) end
+      else end - step
+  }
+
+  /** The last element of this range.  This method will return the correct value
+    *  even if there are too many elements to iterate over.
+    */
+  def last: Int = if (isEmpty) Nil.head else lastElement
+  override def head: Int = if (isEmpty) Nil.head else start
+
+  /** Creates a new range containing all the elements of this range except the first one.
+    *
+    *  $doesNotUseBuilders
+    *
+    *  @return  a new range consisting of all the elements of this range except the first one.
+    */
+  override def tail: Range = {
+    if (isEmpty)
+      Nil.tail
+    if (length == 1) newEmptyRange(end)
+    else new Range(start + step, end, step, isInclusive)
+  }
+
+  protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
+    new Range(start, end, step, isInclusive)
+
+  /** Create a new range with the `start` and `end` values of this range and
+    *  a new `step`.
+    *
+    *  @return a new range with a different step
+    */
+  def by(step: Int): Range = copy(start, end, step)
+
+  // Override for performance
+  override def size: Int = length
+
+  // Check cannot be evaluated eagerly because we have a pattern where
+  // ranges are constructed like: "x to y by z" The "x to y" piece
+  // should not trigger an exception. So the calculation is delayed,
+  // which means it will not fail fast for those cases where failing was
+  // correct.
+  private def validateMaxLength() {
+    if (length < 0)
+      fail()
+  }
+  private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
+  private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
+
+  def apply(idx: Int): Int = {
+    validateMaxLength()
+    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    else start + (step * idx)
+  }
+
+  def fromIterable[B](it: strawman.collection.Iterable[B]): IndexedSeq[B] =
+    Array.fromIterable(it) // TODO Use Vector instead of Array
+
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[Int]): IndexedSeq[Int] =
+    fromIterable(coll)
+
+  @inline override def foreach[U](f: Int => U) {
+    // Implementation chosen on the basis of favorable microbenchmarks
+    // Note--initialization catches step == 0 so we don't need to here
+    if (!isEmpty) {
+      var i = start
+      while (true) {
+        f(i)
+        if (i == lastElement) return
+        i += step
+      }
+    }
+  }
+
+  /** Creates a new range containing the first `n` elements of this range.
+    *
+    *  @param n  the number of elements to take.
+    *  @return   a new range consisting of `n` first elements.
+    */
+  override def take(n: Int): Range =
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (n >= length && length >= 0) this
+    else {
+      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
+      // but the logic is the same either way: take the first n
+      new Range(start, locationAfterN(n - 1), step, isInclusive = true)
+    }
+
+  /** Creates a new range containing all the elements of this range except the first `n` elements.
+    *
+    *  @param n  the number of elements to drop.
+    *  @return   a new range consisting of all the elements of this range except `n` first elements.
+    */
+  override def drop(n: Int): Range =
+    if (n <= 0 || isEmpty) this
+    else if (n >= length && length >= 0) newEmptyRange(end)
+    else {
+      // May have more than Int.MaxValue elements (numRangeElements < 0)
+      // but the logic is the same either way: go forwards n steps, keep the rest
+      copy(locationAfterN(n), end, step)
+    }
+
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int) = start + (step * n)
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: Int) = new Range(value, value, step, isInclusive = false)
+
+  /** Returns the reverse of this range.
+    */
+  override def reverse: Range =
+    if (isEmpty) this
+    else new Range(last, start, -step, isInclusive = true)
+
+  /** Make range inclusive.
+    */
+  def inclusive: Range =
+    if (isInclusive) this
+    else new Range(start, end, step, isInclusive = true)
+
+  override def toString: String = {
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    s"${prefix}Range $start $preposition $end$stepped"
+  }
+
+  // TODO Override min, max, slice, init, takeWhile, dropWhile, span, splitAt, takeRight, dropRight, contains, sum, equals
+}
+
+object Range {
+
+  /** Counts the number of range elements.
+    *  @pre  step != 0
+    *  If the size of the range exceeds Int.MaxValue, the
+    *  result will be negative.
+    */
+  def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
+    if (step == 0)
+      throw new IllegalArgumentException("step cannot be 0.")
+
+    val isEmpty = (
+      if (start == end) !isInclusive
+      else if (start < end) step < 0
+      else step > 0
+    )
+    if (isEmpty) 0
+    else {
+      // Counts with Longs so we can recognize too-large ranges.
+      val gap: Long    = end.toLong - start.toLong
+      val jumps: Long  = gap / step
+      // Whether the size of this range is one larger than the
+      // number of full-sized jumps.
+      val hasStub      = isInclusive || (gap % step != 0)
+      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+
+      if (result > scala.Int.MaxValue) -1
+      else result.toInt
+    }
+  }
+  def count(start: Int, end: Int, step: Int): Int =
+    count(start, end, step, isInclusive = false)
+
+  /** Make a range from `start` until `end` (exclusive) with given step value.
+    * @note step != 0
+    */
+  def apply(start: Int, end: Int, step: Int): Range = new Range(start, end, step, isInclusive = false)
+
+  /** Make a range from `start` until `end` (exclusive) with step value 1.
+    */
+  def apply(start: Int, end: Int): Range = new Range(start, end, 1, isInclusive = false)
+
+  /** Make an inclusive range from `start` to `end` with given step value.
+    * @note step != 0
+    */
+  def inclusive(start: Int, end: Int, step: Int): Range = new Range(start, end, step, isInclusive = true)
+
+  /** Make an inclusive range from `start` to `end` with step value 1.
+    */
+  def inclusive(start: Int, end: Int): Range = new Range(start, end, 1, isInclusive = true)
+
+
+
+}
+
+/**
+  * @param lastElement The last element included in the Range
+  * @param initiallyEmpty Whether the Range was initially empty or not
+  */
+private class RangeIterator(
+  start: Int,
+  step: Int,
+  lastElement: Int,
+  initiallyEmpty: Boolean
+) extends Iterator[Int] {
+  private var _hasNext: Boolean = !initiallyEmpty
+  private var _next: Int = start
+  def hasNext: Boolean = _hasNext
+  def next(): Int = {
+    val value = _next
+    _hasNext = value != lastElement
+    _next = value + step
+    value
+  }
+}

--- a/src/main/scala/strawman/collection/immutable/View.scala
+++ b/src/main/scala/strawman/collection/immutable/View.scala
@@ -1,14 +1,16 @@
-package strawman.collection
+package strawman.collection.immutable
 
-import scala.{Int, Boolean, Nothing, annotation}
+import strawman.collection.{ArrayLike, IterableLikeFromIterable, IterableOnce, Iterator}
+
 import scala.Predef.intWrapper
+import scala.{Boolean, Int, Nothing}
 
 /** Concrete collection type: View */
-trait View[+A] extends Iterable[A] with IterableLike[A, View] {
+trait View[+A] extends Iterable[A] with IterableLikeFromIterable[A, View] {
   override def view = this
 
   /** Avoid copying if source collection is already a view. */
-  override def fromIterable[B](c: Iterable[B]): View[B] = c match {
+  def fromIterable[B](c: strawman.collection.Iterable[B]): View[B] = c match {
     case c: View[B] => c
     case _ => View.fromIterator(c.iterator())
   }
@@ -48,12 +50,12 @@ object View {
   }
 
   /** A view that filters an underlying collection. */
-  case class Filter[A](underlying: Iterable[A], p: A => Boolean) extends View[A] {
+  case class Filter[A](underlying: strawman.collection.Iterable[A], p: A => Boolean) extends View[A] {
     def iterator() = underlying.iterator().filter(p)
   }
 
   /** A view that partitions an underlying collection into two views */
-  case class Partition[A](underlying: Iterable[A], p: A => Boolean) {
+  case class Partition[A](underlying: strawman.collection.Iterable[A], p: A => Boolean) {
 
     /** The view consisting of all elements of the underlying collection
      *  that satisfy `p`.
@@ -72,7 +74,7 @@ object View {
   }
 
   /** A view that drops leading elements of the underlying collection. */
-  case class Drop[A](underlying: Iterable[A], n: Int) extends View[A] {
+  case class Drop[A](underlying: strawman.collection.Iterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().drop(n)
     protected val normN = n max 0
     override def knownSize =
@@ -80,7 +82,7 @@ object View {
   }
 
   /** A view that takes leading elements of the underlying collection. */
-  case class Take[A](underlying: Iterable[A], n: Int) extends View[A] {
+  case class Take[A](underlying: strawman.collection.Iterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().take(n)
     protected val normN = n max 0
     override def knownSize =
@@ -88,20 +90,20 @@ object View {
   }
 
   /** A view that maps elements of the underlying collection. */
-  case class Map[A, B](underlying: Iterable[A], f: A => B) extends View[B] {
+  case class Map[A, B](underlying: strawman.collection.Iterable[A], f: A => B) extends View[B] {
     def iterator() = underlying.iterator().map(f)
     override def knownSize = underlying.knownSize
   }
 
   /** A view that flatmaps elements of the underlying collection. */
-  case class FlatMap[A, B](underlying: Iterable[A], f: A => IterableOnce[B]) extends View[B] {
+  case class FlatMap[A, B](underlying: strawman.collection.Iterable[A], f: A => IterableOnce[B]) extends View[B] {
     def iterator() = underlying.iterator().flatMap(f)
   }
 
   /** A view that concatenates elements of the underlying collection with the elements
    *  of another collection or iterator.
    */
-  case class Concat[A](underlying: Iterable[A], other: IterableOnce[A]) extends View[A] {
+  case class Concat[A](underlying: strawman.collection.Iterable[A], other: IterableOnce[A]) extends View[A] {
     def iterator() = underlying.iterator() ++ other
     override def knownSize = other match {
       case other: Iterable[_] if underlying.knownSize >= 0 && other.knownSize >= 0 =>
@@ -114,7 +116,7 @@ object View {
   /** A view that zips elements of the underlying collection with the elements
    *  of another collection or iterator.
    */
-  case class Zip[A, B](underlying: Iterable[A], other: IterableOnce[B]) extends View[(A, B)] {
+  case class Zip[A, B](underlying: strawman.collection.Iterable[A], other: IterableOnce[B]) extends View[(A, B)] {
     def iterator() = underlying.iterator().zip(other)
     override def knownSize = other match {
       case other: Iterable[_] => underlying.knownSize min other.knownSize

--- a/src/main/scala/strawman/collection/javaSupport.scala
+++ b/src/main/scala/strawman/collection/javaSupport.scala
@@ -1,8 +1,8 @@
 package strawman.collection
 
-import strawman.collection.immutable.List
+import strawman.collection.immutable.{IndexedView, List, View}
 
-import scala.{Array, Char, Int, AnyVal}
+import scala.{AnyVal, Array, Char, Int}
 import scala.Predef.String
 import strawman.collection.mutable.{ArrayBuffer, Buildable, StringBuilder}
 
@@ -10,8 +10,8 @@ import scala.reflect.ClassTag
 
 class StringOps(val s: String)
   extends AnyVal with IterableOps[Char]
-    with SeqMonoTransforms[Char, String]
-    with IterablePolyTransforms[Char, List]
+    with SeqMonoTransformsFromIterable[Char, String]
+    with IterablePolyTransformsFromIterable[Char, List]
     with Buildable[Char, String]
     with ArrayLike[Char] {
 
@@ -75,7 +75,7 @@ case class StringView(s: String) extends IndexedView[Char] {
 
 class ArrayOps[A](val xs: Array[A])
   extends AnyVal with IterableOps[A]
-    with SeqMonoTransforms[A, Array[A]]
+    with SeqMonoTransformsFromIterable[A, Array[A]]
     with Buildable[A, Array[A]]
     with ArrayLike[A] {
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -1,15 +1,17 @@
 package strawman.collection.mutable
 
-import java.lang.IndexOutOfBoundsException
-import scala.{Array, Exception, Int, Long, Boolean, math, StringContext, Unit, AnyRef}
-import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, SeqLike, IndexedView}
+import strawman.collection.immutable.IndexedView
+
+import scala.{AnyRef, Array, Boolean, Exception, IndexOutOfBoundsException, Int, Long, math, StringContext, Unit}
 import scala.Predef.intWrapper
+import strawman.collection.{IterableFactory, IterableLikeFromIterable, IterableOnce, SeqLike, SeqMonoTransformsFromIterable}
 
 /** Concrete collection type: ArrayBuffer */
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   extends IndexedOptimizedGrowableSeq[A]
     with SeqLike[A, ArrayBuffer]
+    with IterableLikeFromIterable[A, ArrayBuffer]
+    with SeqMonoTransformsFromIterable[A, ArrayBuffer[A]]
     with Buildable[A, ArrayBuffer[A]]
     with Builder[A, ArrayBuffer[A]] {
 
@@ -44,7 +46,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def iterator() = view.iterator()
 
-  def fromIterable[B](it: collection.Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](it: strawman.collection.Iterable[B]): ArrayBuffer[B] =
     ArrayBuffer.fromIterable(it)
 
   protected[this] def newBuilder = new ArrayBuffer[A]
@@ -83,7 +85,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
     checkWithinBounds(idx, idx)
     elems match {
-      case elems: collection.Iterable[A] =>
+      case elems: strawman.collection.Iterable[A] =>
         val elemsLength = elems.size
         ensureSize(length + elemsLength)
         Array.copy(array, idx, array, idx + elemsLength, end - idx)
@@ -125,7 +127,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
-  def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): ArrayBuffer[B] =
     if (coll.knownSize >= 0) {
       val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()

--- a/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import scala.{Boolean, Any, Char, Unit}
 import java.lang.String
-import strawman.collection.{IterableMonoTransforms, IterableOnce}
+import strawman.collection.{IterableMonoTransformsFromIterable, IterableOnce}
 
 /** Base trait for collection builders */
 trait Builder[-A, +To] extends Growable[A] { self =>
@@ -31,7 +31,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
   * @tparam  A    the element type of the collection
   * @tparam Repr  the type of the underlying collection
   */
-trait Buildable[+A, +Repr] extends Any with IterableMonoTransforms[A, Repr]  {
+trait Buildable[+A, +Repr] extends Any with IterableMonoTransformsFromIterable[A, Repr]  {
 
   /** Creates a new builder. */
   protected[this] def newBuilder: Builder[A, Repr]

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -1,18 +1,17 @@
 package strawman.collection.mutable
 
-import scala.{Int, Unit, Boolean}
-import scala.Int._
+import scala.{Boolean, IndexOutOfBoundsException, Int, Unit}
+import scala.Predef.intWrapper
 import strawman.collection
-import strawman.collection.{Iterator, IterableOnce, IterableFactory, SeqLike}
-import strawman.collection.immutable.{List, Nil, ::}
+import strawman.collection.{IterableFactory, IterableOnce, Iterator, SeqLikeFromIterable}
+import strawman.collection.immutable.{::, List, Nil}
+
 import scala.annotation.tailrec
-import java.lang.IndexOutOfBoundsException
-import scala.Predef.{assert, intWrapper}
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
   extends Seq[A]
-    with SeqLike[A, ListBuffer]
+    with SeqLikeFromIterable[A, ListBuffer]
     with Buildable[A, ListBuffer[A]]
     with Builder[A, ListBuffer[A]] {
 

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -338,19 +338,29 @@ class StrawmanTest {
     println(xs17.to(List))
   }
 
+  def rangeOps(xs: immutable.Range): Unit = {
+    println(xs.start)
+    println(xs.end)
+    println(xs.step)
+    println(xs.isInclusive)
+  }
+
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)
     val intsBuf = ints.to(mutable.ArrayBuffer)
     val intsListBuf = ints.to(mutable.ListBuffer)
     val intsView = ints.view
+    val range = immutable.Range(1, 3)
     seqOps(ints)
     seqOps(intsBuf)
     seqOps(intsListBuf)
+    seqOps(range)
     viewOps(intsView)
     stringOps("abc")
     arrayOps(Array(1, 2, 3))
     lazyListOps(LazyList(1, 2, 3))
     immutableArrayOps(immutable.Array.tabulate(3)(identity))
+    rangeOps(range)
   }
 }

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -2,11 +2,10 @@ package strawman.collection.test
 
 import java.lang.String
 import scala.{Int, Unit, Array, StringContext, Boolean, Any, Char}
-import scala.Predef.{println, charWrapper}
+import scala.Predef.{println, charWrapper, identity}
 
-import strawman.collection.immutable._
-import strawman.collection.mutable._
-import strawman.collection.{Seq, View, _}
+import strawman.collection._
+import strawman.collection.immutable.{List, Nil, View, LazyList}
 import org.junit.Test
 
 class StrawmanTest {
@@ -215,6 +214,57 @@ class StrawmanTest {
     println(xs16.view)
   }
 
+  def immutableArrayOps(xs: immutable.Array[Int]): Unit = {
+    val x1 = xs.foldLeft("")(_ + _)
+    val y1: String = x1
+    val x2 = xs.foldRight("")(_ + _)
+    val y2: String = x2
+    val x3 = xs.indexWhere(_ % 2 == 0)
+    val y3: Int = x3
+    val x4 = xs.head
+    val y4: Int = x4
+    val x5 = xs.to(List)
+    val y5: List[Int] = x5
+    val (xs6, xs7) = xs.partition(_ % 2 == 0)
+    val ys6: immutable.Array[Int] = xs6
+    val ys7: immutable.Array[Int] = xs7
+    val xs8 = xs.drop(2)
+    val ys8: immutable.Array[Int] = xs8
+    val xs9 = xs.map(_ >= 0)
+    val ys9: immutable.Array[Boolean] = xs9
+    val xs10 = xs.flatMap(x => x :: -x :: Nil)
+    val ys10: immutable.Array[Int] = xs10
+    val xs11 = xs ++ xs
+    val ys11: immutable.Array[Int] = xs11
+    val xs12 = xs ++ Nil
+    val ys12: immutable.Array[Int] = xs12
+    val xs13 = Nil ++ xs
+    val ys13: List[Int] = xs13
+    val xs14 = xs ++ ("a" :: Nil)
+    val ys14: immutable.Array[Any] = xs14
+    val xs15 = xs.zip(xs9)
+    val ys15: immutable.Array[(Int, Boolean)] = xs15
+    val xs16 = xs.reverse
+    val ys16: immutable.Array[Int] = xs16
+    println("-------")
+    println(x1)
+    println(x2)
+    println(x3)
+    println(x4)
+    println(x5)
+    println(xs6)
+    println(xs7)
+    println(xs8)
+    println(xs9)
+    println(xs10)
+    println(xs11)
+    println(xs12)
+    println(xs13)
+    println(xs14)
+    println(xs15)
+    println(xs16)
+  }
+
   def lazyListOps(xs: Seq[Int]): Unit = {
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
@@ -291,8 +341,8 @@ class StrawmanTest {
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)
-    val intsBuf = ints.to(ArrayBuffer)
-    val intsListBuf = ints.to(ListBuffer)
+    val intsBuf = ints.to(mutable.ArrayBuffer)
+    val intsListBuf = ints.to(mutable.ListBuffer)
     val intsView = ints.view
     seqOps(ints)
     seqOps(intsBuf)
@@ -301,5 +351,6 @@ class StrawmanTest {
     stringOps("abc")
     arrayOps(Array(1, 2, 3))
     lazyListOps(LazyList(1, 2, 3))
+    immutableArrayOps(immutable.Array.tabulate(3)(identity))
   }
 }


### PR DESCRIPTION
This PR is a rebased version of #11.

I also tried to make `Range` extend `NumericRange[Int]` but the compiler was crashing with a StackOverflow when I wanted to override the `by(newStep: T): NumericRange[T]` method for range (`by(newStep: Int): Range`).

I `@specialized(Unit)` the `foreach` method in both `Range` and `NumericRange` but this didn’t seem to have any measurable effect on `NumericRange`.