### PR TITLE
Make the different kinds of collection companions consistent together

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,8 +3,9 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Int, Boolean, Array, Any, Unit, StringContext}
+import scala.{Any, Array, Boolean, Int, StringContext, Unit}
 import java.lang.{String, UnsupportedOperationException}
+
 import strawman.collection.mutable.{ArrayBuffer, StringBuilder}
 import java.lang.String
 
@@ -35,18 +36,6 @@ trait IterableLike[+A, +C[X] <: Iterable[X]]
     *  the same element type as this collection. Overridden in StringOps and ArrayOps.
     */
   protected[this] def fromIterableWithSameElemType(coll: Iterable[A]): C[A]
-}
-
-/** Base trait for instances that can construct a collection from an iterable */
-trait FromIterable[+C[X] <: Iterable[X]] {
-  def fromIterable[B](it: Iterable[B]): C[B]
-}
-
-/** Base trait for companion objects of collections */
-trait IterableFactory[+C[X] <: Iterable[X]] extends FromIterable[C] {
-  def empty[X]: C[X] = fromIterable(View.Empty)
-  def apply[A](xs: A*): C[A] = fromIterable(View.Elems(xs: _*))
-  def fill[A](n: Int)(elem: => A): C[A] = fromIterable(View.Fill(n)(elem))
 }
 
 /** Operations over iterables. No operation defined here is generic in the

--- a/src/main/scala/strawman/collection/IterableFactories.scala
+++ b/src/main/scala/strawman/collection/IterableFactories.scala
@@ -11,7 +11,7 @@ trait FromIterable[+C[X] <: Iterable[X]] {
 }
 
 /** Base trait for companion objects of collections */
-trait IterableFactory[+C[X] <: Iterable[X]] extends FromIterable[C] {
+trait IterableFactories[+C[X] <: Iterable[X]] extends FromIterable[C] {
 
   def empty[A]: C[A] = fromIterable(View.Empty)
 

--- a/src/main/scala/strawman/collection/IterableFactory.scala
+++ b/src/main/scala/strawman/collection/IterableFactory.scala
@@ -10,11 +10,6 @@ trait FromIterable[+C[X] <: Iterable[X]] {
   def fromIterable[B](it: Iterable[B]): C[B]
 }
 
-/** Base trait for builder factories */
-trait CanBuild[-A, +Repr] {
-  def apply(): Builder[A, Repr]
-}
-
 /** Base trait for companion objects of collections */
 trait IterableFactory[+C[X] <: Iterable[X]] extends FromIterable[C] {
 
@@ -26,10 +21,6 @@ trait IterableFactory[+C[X] <: Iterable[X]] extends FromIterable[C] {
 
   def newBuilder[A]: Builder[A, C[A]]
 
-  implicit def canBuild[A]: CanBuild[A, C[A]] = new CanBuildThisCollection[A] // TODO Reuse the same instance
-
-  class CanBuildThisCollection[A] extends CanBuild[A, C[A]] {
-    def apply(): Builder[A, C[A]] = newBuilder[A]
-  }
+  implicit def canBuild[A]: () => Builder[A, C[A]] = () => newBuilder[A] // TODO Reuse the same instance
 
 }

--- a/src/main/scala/strawman/collection/IterableFactory.scala
+++ b/src/main/scala/strawman/collection/IterableFactory.scala
@@ -1,0 +1,35 @@
+package strawman
+package collection
+
+import strawman.collection.mutable.Builder
+
+import scala.Int
+
+/** Base trait for instances that can construct a collection from an iterable */
+trait FromIterable[+C[X] <: Iterable[X]] {
+  def fromIterable[B](it: Iterable[B]): C[B]
+}
+
+/** Base trait for builder factories */
+trait CanBuild[-A, +Repr] {
+  def apply(): Builder[A, Repr]
+}
+
+/** Base trait for companion objects of collections */
+trait IterableFactory[+C[X] <: Iterable[X]] extends FromIterable[C] {
+
+  def empty[A]: C[A] = fromIterable(View.Empty)
+
+  def apply[A](xs: A*): C[A] = fromIterable(View.Elems(xs: _*))
+
+  def fill[A](n: Int)(elem: => A): C[A] = fromIterable(View.Fill(n)(elem))
+
+  def newBuilder[A]: Builder[A, C[A]]
+
+  implicit def canBuild[A]: CanBuild[A, C[A]] = new CanBuildThisCollection[A] // TODO Reuse the same instance
+
+  class CanBuildThisCollection[A] extends CanBuild[A, C[A]] {
+    def apply(): Builder[A, C[A]] = newBuilder[A]
+  }
+
+}

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -41,10 +41,6 @@ trait MapFactories[C[_, _]] {
   def apply[K, V](elems: (K, V)*): C[K, V] =
     newBuilder[K, V].++=(elems.toStrawman).result
 
-  implicit def canBuild[K, V]: CanBuild[(K, V), C[K, V]] = new CanBuildThisCollection[K, V]
-
-  class CanBuildThisCollection[K, V] extends CanBuild[(K, V), C[K, V]] {
-    def apply(): Builder[(K, V), C[K, V]] = newBuilder[K, V]
-  }
+  implicit def canBuild[K, V]: () => Builder[(K, V), C[K, V]] = () => newBuilder[K, V]
 
 }

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -41,4 +41,10 @@ trait MapFactories[C[_, _]] {
   def apply[K, V](elems: (K, V)*): C[K, V] =
     newBuilder[K, V].++=(elems.toStrawman).result
 
+  implicit def canBuild[K, V]: CanBuild[(K, V), C[K, V]] = new CanBuildThisCollection[K, V]
+
+  class CanBuildThisCollection[K, V] extends CanBuild[(K, V), C[K, V]] {
+    def apply(): Builder[(K, V), C[K, V]] = newBuilder[K, V]
+  }
+
 }

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -34,10 +34,6 @@ trait OrderingGuidedFactories[C[_]] {
 
   def apply[A : Ordering](as: A*): C[A] = (newBuilder[A] ++= as.toStrawman).result
 
-  implicit def canBuild[A : Ordering]: CanBuild[A, C[A]] = new CanBuildThisCollection[A]
-
-  class CanBuildThisCollection[A : Ordering] extends CanBuild[A, C[A]] {
-    def apply(): Builder[A, C[A]] = newBuilder[A]
-  }
+  implicit def canBuild[A : Ordering]: () => Builder[A, C[A]] = () => newBuilder[A]
 
 }

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -28,10 +28,16 @@ trait SortedPolyTransforms[A, +C[X] <: Sorted[X]]
   */
 trait OrderingGuidedFactories[C[_]] {
 
-  def builder[A](implicit ordering: Ordering[A]): Builder[A, C[A]]
+  def newBuilder[A](implicit ordering: Ordering[A]): Builder[A, C[A]]
 
-  def empty[A : Ordering]: C[A] = builder[A].result
+  def empty[A : Ordering]: C[A] = newBuilder[A].result
 
-  def apply[A : Ordering](as: A*): C[A] = (builder[A] ++= as.toStrawman).result
+  def apply[A : Ordering](as: A*): C[A] = (newBuilder[A] ++= as.toStrawman).result
+
+  implicit def canBuild[A : Ordering]: CanBuild[A, C[A]] = new CanBuildThisCollection[A]
+
+  class CanBuildThisCollection[A : Ordering] extends CanBuild[A, C[A]] {
+    def apply(): Builder[A, C[A]] = newBuilder[A]
+  }
 
 }

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -1,5 +1,8 @@
-package strawman.collection.immutable
+package strawman
 
+package collection.immutable
+
+import strawman.collection.mutable.Builder
 import strawman.collection.{IterableFactory, Iterator}
 
 import scala.Boolean
@@ -12,16 +15,16 @@ class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
   def iterator(): Iterator[A] = ???
 
   // From IterablePolyTransforms
-  def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] = ???
-  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): HashSet[A] = fromIterable(coll)
+  def fromIterable[B](coll: collection.Iterable[B]): HashSet[B] = HashSet.fromIterable(coll)
+  protected[this] def fromIterableWithSameElemType(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
   // From SetLike
   def contains(elem: A): Boolean = ???
-  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
+  def subsetOf(that: collection.Set[A]): Boolean = ???
 
   // From SetMonoTransforms
-  def & (that: strawman.collection.Set[A]): HashSet[A] = ???
-  def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
+  def & (that: collection.Set[A]): HashSet[A] = ???
+  def ++ (that: collection.Set[A]): HashSet[A] = ???
 
   // From immutable.SetLike
   def + (elem: A): HashSet[A] = ???
@@ -31,6 +34,8 @@ class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = ???
+  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] = ???
+
+  def newBuilder[A]: Builder[A, HashSet[A]] = ???
 
 }

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -3,7 +3,7 @@ package strawman
 package collection.immutable
 
 import strawman.collection.mutable.Builder
-import strawman.collection.{IterableFactory, Iterator}
+import strawman.collection.{IterableFactories, Iterator}
 
 import scala.Boolean
 import scala.Predef.???
@@ -32,7 +32,7 @@ class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
 
 }
 
-object HashSet extends IterableFactory[HashSet] {
+object HashSet extends IterableFactories[HashSet] {
 
   def fromIterable[A](it: collection.Iterable[A]): HashSet[A] = ???
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -1,8 +1,10 @@
 package strawman.collection.immutable
 
-import scala.{Option, Some, None, Nothing, StringContext}
+import scala.{None, Nothing, Option, Some, StringContext}
+import scala.Predef.???
 import strawman.collection
-import strawman.collection.{IterableFactory, LinearSeq, SeqLike, Iterator}
+import strawman.collection.mutable.Builder
+import strawman.collection.{IterableFactory, Iterator, LinearSeq, SeqLike}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
   extends Seq[A] with SeqLike[A, LazyList] with LinearSeq[A] {
@@ -47,11 +49,14 @@ object LazyList extends IterableFactory[LazyList] {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force
   }
 
-  def fromIterable[B](coll: collection.Iterable[B]): LazyList[B] = coll match {
-    case coll: LazyList[B] => coll
+  def fromIterable[A](coll: collection.Iterable[A]): LazyList[A] = coll match {
+    case coll: LazyList[A] => coll
     case _ => fromIterator(coll.iterator())
   }
 
-  def fromIterator[B](it: Iterator[B]): LazyList[B] =
+  def fromIterator[A](it: Iterator[A]): LazyList[A] =
     new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
+
+  def newBuilder[A]: Builder[A, LazyList[A]] = ???
+
 }

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -4,7 +4,7 @@ import scala.{None, Nothing, Option, Some, StringContext}
 import scala.Predef.???
 import strawman.collection
 import strawman.collection.mutable.Builder
-import strawman.collection.{IterableFactory, Iterator, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactories, Iterator, LinearSeq, SeqLike}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
   extends Seq[A] with SeqLike[A, LazyList] with LinearSeq[A] {
@@ -39,7 +39,7 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
     else "LazyList(?)"
 }
 
-object LazyList extends IterableFactory[LazyList] {
+object LazyList extends IterableFactories[LazyList] {
 
   type Evaluated[+A] = Option[(A, LazyList[A])]
 

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -5,7 +5,7 @@ import scala.Nothing
 import scala.Predef.???
 import strawman.collection
 import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
-import strawman.collection.mutable.{Buildable, ListBuffer}
+import strawman.collection.mutable.{Buildable, Builder, ListBuffer}
 
 
 /** Concrete collection type: List */
@@ -17,7 +17,7 @@ sealed trait List[+A]
 
   def fromIterable[B](c: collection.Iterable[B]): List[B] = List.fromIterable(c)
 
-  protected[this] def newBuilder = new ListBuffer[A].mapResult(_.toList)
+  protected[this] def newBuilder = List.newBuilder
 
   /** Prepend element */
   def :: [B >: A](elem: B): List[B] =  new ::(elem, this)
@@ -52,8 +52,12 @@ case object Nil extends List[Nothing] {
 }
 
 object List extends IterableFactory[List] {
+
   def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.fromIterable(coll).toList
   }
+
+  def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
+
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -4,7 +4,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.Nothing
 import scala.Predef.???
 import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactories, IterableOnce, LinearSeq, SeqLike}
 import strawman.collection.mutable.{Buildable, Builder, ListBuffer}
 
 
@@ -51,7 +51,7 @@ case object Nil extends List[Nothing] {
   override def tail = ???
 }
 
-object List extends IterableFactory[List] {
+object List extends IterableFactories[List] {
 
   def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
     case coll: List[B] => coll

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -1,7 +1,8 @@
 package strawman
 package collection.immutable
 
-import strawman.collection.{IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike}
+import strawman.collection.{CanBuild, IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike, toNewSeq}
+import strawman.collection.mutable.Builder
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.Ordering
@@ -41,3 +42,18 @@ trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]
 
 }
 
+trait SortedMapFactory[C[_, _]] {
+
+  def newBuilder[K : Ordering, V]: Builder[(K, V), C[K, V]]
+
+  def empty[K : Ordering, V]: C[K, V] = newBuilder[K, V].result
+
+  def apply[K : Ordering, V](elems: (K, V)*): C[K, V] = newBuilder[K, V].++=(elems.toStrawman).result
+
+  implicit def canBuild[K : Ordering, V]: CanBuild[(K, V), C[K, V]] = new CanBuildThisCollection[K, V]
+
+  class CanBuildThisCollection[K : Ordering, V] extends CanBuild[(K, V), C[K, V]] {
+    def apply(): Builder[(K, V), C[K, V]] = newBuilder[K, V]
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.immutable
 
-import strawman.collection.{CanBuild, IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike, toNewSeq}
+import strawman.collection.{IterablePolyTransforms, MapPolyTransforms, Sorted, SortedLike, toNewSeq}
 import strawman.collection.mutable.Builder
 
 import scala.annotation.unchecked.uncheckedVariance
@@ -50,10 +50,6 @@ trait SortedMapFactory[C[_, _]] {
 
   def apply[K : Ordering, V](elems: (K, V)*): C[K, V] = newBuilder[K, V].++=(elems.toStrawman).result
 
-  implicit def canBuild[K : Ordering, V]: CanBuild[(K, V), C[K, V]] = new CanBuildThisCollection[K, V]
-
-  class CanBuildThisCollection[K : Ordering, V] extends CanBuild[(K, V), C[K, V]] {
-    def apply(): Builder[(K, V), C[K, V]] = newBuilder[K, V]
-  }
+  implicit def canBuild[K : Ordering, V]: () => Builder[(K, V), C[K, V]] = () => newBuilder[K, V]
 
 }

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -42,7 +42,7 @@ trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]
 
 }
 
-trait SortedMapFactory[C[_, _]] {
+trait SortedMapFactories[C[_, _]] {
 
   def newBuilder[K : Ordering, V]: Builder[(K, V), C[K, V]]
 

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -40,7 +40,7 @@ final class TreeMap[K, +V]
 
 }
 
-object TreeMap extends SortedMapFactory[TreeMap] {
+object TreeMap extends SortedMapFactories[TreeMap] {
 
   def newBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] = ???
 

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -2,6 +2,7 @@ package strawman
 package collection.immutable
 
 import strawman.collection.SortedLike
+import strawman.collection.mutable.Builder
 
 import scala.{Option, Ordering}
 import scala.Predef.???
@@ -36,5 +37,11 @@ final class TreeMap[K, +V]
   // Members declared in collection.SortedLike
   def ordering: Ordering[K] = ???
   def range(from: K,until: K): TreeMap[K,V] = ???
+
+}
+
+object TreeMap extends SortedMapFactory[TreeMap] {
+
+  def newBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] = ???
 
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -16,7 +16,7 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
 
   // From IterablePolyTransforms
   def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = ???
-  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): TreeSet[A] = TreeSet.builder[A].++=(coll).result
+  protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): TreeSet[A] = TreeSet.newBuilder[A].++=(coll).result
 
   // From SetLike
   def contains(elem: A): Boolean = ???
@@ -40,6 +40,6 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
 
 object TreeSet extends OrderingGuidedFactories[TreeSet] {
 
-  def builder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = ???
+  def newBuilder[A](implicit ordering: Ordering[A]): Builder[A, TreeSet[A]] = ???
 
 }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -1,9 +1,11 @@
 package strawman.collection.mutable
 
 import java.lang.IndexOutOfBoundsException
-import scala.{Array, Exception, Int, Long, Boolean, math, StringContext, Unit, AnyRef}
+
+import scala.{AnyRef, Array, Boolean, Exception, Int, Long, StringContext, Unit, math}
 import strawman.collection
-import strawman.collection.{IterableFactory, IterableOnce, SeqLike, IndexedView}
+import strawman.collection.{IndexedView, IterableFactory, IterableOnce, SeqLike}
+
 import scala.Predef.intWrapper
 
 /** Concrete collection type: ArrayBuffer */
@@ -133,6 +135,9 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
       new ArrayBuffer[B](array, array.length)
     }
     else new ArrayBuffer[B] ++= coll
+
+  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
+
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -4,7 +4,7 @@ import java.lang.IndexOutOfBoundsException
 
 import scala.{AnyRef, Array, Boolean, Exception, Int, Long, StringContext, Unit, math}
 import strawman.collection
-import strawman.collection.{IndexedView, IterableFactory, IterableOnce, SeqLike}
+import strawman.collection.{IndexedView, IterableFactories, IterableOnce, SeqLike}
 
 import scala.Predef.intWrapper
 
@@ -124,7 +124,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   override def className = "ArrayBuffer"
 }
 
-object ArrayBuffer extends IterableFactory[ArrayBuffer] {
+object ArrayBuffer extends IterableFactories[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
   def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -43,4 +43,6 @@ object HashSet extends IterableFactory[HashSet] {
     result
   }
 
+  def newBuilder[A]: Builder[A, HashSet[A]] = new HashSet[A]
+
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection.mutable
 
-import strawman.collection.{IterableFactory, Iterator}
+import strawman.collection.{IterableFactories, Iterator}
 
 import scala.{Boolean, Option, Unit}
 import scala.Predef.???
@@ -33,7 +33,7 @@ final class HashSet[A]
 
 }
 
-object HashSet extends IterableFactory[HashSet] {
+object HashSet extends IterableFactories[HashSet] {
 
   def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = {
     val result = new HashSet[B]

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -3,7 +3,7 @@ package strawman.collection.mutable
 import scala.{Int, Unit, Boolean}
 import scala.Int._
 import strawman.collection
-import strawman.collection.{Iterator, IterableOnce, IterableFactory, SeqLike}
+import strawman.collection.{Iterator, IterableOnce, IterableFactories, SeqLike}
 import strawman.collection.immutable.{List, Nil, ::}
 import scala.annotation.tailrec
 import java.lang.IndexOutOfBoundsException
@@ -197,7 +197,7 @@ class ListBuffer[A]
   override def className = "ListBuffer"
 }
 
-object ListBuffer extends IterableFactory[ListBuffer] {
+object ListBuffer extends IterableFactories[ListBuffer] {
 
   def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -198,5 +198,9 @@ class ListBuffer[A]
 }
 
 object ListBuffer extends IterableFactory[ListBuffer] {
-  def fromIterable[B](coll: collection.Iterable[B]): ListBuffer[B] = new ListBuffer[B] ++= coll
+
+  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
+
+  def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
+
 }

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -1,0 +1,42 @@
+package strawman
+
+package collection.test
+
+import org.junit.Test
+import strawman.collection.{CanBuild, Iterable}
+import strawman.collection.mutable.Builder
+import strawman.collection._
+
+import scala.{Either, Int, Left, None, Option, Right, Some, Unit}
+import java.lang.String
+
+class TraverseTest {
+
+  def optionSequence[C[X] <: Iterable[X], A](xs: C[Option[A]])(implicit canBuild: CanBuild[A, C[A]]): Option[C[A]] =
+    xs.foldLeft[Option[Builder[A, C[A]]]](Some(canBuild.apply())) {
+      case (Some(builder), Some(a)) => Some(builder += a)
+      case _ => None
+    }.map(_.result)
+
+  def eitherSequence[C[X] <: Iterable[X], A, B](xs: C[Either[A, B]])(implicit canBuild: CanBuild[B, C[B]]): Either[A, C[B]] =
+    xs.foldLeft[Either[A, Builder[B, C[B]]]](Right(canBuild.apply())) {
+      case (Right(builder), Right(b)) => Right(builder += b)
+      case (Left(a)       ,        _) => Left(a)
+      case (_             ,  Left(a)) => Left(a)
+    }.map(_.result)
+
+//  @Test
+  def traverseTest: Unit = {
+
+    val xs1 = immutable.List(Some(1), None, Some(2))
+    optionSequence(xs1)(immutable.List.canBuild[Int]) // TODO Remove explicit CanBuild parameter after https://issues.scala-lang.org/browse/SI-10081 is fixed?
+
+    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
+    optionSequence(xs2)(immutable.TreeSet.canBuild[String])
+
+    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
+    eitherSequence(xs3)(mutable.ListBuffer.canBuild[String])
+
+  }
+
+}

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -3,7 +3,7 @@ package strawman
 package collection.test
 
 import org.junit.Test
-import strawman.collection.{CanBuild, Iterable}
+import strawman.collection.Iterable
 import strawman.collection.mutable.Builder
 import strawman.collection._
 
@@ -12,13 +12,13 @@ import java.lang.String
 
 class TraverseTest {
 
-  def optionSequence[C[X] <: Iterable[X], A](xs: C[Option[A]])(implicit canBuild: CanBuild[A, C[A]]): Option[C[A]] =
+  def optionSequence[C[X] <: Iterable[X], A](xs: C[Option[A]])(implicit canBuild: () => Builder[A, C[A]]): Option[C[A]] =
     xs.foldLeft[Option[Builder[A, C[A]]]](Some(canBuild.apply())) {
       case (Some(builder), Some(a)) => Some(builder += a)
       case _ => None
     }.map(_.result)
 
-  def eitherSequence[C[X] <: Iterable[X], A, B](xs: C[Either[A, B]])(implicit canBuild: CanBuild[B, C[B]]): Either[A, C[B]] =
+  def eitherSequence[C[X] <: Iterable[X], A, B](xs: C[Either[A, B]])(implicit canBuild: () => Builder[B, C[B]]): Either[A, C[B]] =
     xs.foldLeft[Either[A, Builder[B, C[B]]]](Right(canBuild.apply())) {
       case (Right(builder), Right(b)) => Right(builder += b)
       case (Left(a)       ,        _) => Left(a)


### PR DESCRIPTION
Also, define an implicit builder factory `() => Builder[A, C[A]]` that can be used by end-users to retrieve a factory for a given collection type. For instance we can now write `Future.sequence` (or equivalent) as follows:

~~~ scala
def futureSequence[A, C[X] <: Iterable[X]](xs: C[Future[A]])(implicit canBuild: () => Builder[A, C[A]]): Future[C[A]] =
  xs.foldLeft(Future.successful(canBuild.apply())) { (fr, fa) =>
    fr.zipWith(fa)(_ += _)
  }.map(_.result)
~~~

Note that I duplicated the collection factories: `IterableFactory` works only for collection types of kind `* -> *`, `OrderingGuidedFactory` works for the same kind of collection types but requires an implicit `Ordering`, `MapFactory` works for collection types of kind `* -> * -> *`, and `SortedMapFactory` is the same but requires an implicit `Ordering` for keys. I don’t think this duplication is a problem. Trying to abstract over these difference would not be worth it, in my opinion.