### PR TITLE
Attempt at basic NonEmptyLists

### DIFF
--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -4,8 +4,9 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.Nothing
 import scala.Predef.???
 import strawman.collection
-import strawman.collection.{IterableFactories, IterableOnce, LinearSeq, SeqLike}
+import strawman.collection.{IterableFactories, IterableOnce, LinearSeq, SeqLike, View}
 import strawman.collection.mutable.{Buildable, Builder, ListBuffer}
+import scala.{Unit, Option, Int, None, Some}
 
 
 /** Concrete collection type: List */
@@ -20,7 +21,7 @@ sealed trait List[+A]
   protected[this] def newBuilder = List.newBuilder
 
   /** Prepend element */
-  def :: [B >: A](elem: B): List[B] =  new ::(elem, this)
+  def :: [B >: A](elem: B): ::[B] =  new ::(elem, this)
 
   /** Prepend operation that avoids copying this list */
   def ++:[B >: A](prefix: List[B]): List[B] =
@@ -42,6 +43,27 @@ case class :: [+A](x: A, private[collection] var next: List[A @uncheckedVariance
   override def nonEmpty = true
   override def head = x
   override def tail = next
+
+  /** headOption not in strawman library, but worth pointing this out anyways */
+  /* override */ def headOption: Some[A] = Some(x)
+
+  override def ++:[B >: A](prefix: List[B]): ::[B] =
+    if (prefix.isEmpty) this
+    else prefix.head :: (prefix.tail ++: this)
+
+  override def ++[B >: A](xs: IterableOnce[B]): ::[B] = xs match {
+    case Nil => this
+    case xs: List[B] => head :: (tail ++: xs)
+    case xs => head :: (tail ++ xs)
+  }
+
+  override def map[B](f: A => B): ::[B] = f(head) :: tail.map(f)
+
+  override def reverse: ::[A] = tail.foldLeft(head :: Nil)((as, a) => a :: as)
+
+  override def className = "::"
+
+  def zip[B](xs: ::[B]): ::[(A @uncheckedVariance, B)] = (head, xs.head) :: tail.zip(xs.tail)
 }
 
 case object Nil extends List[Nothing] {
@@ -49,6 +71,14 @@ case object Nil extends List[Nothing] {
   override def nonEmpty = false
   override def head = ???
   override def tail = ???
+
+  // Similarly if we wanted to, we could override many methods here, keeping type information
+  // For example:
+  // def ++(nil: Nil.type): Nil.type = this
+  // def map[B](f: _ => B): Nil.type = Nil
+  // def filter(f: _ => Boolean): Nil.type = Nil
+  // etc..
+
 }
 
 object List extends IterableFactories[List] {
@@ -60,4 +90,61 @@ object List extends IterableFactories[List] {
 
   def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
+
 }
+
+// Can't actually extend IterableFactories[::], since it's impossible to create a builder
+object :: /* extends IterableFactories[::] */{
+  def apply[A](x: A, xs: A*): ::[A] = new ::(x, List(xs: _*))
+  def fill[A](n: Int)(elem: => A): ::[A] = if(n > 0) elem :: List.fill(n - 1)(elem) else ???
+
+//  Not sure what to do with these methods...
+  def newBuilder[A]: Builder[A, ::[A]] = ???
+}
+
+
+// Possible alternative...
+
+// Doesn't actually compile because NonEmptyListOption doesn't extend Iterable,
+// but maybe if Iterable were a typeclass this could work..
+
+//package object immutable {
+//  type NonEmptyListOption[+A] = Option[::[A]]
+//}
+
+//object :: extends IterableFactories[NonEmptyListOption] {
+//  override def empty[A]: Option[::[A]] = None
+//
+//  override def apply[A](xs: A*): Option[::[A]] = xs match {
+//    case xs if xs.nonEmpty => Option(new ::(xs.head, List(xs.tail: _*)))
+//    case _ => None
+//  }
+//
+//  override def fill[A](n: Int)(elem: => A): Option[::[A]] =
+//    if(n > 0) Some(elem :: List.fill(n - 1)(elem)) else None
+//
+//  def newBuilder[A]: Builder[A, Option[::[A]]] = new Builder[A, Option[::[A]]] {
+//    /** build NonEmptyList in reverse */
+//    var tempReverse: Option[::[A]] = None
+//
+//    override def +=(x: A): Unit = tempReverse match {
+//      case Some(nonEmpty) => Some(x :: nonEmpty)
+//      case None => Some(x :: List.empty)
+//    }
+//
+//    override def clear(): Unit = {
+//      tempReverse = None
+//    }
+//
+//    override def result: Option[::[A]] = tempReverse.map(_.reverse)
+//  }
+//
+//  def fromIterable[B](coll: collection.Iterable[B]): Option[::[B]] = {
+//    val iterator = coll.iterator()
+//    if (iterator.hasNext) Option(iterator.next() :: iterator.foldRight(List.empty[B])((b, bs) => b :: bs))
+//    else None
+//  }
+//}
+
+
+

--- a/src/main/scala/strawman/collection/package.scala
+++ b/src/main/scala/strawman/collection/package.scala
@@ -114,6 +114,9 @@ package object collection extends LowPriority {
     def toClassic: scala.collection.Seq[A] =
       new scala.collection.mutable.ArrayBuffer ++= s.iterator().toClassic
   }
+
+  type NonEmptyList[+A] = strawman.collection.immutable.::[A]
+  val NonEmptyList = strawman.collection.immutable.::
 }
 
 class LowPriority {

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -349,6 +349,34 @@ class StrawmanTest {
     val xs12: immutable.BitSet = xs11
   }
 
+  def nonEmptyLists(): Unit = {
+    import scala.Some
+
+    println("------- NonEmptyLists (start)")
+    val nonEmpty = NonEmptyList(1,2,3)
+    val list = List(1,2,3)
+
+
+    println(nonEmpty.head)
+    println(nonEmpty.headOption: Some[Int])
+    println(nonEmpty.tail)
+    println(nonEmpty.zip(NonEmptyList(67)))
+    println(nonEmpty ++ Nil: NonEmptyList[Int])
+    println(nonEmpty ++ nonEmpty: NonEmptyList[Int])
+    println(nonEmpty ++ list: NonEmptyList[Int])
+    println(nonEmpty.map(_.toString): NonEmptyList[String])
+
+    println(nonEmpty.reverse: NonEmptyList[Int])
+    println(9 :: nonEmpty : NonEmptyList[Int])
+    println(9 :: list: NonEmptyList[Int])
+    println(9 :: Nil: NonEmptyList[Int])
+
+    println(NonEmptyList.fill(4)(77))
+
+
+    println("------- NonEmptyLists (end)")
+  }
+
   @Test
   def mainTest: Unit = {
     val ints = List(1, 2, 3)
@@ -363,5 +391,6 @@ class StrawmanTest {
     arrayOps(Array(1, 2, 3))
     lazyListOps(LazyList(1, 2, 3))
     equality()
+    nonEmptyLists()
   }
 }


### PR DESCRIPTION
* Overrides many methods in `::[A]` and `List[A]` to keep type information when doing size-preserving transformations
* Add a `NonEmptyList` factory, which cannot conform to `IterableFactories[NonEmptyList]` because it is impossible to construct a `Builder[A, NonEmptyList[A]]`, as that trait requires a `clear()` method, returning the underlying collection to an empty state

Really hopeful that some form of NonEmpty collections can make it into the next redesign in one way or an other :)