### PR TITLE
Fix minor ArrayBufferView type inference problem

### DIFF
--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -42,7 +42,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def length = end
   override def knownSize = length
 
-  override def view = new ArrayBufferView(array, end)
+  override def view: ArrayBufferView[A] = new ArrayBufferView(array, end)
 
   def iterator() = view.iterator()
 


### PR DESCRIPTION
Before:

```scala
scala> strawman.collection.mutable.ArrayBuffer(1,2,3,4,5).view
res0: strawman.collection.mutable.ArrayBufferView[Nothing] = ArrayBufferView(1, 2, 3, 4, 5)
```

After:

```scala
scala> strawman.collection.mutable.ArrayBuffer(1,2,3,4,5).view
res0: strawman.collection.mutable.ArrayBufferView[Int] = ArrayBufferView(1, 2, 3, 4, 5)
```
