### PR TITLE
Flatten and interaction between flatMap and Options

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -285,6 +285,9 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** Flatmap */
   def flatMap[B](f: A => IterableOnce[B]): CC[B] = fromIterable(View.FlatMap(coll, f))
 
+  def flatten[B](implicit ev: A => IterableOnce[B]): CC[B] =
+    fromIterable(View.FlatMap(coll, ev))
+
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
     *  the element types of the two operands.

--- a/src/main/scala/strawman/collection/package.scala
+++ b/src/main/scala/strawman/collection/package.scala
@@ -1,6 +1,6 @@
 package strawman
 
-import scala.{Any, AnyVal, Array, Char, IllegalArgumentException, IndexOutOfBoundsException, Int, NoSuchElementException, Unit, UnsupportedOperationException}
+import scala.{Any, AnyVal, Array, Boolean, Char, IllegalArgumentException, IndexOutOfBoundsException, Int, NoSuchElementException, Unit, UnsupportedOperationException}
 import scala.Predef.String
 import scala.reflect.ClassTag
 
@@ -70,6 +70,13 @@ package object collection extends LowPriority {
       }: scala.PartialFunction[T, String]) mkString " | "
     }
   }
+
+  implicit def optionToIterableOnce[A](maybeA: scala.Option[A]): IterableOnce[A] =
+     new Iterator[A] {
+       private var _hasNext = maybeA.nonEmpty
+       def next(): A = if (_hasNext) { _hasNext = false; maybeA.get } else Iterator.empty.next()
+       def hasNext: Boolean = _hasNext
+     }
 
 }
 

--- a/src/test/scala/strawman/collection/test/FlattenTest.scala
+++ b/src/test/scala/strawman/collection/test/FlattenTest.scala
@@ -1,0 +1,26 @@
+package strawman
+package collection.test
+
+import org.junit.Test
+import strawman.collection.Iterable
+import strawman.collection.immutable.{List, HashSet}
+
+import scala.{Int, Some, Unit}
+import scala.Predef.$conforms
+
+class FlattenTest {
+
+  def f(xs: Iterable[Iterable[Int]], ys: Iterable[Int]): Unit = {
+    xs.flatten                   // Iterable[Iterable[Int]] => Iterable[Int]
+    ys.flatMap(y => Some(y))     // Iterable[Option[Int]]   => Iterable[Int]
+    ys.map(y => Some(y)).flatten // Iterable[Option[Int]]   => Iterable[Int]
+  }
+
+//  @Test
+  def flattenTest: Unit = {
+
+    f(List(HashSet(1, 2, 3)), List(1, 2, 3))
+
+  }
+
+}

--- a/src/test/scala/strawman/collection/test/FlattenTest.scala
+++ b/src/test/scala/strawman/collection/test/FlattenTest.scala
@@ -2,25 +2,22 @@ package strawman
 package collection.test
 
 import org.junit.Test
-import strawman.collection.Iterable
-import strawman.collection.immutable.{List, HashSet}
+import strawman.collection.Seq
+import strawman.collection.immutable.{ImmutableArray, List}
 
 import scala.{Int, Some, Unit}
-import scala.Predef.$conforms
+import scala.Predef.{$conforms, assert}
 
 class FlattenTest {
 
-  def f(xs: Iterable[Iterable[Int]], ys: Iterable[Int]): Unit = {
-    xs.flatten                   // Iterable[Iterable[Int]] => Iterable[Int]
-    ys.flatMap(y => Some(y))     // Iterable[Option[Int]]   => Iterable[Int]
-    ys.map(y => Some(y)).flatten // Iterable[Option[Int]]   => Iterable[Int]
+  def f(xs: Seq[Seq[Int]], ys: Seq[Int]): Unit = {
+    assert(xs.flatten == ys)
+    assert(ys.flatMap(y => Some(y)) == ys.map(y => Some(y)).flatten)
   }
 
-//  @Test
+  @Test
   def flattenTest: Unit = {
-
-    f(List(HashSet(1, 2, 3)), List(1, 2, 3))
-
+    f(List(ImmutableArray(1, 2, 3)), List(1, 2, 3))
   }
 
 }


### PR DESCRIPTION
This is based on szeiger:wip/constrained-collections2. I only added the [last commit](https://github.com/scala/collection-strawman/pull/48/commits/960ce6a17d226c2bbe5344e0e81bc7e29f9455ce) to check that `flatten` would work with `Iterable[Option[?]]` values. This requires `flatten` to take an implicit view parameter and to define an implicit conversion from `Option[A]` to `Iterable[A]` (as it is currently the case in 2.12).

I also checked that it was possible to use `flatMap` with a function returning an `Option[?]` (instead of the expected `IterableOnce[?]`), which is a common pattern I think.