### PR TITLE
ArraySeq (f.k.a. Spandex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For more information, see the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [ ] `EqSet`
 - [x] `BitSet`
 - [x] `View`
+- [x] `ArraySeq` (new immutable indexed sequence)
 
 ## Implemented operations (on the relevant collection types)
 
@@ -216,10 +217,11 @@ For more information, see the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 - [x] `combinations`
 - [x] `updated`
-- [x] `prepend`
-- [x] `append`
+- [x] `+:` / `prepend`
+- [x] `:+` / `append`
 - [x] `++` / `concat` / `union`
 - [x] `++:` / `prependAll`
+- [x] `:++` / `appendAll`
 - [x] `flatMap`
 - [x] `grouped`
 - [x] `keys` / `keySet` / `keysIterator`

--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -1,10 +1,10 @@
 package bench
 
-import strawman.collection.immutable.{LazyList, List, Range, NumericRange, Vector}
+import strawman.collection.immutable.{LazyList, List, Range, NumericRange, Vector, ImmutableArray, ArraySeq}
 import strawman.collection.mutable.{ArrayBuffer, ListBuffer}
 
 import scala.{Any, AnyRef, App, Int, Long, Seq, StringContext}
-import scala.Predef.{ArrowAssoc, println, intWrapper}
+import scala.Predef.{ArrowAssoc, intWrapper}
 import scala.compat.Platform
 import java.lang.Runtime
 import java.nio.file.{Files, Paths}
@@ -48,11 +48,12 @@ object MemoryFootprint extends App {
       "TreeSet"       -> benchmark(n => strawman.collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
       "ArrayBuffer"   -> benchmark(ArrayBuffer.fill(_)(obj)),
       "ListBuffer"    -> benchmark(ListBuffer.fill(_)(obj)),
-      "ImmutableArray" -> benchmark(strawman.collection.immutable.ImmutableArray.fill(_)(obj)),
-      "ImmutableArray (primitive)" -> benchmark(strawman.collection.immutable.ImmutableArray.fill(_)(123)),
+      "ImmutableArray" -> benchmark(ImmutableArray.fill(_)(obj)),
+      "scala.Array"   -> benchmark(scala.Array.fill(_)(obj)),
       "Range"         -> benchmark(Range(0, _)),
-      "NumericRange"  -> benchmark(NumericRange(0, _, 1))
-    )
+      "NumericRange"  -> benchmark(NumericRange(0, _, 1)),
+      "ArraySeq"      -> benchmark(ArraySeq.fill(_)(obj))
+  )
 
   // We use a format similar to the one used by JMH so that
   // our charts can be generated in the same way

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,8 +17,7 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 15)
 @State(Scope.Benchmark)
 class ArrayBaselineBenchmark {
-
-  @Param(scala.Array("39", "282", "73121", "7312102"))
+  @Param(scala.Array("39", "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   @Param(scala.Array("39"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArraySeq_AlwaysBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArraySeq_AlwaysBenchmark.scala
@@ -3,12 +3,11 @@ package collection
 package immutable
 
 import java.util.concurrent.TimeUnit
-
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
-import scala.{Any, AnyRef, Int, Long, Unit, math}
-import scala.Predef.intWrapper
+import scala.{math, Any, AnyRef, Int, Long, Unit}
+import scala.Predef.{intWrapper, longWrapper}
+import strawman.collection.immutable.ArraySeq.AutoTrimming
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -16,17 +15,19 @@ import scala.Predef.intWrapper
 @Warmup(iterations = 12)
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
-class LazyListBenchmark {
+class ArraySeq_AlwaysBenchmark {
   //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
   @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
-  var xs: LazyList[Long] = _
-  var ys: LazyList[Long] = _
-  var zs: LazyList[Long] = _
-  var zipped: LazyList[(Long, Long)] = _
+  val random = new scala.util.Random(19740115L)
+  var xs: ArraySeq[Long] = _
+  var ys: ArraySeq[Long] = _
+  var zs: ArraySeq[Long] = _
+  var zipped: ArraySeq[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
-  def fresh(n: Int) = LazyList((1 to n).map(_.toLong): _*)
+  def fresh(n: Int) = ArraySeq((1 to n).map(_.toLong): _*).withAutoTrimming(AutoTrimming.Always)
+  def freshBuilder() = ArraySeq.newBuilder[Long](autoTrimming = AutoTrimming.Always)
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
@@ -36,7 +37,7 @@ class LazyListBenchmark {
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+      randomIndices = scala.Array.fill(1000)(random.nextInt(size))
     }
   }
 
@@ -46,12 +47,55 @@ class LazyListBenchmark {
   @Benchmark
   def create_build(bh: Blackhole): Unit = {
     var i = 0L
-    val builder = xs.iterableFactory.newBuilder[Long]()
+    val builder = freshBuilder()
+    builder.sizeHint(size)
     while (i < size) {
       builder += i
       i += 1
     }
     bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def create_buildRange(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size * 10)
+    while (i < size) {
+      builder ++= xs.iterableFactory.range(i - 10, i)
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def expand_foldAppend(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        //bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDouble(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDoubleForeach(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    ys.foreach(bh.consume)
   }
 
   @Benchmark
@@ -68,10 +112,11 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prepend(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys = i #:: ys
+      ys = i +: ys
       i += 1
     }
     bh.consume(ys)
@@ -80,10 +125,11 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependTail(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys = i #:: ys
+      ys = i +: ys
       i += 1
       ys = ys.tail
     }
@@ -93,6 +139,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_append(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -105,6 +152,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_appendInit(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -118,11 +166,12 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAppend(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
       if ((i & 1) == 1) ys = ys :+ i
-      else ys = i #:: ys
+      else ys = i +: ys
       i += 1
     }
     bh.consume(ys)
@@ -131,6 +180,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -143,6 +193,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_appendAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -155,6 +206,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -166,7 +218,10 @@ class LazyListBenchmark {
   }
 
   @Benchmark
-  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+  def expand_padTo(bh: Blackhole): Unit = {
+    xs.reset()
+    bh.consume(xs.padTo(size * 2, 42L))
+  }
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -198,17 +253,17 @@ class LazyListBenchmark {
   }
 
   @Benchmark
-  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0L) {
     case (acc, n) =>
       bh.consume(n)
-      acc + 1
+      acc + n
   })
 
   @Benchmark
-  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0L) {
     case (n, acc) =>
       bh.consume(n)
-      acc - 1
+      acc - n
   })
 
   @Benchmark
@@ -250,7 +305,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def transform_updateLast(bh: Blackhole): Unit = {
-    var i = 0
+    var i = 0L
     while (i < 1000) {
       bh.consume(xs.updated(size - 1, i))
       i += 1
@@ -259,12 +314,28 @@ class LazyListBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(1000)
-  def transform_updateRandom(bh: Blackhole): Unit = {
+  def transform_updateForeach(bh: Blackhole): Unit = {
+    var ys = xs
     var i = 0
     while (i < 1000) {
-      bh.consume(xs.updated(randomIndices(i), i))
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
       i += 1
     }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def transform_updateRandom(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0
+    while (i < 1000) {
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
+      i += 1
+    }
+    bh.consume(ys)
   }
 
   @Benchmark
@@ -284,35 +355,35 @@ class LazyListBenchmark {
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
   @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2L))
 
   @Benchmark
-  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map((n: Long) => n + 1L))
 
   @Benchmark
-  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5L == 0L => n })
 
   @Benchmark
   def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
-    case n if n % 3 == 0 => List(n, -n)
-    case n if n % 5 == 0 => List(n)
+    case n if n % 3L == 0L => List(n, -n)
+    case n if n == size => List.range(1L, n)
     case _ => Nil
   })
 
   @Benchmark
-  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5L == 0L))
 
   @Benchmark
   @OperationsPerInvocation(100)
   def transform_span(bh: Blackhole): Unit = {
     var i = 0
     while (i < 100) {
-      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i).toLong)
       bh.consume(xs1)
       bh.consume(xs2)
       i += 1
     }
-  }
+}
 
   @Benchmark
   def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
@@ -337,7 +408,7 @@ class LazyListBenchmark {
 
   @Benchmark
   def transform_groupBy(bh: Blackhole): Unit = {
-    val result = xs.groupBy(_ % 5)
+    val result = xs.groupBy(_ % 5L)
     bh.consume(result)
   }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArraySeq_NeverBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArraySeq_NeverBenchmark.scala
@@ -6,9 +6,9 @@ import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-
-import scala.{Any, AnyRef, Int, Long, Unit, math}
-import scala.Predef.intWrapper
+import scala.{math, Any, AnyRef, Int, Long, Unit}
+import scala.Predef.{intWrapper, longWrapper}
+import strawman.collection.immutable.ArraySeq.AutoTrimming
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -16,17 +16,19 @@ import scala.Predef.intWrapper
 @Warmup(iterations = 12)
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
-class LazyListBenchmark {
+class ArraySeq_NeverBenchmark {
   //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
   @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
-  var xs: LazyList[Long] = _
-  var ys: LazyList[Long] = _
-  var zs: LazyList[Long] = _
-  var zipped: LazyList[(Long, Long)] = _
+  val random = new scala.util.Random(19740115L)
+  var xs: ArraySeq[Long] = _
+  var ys: ArraySeq[Long] = _
+  var zs: ArraySeq[Long] = _
+  var zipped: ArraySeq[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
-  def fresh(n: Int) = LazyList((1 to n).map(_.toLong): _*)
+  def fresh(n: Int) = ArraySeq((1 to n).map(_.toLong): _*).withAutoTrimming(AutoTrimming.Never)
+  def freshBuilder() = ArraySeq.newBuilder[Long](autoTrimming = AutoTrimming.Never)
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
@@ -36,7 +38,7 @@ class LazyListBenchmark {
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+      randomIndices = scala.Array.fill(1000)(random.nextInt(size))
     }
   }
 
@@ -46,12 +48,55 @@ class LazyListBenchmark {
   @Benchmark
   def create_build(bh: Blackhole): Unit = {
     var i = 0L
-    val builder = xs.iterableFactory.newBuilder[Long]()
+    val builder = freshBuilder()
+    builder.sizeHint(size)
     while (i < size) {
       builder += i
       i += 1
     }
     bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def create_buildRange(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size * 10)
+    while (i < size) {
+      builder ++= xs.iterableFactory.range(i - 10, i)
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def expand_foldAppend(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        //bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDouble(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDoubleForeach(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    ys.foreach(bh.consume)
   }
 
   @Benchmark
@@ -68,10 +113,11 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prepend(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys = i #:: ys
+      ys = i +: ys
       i += 1
     }
     bh.consume(ys)
@@ -80,10 +126,11 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependTail(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys = i #:: ys
+      ys = i +: ys
       i += 1
       ys = ys.tail
     }
@@ -93,6 +140,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_append(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -105,6 +153,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_appendInit(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -118,11 +167,12 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAppend(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
       if ((i & 1) == 1) ys = ys :+ i
-      else ys = i #:: ys
+      else ys = i +: ys
       i += 1
     }
     bh.consume(ys)
@@ -131,6 +181,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -143,6 +194,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_appendAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -155,6 +207,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+    xs.reset()
     var ys = xs
     var i = 0L
     while (i < 1000) {
@@ -166,7 +219,10 @@ class LazyListBenchmark {
   }
 
   @Benchmark
-  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+  def expand_padTo(bh: Blackhole): Unit = {
+    xs.reset()
+    bh.consume(xs.padTo(size * 2, 42L))
+  }
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -198,17 +254,17 @@ class LazyListBenchmark {
   }
 
   @Benchmark
-  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0L) {
     case (acc, n) =>
       bh.consume(n)
-      acc + 1
+      acc + n
   })
 
   @Benchmark
-  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0L) {
     case (n, acc) =>
       bh.consume(n)
-      acc - 1
+      acc - n
   })
 
   @Benchmark
@@ -250,7 +306,7 @@ class LazyListBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def transform_updateLast(bh: Blackhole): Unit = {
-    var i = 0
+    var i = 0L
     while (i < 1000) {
       bh.consume(xs.updated(size - 1, i))
       i += 1
@@ -259,12 +315,28 @@ class LazyListBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(1000)
-  def transform_updateRandom(bh: Blackhole): Unit = {
+  def transform_updateForeach(bh: Blackhole): Unit = {
+    var ys = xs
     var i = 0
     while (i < 1000) {
-      bh.consume(xs.updated(randomIndices(i), i))
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
       i += 1
     }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def transform_updateRandom(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0
+    while (i < 1000) {
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
+      i += 1
+    }
+    bh.consume(ys)
   }
 
   @Benchmark
@@ -284,30 +356,30 @@ class LazyListBenchmark {
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
   @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2L))
 
   @Benchmark
-  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map((n: Long) => n + 1L))
 
   @Benchmark
-  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5L == 0L => n })
 
   @Benchmark
   def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
-    case n if n % 3 == 0 => List(n, -n)
-    case n if n % 5 == 0 => List(n)
+    case n if n % 3L == 0L => List(n, -n)
+    case n if n == size => List.range(1L, n)
     case _ => Nil
   })
 
   @Benchmark
-  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5L == 0L))
 
   @Benchmark
   @OperationsPerInvocation(100)
   def transform_span(bh: Blackhole): Unit = {
     var i = 0
     while (i < 100) {
-      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i).toLong)
       bh.consume(xs1)
       bh.consume(xs2)
       i += 1
@@ -337,7 +409,7 @@ class LazyListBenchmark {
 
   @Benchmark
   def transform_groupBy(bh: Blackhole): Unit = {
-    val result = xs.groupBy(_ % 5)
+    val result = xs.groupBy(_ % 5L)
     bh.consume(result)
   }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,8 +17,7 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 15)
 @State(Scope.Benchmark)
 class ArrayViewBenchmark {
-
-  @Param(scala.Array("39", "282", "73121", "7312102"))
+  @Param(scala.Array("39", "282", "4096", "131070", "7312102"))
   var size: Int = _
 
   @Param(scala.Array("39"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,14 +17,17 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class HashSetBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
+  val random = new scala.util.Random(19740115L)
   var xs: HashSet[Long] = _
   var zs: HashSet[Long] = _
   var zipped: HashSet[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
   def fresh(n: Int) = HashSet((1 to n).map(_.toLong): _*)
+  def freshBuilder() = HashSet.newBuilder[Long]()
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
@@ -30,12 +35,24 @@ class HashSetBenchmark {
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+      randomIndices = scala.Array.fill(1000)(random.nextInt(size))
     }
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size)
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -82,17 +99,17 @@ class HashSetBenchmark {
   }
 
   @Benchmark
-  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0L) {
     case (acc, n) =>
       bh.consume(n)
-      acc + 1
+      acc + n
   })
 
   @Benchmark
-  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0L) {
     case (n, acc) =>
       bh.consume(n)
-      acc - 1
+      acc - n
   })
   @Benchmark
   def access_tail(bh: Blackhole): Unit = bh.consume(xs.tail)
@@ -121,14 +138,27 @@ class HashSetBenchmark {
   }
 
   @Benchmark
-  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1L))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5L == 0L => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3L == 0L => List(n, -n)
+    case n if n == size => List.range(1L, n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5L == 0L))
 
   @Benchmark
   @OperationsPerInvocation(100)
   def transform_span(bh: Blackhole): Unit = {
     var i = 0
     while (i < 100) {
-      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i).toLong)
       bh.consume(xs1)
       bh.consume(xs2)
       i += 1

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -6,7 +8,7 @@ import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit, math}
-import scala.Predef.intWrapper
+import scala.Predef.{intWrapper, longWrapper}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -15,27 +17,98 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ImmutableArrayBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
+  val random = new scala.util.Random(19740115L)
   var xs: ImmutableArray[Long] = _
+  var ys: ImmutableArray[Long] = _
   var zs: ImmutableArray[Long] = _
   var zipped: ImmutableArray[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
   def fresh(n: Int) = ImmutableArray((1 to n).map(_.toLong): _*)
+  def freshBuilder() = ImmutableArray.newBuilder[Long]()
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+      randomIndices = scala.Array.fill(1000)(random.nextInt(size))
     }
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size)
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def create_buildRange(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size * 10)
+    while (i < size) {
+      builder ++= xs.iterableFactory.range(i - 10, i)
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def expand_foldAppend(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        //bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDouble(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDoubleForeach(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -138,7 +211,7 @@ class ImmutableArrayBenchmark {
   }
 
   @Benchmark
-  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42L))
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -170,17 +243,17 @@ class ImmutableArrayBenchmark {
   }
 
   @Benchmark
-  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0L) {
     case (acc, n) =>
       bh.consume(n)
-      acc + 1
+      acc + n
   })
 
   @Benchmark
-  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0L) {
     case (n, acc) =>
       bh.consume(n)
-      acc - 1
+      acc - n
   })
 
   @Benchmark
@@ -222,7 +295,7 @@ class ImmutableArrayBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def transform_updateLast(bh: Blackhole): Unit = {
-    var i = 0
+    var i = 0L
     while (i < 1000) {
       bh.consume(xs.updated(size - 1, i))
       i += 1
@@ -231,12 +304,28 @@ class ImmutableArrayBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(1000)
-  def transform_updateRandom(bh: Blackhole): Unit = {
+  def transform_updateForeach(bh: Blackhole): Unit = {
+    var ys = xs
     var i = 0
     while (i < 1000) {
-      bh.consume(xs.updated(randomIndices(i), i))
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
       i += 1
     }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def transform_updateRandom(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0
+    while (i < 1000) {
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
+      i += 1
+    }
+    bh.consume(ys)
   }
 
   @Benchmark
@@ -256,17 +345,30 @@ class ImmutableArrayBenchmark {
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
   @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2L))
 
   @Benchmark
-  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map((n: Long) => n + 1L))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5L == 0L => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3L == 0L => List(n, -n)
+    case n if n == size => List.range(1L, n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5L == 0L))
 
   @Benchmark
   @OperationsPerInvocation(100)
   def transform_span(bh: Blackhole): Unit = {
     var i = 0
     while (i < 100) {
-      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i).toLong)
       bh.consume(xs1)
       bh.consume(xs2)
       i += 1
@@ -296,7 +398,7 @@ class ImmutableArrayBenchmark {
 
   @Benchmark
   def transform_groupBy(bh: Blackhole): Unit = {
-    val result = xs.groupBy(_ % 5)
+    val result = xs.groupBy(_ % 5L)
     bh.consume(result)
   }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,7 +17,8 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class NumericRangeBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: NumericRange[Int] = _
@@ -35,7 +38,18 @@ class NumericRangeBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.iterableFactory.newBuilder[Long]()
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -157,6 +171,19 @@ class NumericRangeBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,7 +17,8 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class RangeBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: Range = _
@@ -35,7 +38,18 @@ class RangeBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.iterableFactory.newBuilder[Long]()
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -157,6 +171,19 @@ class RangeBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,7 +17,8 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ScalaHashSetBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.collection.immutable.HashSet[Long] = _
@@ -35,7 +38,18 @@ class ScalaHashSetBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.companion.newBuilder[Long]
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -122,6 +136,19 @@ class ScalaHashSetBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => scala.List(n, -n)
+    case n if n % 5 == 0 => scala.List(n)
+    case _ => scala.Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,10 +17,12 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ScalaListBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.List[Long] = _
+  var ys: scala.List[Long] = _
   var zs: scala.List[Long] = _
   var zipped: scala.List[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -27,6 +31,8 @@ class ScalaListBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -35,7 +41,31 @@ class ScalaListBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.companion.newBuilder[Long]
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  val +: = scala.collection.+:
+  val :+ = scala.collection.:+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: scala.Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -257,6 +287,19 @@ class ScalaListBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => scala.List(n, -n)
+    case n if n % 5 == 0 => scala.List(n)
+    case _ => scala.Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,7 +17,8 @@ import scala.Predef.{intWrapper, tuple2ToZippedOps, $conforms}
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ScalaTreeSetBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.collection.immutable.TreeSet[Long] = _
@@ -35,7 +38,18 @@ class ScalaTreeSetBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.companion.newBuilder[Long]
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -122,6 +136,19 @@ class ScalaTreeSetBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => scala.List(n, -n)
+    case n if n % 5 == 0 => scala.List(n)
+    case _ => scala.Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -15,10 +17,12 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ScalaVectorBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.Vector[Long] = _
+  var ys: scala.Vector[Long] = _
   var zs: scala.Vector[Long] = _
   var zipped: scala.Vector[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -27,6 +31,8 @@ class ScalaVectorBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -35,7 +41,31 @@ class ScalaVectorBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.companion.newBuilder[Long]
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  val +: = scala.collection.+:
+  val :+ = scala.collection.:+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: scala.Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -257,6 +287,19 @@ class ScalaVectorBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => scala.List(n, -n)
+    case n if n % 5 == 0 => scala.List(n)
+    case _ => scala.Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -1,11 +1,13 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import scala.{Any, AnyRef, Int, Long, Unit, math}
+import scala.{Any, AnyRef, Int, Long, Ordering, Unit, math}
 import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
@@ -15,7 +17,8 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class TreeSetBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: TreeSet[Long] = _
@@ -35,7 +38,18 @@ class TreeSetBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.iterableFactory.newBuilder[Long]()
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -122,6 +136,21 @@ class TreeSetBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  /*
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect[Long] { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+  */
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.immutable
+package strawman
+package collection
+package immutable
 
 import java.util.concurrent.TimeUnit
 
@@ -6,7 +8,7 @@ import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit, math}
-import scala.Predef.intWrapper
+import scala.Predef.{intWrapper, longWrapper}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -15,27 +17,98 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class VectorBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
+  val random = new scala.util.Random(19740115L)
   var xs: Vector[Long] = _
+  var ys: Vector[Long] = _
   var zs: Vector[Long] = _
   var zipped: Vector[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
   def fresh(n: Int) = Vector((1 to n).map(_.toLong): _*)
+  def freshBuilder() = Vector.newBuilder[Long]()
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+      randomIndices = scala.Array.fill(1000)(random.nextInt(size))
     }
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size)
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def create_buildRange(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = freshBuilder()
+    builder.sizeHint(size * 10)
+    while (i < size) {
+      builder ++= xs.iterableFactory.range(i - 10, i)
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def expand_foldAppend(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        //bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDouble(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_foldAppendDoubleForeach(bh: Blackhole): Unit = {
+    val ys = (1L to size).foldLeft(xs.slice(0, 0)) {
+      case (acc, i) =>
+        bh.consume(acc :+ 42L)
+        acc :+ i
+    }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -138,7 +211,7 @@ class VectorBenchmark {
   }
 
   @Benchmark
-  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+  def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42L))
 
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
@@ -170,17 +243,17 @@ class VectorBenchmark {
   }
 
   @Benchmark
-  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0L) {
     case (acc, n) =>
       bh.consume(n)
-      acc + 1
+      acc + n
   })
 
   @Benchmark
-  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0L) {
     case (n, acc) =>
       bh.consume(n)
-      acc - 1
+      acc - n
   })
 
   @Benchmark
@@ -222,7 +295,7 @@ class VectorBenchmark {
   @Benchmark
   @OperationsPerInvocation(1000)
   def transform_updateLast(bh: Blackhole): Unit = {
-    var i = 0
+    var i = 0L
     while (i < 1000) {
       bh.consume(xs.updated(size - 1, i))
       i += 1
@@ -231,12 +304,28 @@ class VectorBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(1000)
-  def transform_updateRandom(bh: Blackhole): Unit = {
+  def transform_updateForeach(bh: Blackhole): Unit = {
+    var ys = xs
     var i = 0
     while (i < 1000) {
-      bh.consume(xs.updated(randomIndices(i), i))
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
       i += 1
     }
+    ys.foreach(bh.consume)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def transform_updateRandom(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0
+    while (i < 1000) {
+      ys = ys.updated(randomIndices(i), i.toLong)
+      bh.consume(ys)
+      i += 1
+    }
+    bh.consume(ys)
   }
 
   @Benchmark
@@ -256,17 +345,30 @@ class VectorBenchmark {
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
   @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2L))
 
   @Benchmark
-  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map((n: Long) => n + 1L))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5L == 0L => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3L == 0L => List(n, -n)
+    case n if n == size => List.range(1L, n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5L == 0L))
 
   @Benchmark
   @OperationsPerInvocation(100)
   def transform_span(bh: Blackhole): Unit = {
     var i = 0
     while (i < 100) {
-      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i).toLong)
       bh.consume(xs1)
       bh.consume(xs2)
       i += 1
@@ -296,7 +398,7 @@ class VectorBenchmark {
 
   @Benchmark
   def transform_groupBy(bh: Blackhole): Unit = {
-    val result = xs.groupBy(_ % 5)
+    val result = xs.groupBy(_ % 5L)
     bh.consume(result)
   }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.mutable
+package strawman
+package collection
+package mutable
 
 import java.util.concurrent.TimeUnit
 
@@ -7,6 +9,7 @@ import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit, math}
 import scala.Predef.intWrapper
+import strawman.collection.immutable.{List, Nil}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -15,10 +18,12 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ArrayBufferBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: ArrayBuffer[Long] = _
+  var ys: ArrayBuffer[Long] = _
   var zs: ArrayBuffer[Long] = _
   var zipped: ArrayBuffer[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -27,6 +32,8 @@ class ArrayBufferBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -35,7 +42,29 @@ class ArrayBufferBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.iterableFactory.newBuilder[Long]()
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -260,6 +289,19 @@ class ArrayBufferBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filterInPlace(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.mutable
+package strawman
+package collection
+package mutable
 
 import java.util.concurrent.TimeUnit
 
@@ -7,6 +9,7 @@ import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit, math}
 import scala.Predef.intWrapper
+import strawman.collection.immutable.{List, Nil}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -15,10 +18,12 @@ import scala.Predef.intWrapper
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ListBufferBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: ListBuffer[Long] = _
+  var ys: ListBuffer[Long] = _
   var zs: ListBuffer[Long] = _
   var zipped: ListBuffer[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -27,6 +32,8 @@ class ListBufferBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -35,7 +42,29 @@ class ListBufferBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.iterableFactory.newBuilder[Long]()
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -260,6 +289,19 @@ class ListBufferBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filterInPlace(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
@@ -1,4 +1,6 @@
-package strawman.collection.mutable
+package strawman
+package collection
+package mutable
 
 import java.util.concurrent.TimeUnit
 
@@ -17,10 +19,12 @@ import scala.Predef.{intWrapper, longArrayOps}
 @Measurement(iterations = 12)
 @State(Scope.Benchmark)
 class ScalaArrayBenchmark {
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  //@Param(scala.Array("0", "1"/*, "2", "3", "4"*/, "7", "8"/*, "15"*/, "16", "17", "39"/*, "282", "4096", "131070", "7312102"*/))
+  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.Array[Long] = _
+  var ys: scala.Array[Long] = _
   var zs: scala.Array[Long] = _
   var zipped: scala.Array[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -29,6 +33,8 @@ class ScalaArrayBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    val xsl = xs.splitAt(size / 2)._1
+    ys = xsl ++ xsl.reverse
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -37,7 +43,31 @@ class ScalaArrayBenchmark {
   }
 
   @Benchmark
-  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+  def create_apply(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  def create_build(bh: Blackhole): Unit = {
+    var i = 0L
+    val builder = xs.companion.newBuilder[Long]
+    while (i < size) {
+      builder += i
+      i += 1
+    }
+    bh.consume(builder.result())
+  }
+
+  val +: = scala.collection.+:
+  val :+ = scala.collection.:+
+  @Benchmark
+  def extract_palindrome(bh: Blackhole): Unit = {
+    def isPalindrome[A](xs: scala.Seq[A]): Boolean = {
+      xs match {
+        case first +: middle :+ last => first == last && isPalindrome(middle)
+        case _ => true
+      }
+    }
+    bh.consume(isPalindrome(ys))
+  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -259,6 +289,19 @@ class ScalaArrayBenchmark {
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  def transform_collect(bh: Blackhole): Unit = bh.consume(xs.collect { case n if n % 5 == 0 => n })
+
+  @Benchmark
+  def transform_flatMap(bh: Blackhole): Unit = bh.consume(xs.flatMap {
+    case n if n % 3 == 0 => List(n, -n)
+    case n if n % 5 == 0 => List(n)
+    case _ => Nil
+  })
+
+  @Benchmark
+  def transform_filter(bh: Blackhole): Unit = bh.consume(xs.filter(_ % 5 == 0))
 
   @Benchmark
   @OperationsPerInvocation(100)

--- a/collections/src/main/scala/strawman/collection/immutable/ArraySeq.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ArraySeq.scala
@@ -1,0 +1,1454 @@
+package strawman
+package collection
+package immutable
+
+import java.util.concurrent.atomic.AtomicLong
+import scala.{`inline`, Any, AnyRef, Array, ArrayIndexOutOfBoundsException, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, Long, NoSuchElementException, PartialFunction, Serializable, SerialVersionUID, StringContext, Unit, UnsupportedOperationException}
+import scala.Predef.{<:<, ArrowAssoc, String}
+import scala.annotation.switch
+import scala.reflect.ClassTag
+import scala.runtime.ScalaRunTime
+import strawman.collection.mutable.ReusableBuilder
+
+/**
+  * An <i>ArraySeq</i> is an (ostensible) immutable array-like collection designed to support the following performance characteristics:
+  * <ul>
+  * <li>constant time <code>head</code>, <code>last</code>, <code>tail</code>*, <code>init</code>*, <code>take</code>*, <code>takeRight</code>*, <code>takeWhile</code>*, <code>drop</code>*, <code>dropRight</code>*, <code>dropWhile</code>*, <code>slice</code>* and <code>reverse</code> (* = depending on the <code>AutoTrimming</code> mode in use)</li>
+  * <li>amortised constant time <code>prepend</code>/<code>prependAll</code>, <code>append</code>/<code>appendAll</code> and <code>concat</code> (depending on the complexity of <code>java.util.System.arraycopy</code></li>
+  * <li>efficient indexed access</li>
+  * <li>linear time iteration (i.e. <code>iterator</code> and <code>foreach</code>) with low constant factors
+  * <li>reasonable memory usage (approximately double that of an array with the same number of elements)
+  * </ul>
+  * <br/>
+  * Elements can be added to both the front and the rear of the underlying array (via <code>prepend</code>/<code>prependAll</code>
+  * and <code>append</code>/<code>appendAll</code>/<code>concat</code> respectively), but never more than once for any given array slot.
+  * For any operation trying to use an already occupied slot (such as <code>appended</code>, <code>prepended</code> or <code>updated</code>) an overlay is provided that can store the index and element pair using an <code>immutable.HashMap</code> (thus avoiding having to copy the underlying array).
+  * The overlay will only be allowed to grow according to the used <code>AutoTrimming</code> mode, after which it will be merged with the underlying array on the next transformation operation.
+  * <br/>
+  * <br/>
+  * To guarantee that only a single thread can write to an array slot an atomic long is used to guard the low and high index
+  * assignments.
+  * <br/>
+  * <br/>
+  * When the underlying array is too small to fit a requested addition a new array will be allocated (the size is dependent on the <code>AutoTrimming</code> mode used).
+  * <br/>
+  * <br/>
+  * To ensure that no longer accessible array slots (i.e. on the returned instance of a <code>slice</code> operation) are freed, trimming can be used.
+  * Trimming can either be performed manually (via the <code>trim</code> method) or automatically via the <code>withAutoTrimming</code> method.
+  * <br/>
+  * The automatic trimming can be customized via these three properties:
+  * <table>
+  *   <tr>
+  *     <th align="left">Property</th>
+  *     <th align="left">Default</th>
+  *     <th align="left">Description</th>
+  *   </tr>
+  *   <tr>
+  *     <td>minUsagePercentage</td>
+  *     <td>25</td>
+  *     <td>The minimum <code>size / capacity</code> percentage allowed before auto trimming.</td>
+  *   </tr>
+  *   <tr>
+  *     <td>maxOverlaidPercentage</td>
+  *     <td>50</td>
+  *     <td>The maximum <code>overlay.size / capacity</code> percentage allowed before auto trimming.</td>
+  *   </tr>
+  *   <tr>
+  *     <td>usePadding</td>
+  *     <td>true</td>
+  *     <td>Indicates whether to use padding or not.</td>
+  *   </tr>
+  * </table>
+  * <br/>
+  * <br/>
+  * There exists three predefined auto trimming modes:
+  * <ul>
+  *   <li><b>Always</b> will use auto trimming for all transformation operations and never use an overlay nor any padding. Safe but slow.</li>
+  * </ul>
+  * <ul>
+  *   <li><b>Default</b> will use auto trimming for all transformation operations where the size of the returned instance is at most 25% of the capacity of the underlay.
+  *   Will use an overlay with a size of at most 50% of the capacity of the underlay and will use padding. Somewhat leaky but fast except for creating small slices.</li>
+  * </ul>
+  * <ul>
+  *   <li><b>Never</b> will never use auto trimming and will allow the overlay to grow to the same size as the capacity of the underlay and will use padding. Leaky but fast.</li>
+  * </ul>
+  * <br/>
+  * <b>Examples</b>
+  * <br/>
+  <pre><code>
+    // expression                                               (array, start, stop)
+    ArraySeq()                                               ==> ([], 0, 0)
+    ArraySeq() :+ a                                          ==> ([a, _, _, _, _, _, _, _], 0, 1)
+    a +: ArraySeq()                                          ==> ([_, _, _, _, _, _, _, a], -1, 0)
+    ArraySeq() :++ Seq(a, b, c, d)                           ==> ([a, b, c, d, _, _, _, _], 0, 4)
+    Seq(a, b, c, d) ++: ArraySeq()                           ==> ([_, _, _, _, a, b, c, d], -4, 0)
+    Seq(a, b, c, d) ++: ArraySeq() :++ Seq(e, f, g, h)       ==> ([e, f, g, h, a, b, c, d], -4, 4)
+    ArraySeq(a, b, c, d, e, f, g, h)                         ==> ([a, b, c, d, e, f, g, h], 0, 8)
+    ArraySeq() :++ Seq(a, b, c, d, e, f, g, h)               ==> ([a, b, c, d, e, f, g, h], 0, 8)
+    Seq(a, b, c, d, e, f, g, h) ++: ArraySeq()               ==> ([a, b, c, d, e, f, g, h], -8, 0)
+    (Seq(a, b, c, d) ++: ArraySeq()).slice(1, 3)             ==> ([_, _, _, _, a, b, c, d], -3, -1)
+    (ArraySeq() :++ Seq(a, b, c, d)).slice(1, 3)             ==> ([a, b, c, d, _, _, _, _], 1, 3)
+    (Seq(a, b) ++: ArraySeq() :++ Seq(c, d)).slice(1, 3)     ==> ([c, d, _, _, _, _, a, b], -1, 1)
+  </code></pre>
+  */
+@SerialVersionUID(1974011501L)
+final class ArraySeq[+A] private (
+    private val underlay: ArraySeq.Underlay[A],
+    private val overlay: ArraySeq.Overlay[A],
+    private val start: Int,
+    private val stop: Int,
+    val autoTrimming: ArraySeq.AutoTrimming)
+  extends IndexedSeq[A]
+    with IndexedSeqOps[A, ArraySeq, ArraySeq[A]]
+    with StrictOptimizedSeqOps[A, ArraySeq, ArraySeq[A]]
+    with Serializable {
+
+  import ArraySeq._
+
+  def toDebugString: String = s"""${mkString("[", ", ", "]")}: ArraySeq(start: $start, stop: $stop, autoTrimming: $autoTrimming, underlay: ${underlay.toDebugString}${if (overlay != null) s""", overlay:  ${overlay.mkString("[", ", ", "]")}""" else ""}"""
+
+  override def toString() = toDebugString // Should be removed once finished
+
+  @`inline`
+  private[immutable] def array: Array[Any] = underlay.elements
+
+  @`inline`
+  def capacity: Int = underlay.capacity
+  @`inline`
+  def isUncapacitated = capacity == 0
+
+  //@`inline` // Causes problems with errors and infinite inlining when running test cases on Dotty
+  @`inline`
+  private def isReversed: Boolean = start > stop
+  @`inline`
+  private def nonReversed: Boolean = start <= stop
+
+  @`inline`
+  private[this] def in(slot: Int): A = {
+    if (overlay == null) underlay(slot)
+    else overlay.get(slot).getOrElse(underlay(slot))
+  }
+
+  @`inline`
+  private[this] def at(index: Int): A = in(slot(index, start, stop, capacity))
+
+  /**
+    * Returns a <code>ArraySeq</code> that uses the specified auto trimming configuration.
+    * @param autoTrimming the auto trimming configuration (defaults to <code>AutoTrimming.Default</code>).
+    */
+  def withAutoTrimming(autoTrimming: AutoTrimming = AutoTrimming.Default): ArraySeq[A] =
+    if (autoTrimming == this.autoTrimming) this
+    else create(underlay, overlay, start, stop, autoTrimming, trim = true)
+
+  /**
+    * Returns a <code>ArraySeq</code> that uses no auto trimming (<code>AutoTrimming.Never</code>).
+    */
+  def withoutAutoTrimming: ArraySeq[A] =
+    withAutoTrimming(AutoTrimming.Never)
+  /**
+    * Executes <code>f</code> on this instance without auto trimming during the execution of <code>f</code>.
+    * The returned instance has the same auto trimming setting as this instance.
+    */
+  def withoutAutoTrimming[B >: A](f: ArraySeq[A] => ArraySeq[B]): ArraySeq[B] =
+    f(withAutoTrimming(AutoTrimming.Never)).withAutoTrimming(autoTrimming)
+
+  override def length = size
+
+  override def size: Int = distance(start, stop)
+
+  override def knownSize: Int = size
+
+  override def isEmpty: Boolean = size == 0
+
+  override def nonEmpty: Boolean = !isEmpty
+
+  override def apply(i: Int): A =
+    if (i < 0 || i >= size) throw new ArrayIndexOutOfBoundsException(i)
+    else at(i)
+
+  override def slice(from: Int, until: Int): ArraySeq[A] = {
+    val sz = size
+    if (sz == 0 || until <= from) create(autoTrimming)
+    else if (from <= 0 && until >= sz) this
+    else {
+      val f = minOf(maxOf(from, 0), sz)
+      val u = maxOf(minOf(until, sz), 0)
+      if (isReversed) create(underlay, if (overlay != null) overlay.slice(f, u) else null, start - f, start - u, autoTrimming, trim = true)
+      else create(underlay, if (overlay != null) overlay.slice(f, u) else null, start + f, start + u, autoTrimming, trim = true)
+    }
+  }
+
+  override def take(n: Int): ArraySeq[A] =
+    slice(0, maxOf(minOf(n, size), 0))
+
+  override def takeRight(n: Int): ArraySeq[A] = {
+    val sz = size
+    slice(sz - maxOf(minOf(n, sz), 0), sz)
+  }
+
+  override def takeWhile(p: (A) => Boolean): ArraySeq[A] = {
+    val sz = size
+    var i = 0
+    while (i < sz) {
+      if (!p(at(i))) return take(i)
+      i += 1
+    }
+    this
+  }
+
+  override def drop(n: Int): ArraySeq[A] =
+    slice(n, size)
+
+  override def dropRight(n: Int): ArraySeq[A] = {
+    val sz = size
+    slice(0, sz - maxOf(minOf(n, sz), 0))
+  }
+
+  override def dropWhile(p: (A) => Boolean): ArraySeq[A] = {
+    val sz = size
+    var i = 0
+    while (i < sz) {
+      if (!p(at(i))) return drop(i)
+      i += 1
+    }
+    create(autoTrimming)
+  }
+
+  override def span(p: (A) => Boolean) = {
+    val prefix = takeWhile(p)
+    (prefix, drop(prefix.size))
+  }
+
+  override def partition(p: (A) => Boolean) = {
+    val sz = size
+    val l, r = newBuilder[A](sz, autoTrimming)
+    var i = 0
+    while (i < sz) {
+      val elem = at(i)
+      if (p(elem)) l += elem
+      else r += elem
+      i += 1
+    }
+    (l.result(), r.result())
+  }
+
+  override def head: A =
+    if (isEmpty) throw new UnsupportedOperationException
+    else at(0)
+
+  override def tail: ArraySeq[A] =
+    if (isEmpty) throw new UnsupportedOperationException
+    else drop(1)
+
+  override def last: A =
+    if (isEmpty) throw new UnsupportedOperationException
+    else at(size - 1)
+
+  override def init: ArraySeq[A] =
+    if (isEmpty) throw new UnsupportedOperationException
+    else dropRight(1)
+
+  override def padTo[B >: A](len: Int, elem: B): ArraySeq[B] = {
+    val sz = size
+    if (len <= sz) this
+    else if (len <= 8 || len > 128) {
+      val n = len - sz
+      appendedAll0(Iterator.continually(elem).take(n), n)
+    } else {
+      val builder = newBuilder[B](len, autoTrimming)
+      builder ++= this
+      var i = len - sz
+      while (i > 0) {
+        builder += elem
+        i -= 1
+      }
+      builder.result()
+    }
+  }
+
+  def leftPadTo[B >: A](len: Int, elem: B): ArraySeq[B] = {
+    val sz = size
+    if (len <= sz) this
+    else if (len <= 8 || len > 128) {
+      val n = len - sz
+      prependedAll0(Iterator.continually(elem).take(n), n)
+    } else {
+      val builder = newBuilder[B](len, autoTrimming)
+      var i = len - sz
+      while (i > 0) {
+        builder += elem
+        i -= 1
+      }
+      builder ++= this
+      builder.result()
+    }
+  }
+
+  @`inline`
+  def rightPadTo[B >: A](len: Int, elem: B): ArraySeq[B] = padTo(len, elem)
+
+  override def prepended[B >: A](elem: B): ArraySeq[B] =
+    if (nonReversed && underlay.prependedElement(elem, start)) create(underlay, overlay, start - 1, stop, autoTrimming)
+    else if (isReversed && underlay.appendedElement(elem, start)) create(underlay, overlay, start + 1, stop, autoTrimming) // as it is reversed start is really stop and stop is really start
+    else if (underlay.isFull) elem +: allocate(capacitate(size + 1, autoTrimming.usePadding), underlay, overlay, start, stop, autoTrimming)
+    else if (nonReversed) create(underlay, if (overlay != null) overlay + (slot(start - 1, capacity) -> elem) else Overlay((slot(start - 1, capacity), elem)), start - 1, stop, autoTrimming)
+    else create(underlay, if (overlay != null) overlay + (slot(start, capacity) -> elem) else Overlay(slot(start, capacity) -> elem), start + 1, stop, autoTrimming) // as it is reversed start is really stop and stop is really start
+
+  override def appended[B >: A](elem: B): ArraySeq[B] =
+    if (nonReversed && underlay.appendedElement(elem, stop)) create(underlay, overlay, start, stop + 1, autoTrimming)
+    else if (isReversed && underlay.prependedElement(elem, stop)) create(underlay, overlay, start, stop - 1, autoTrimming) // as it is reversed start is really stop and stop is really start
+    else if (underlay.isFull) allocate(capacitate(size + 1, autoTrimming.usePadding), underlay, overlay, start, stop, autoTrimming) :+ elem
+    else if (nonReversed) create(underlay, if (overlay != null) overlay + (slot(stop, capacity) -> elem) else Overlay(slot(stop, capacity) -> elem), start, stop + 1, autoTrimming)
+    else create(underlay, if (overlay != null) overlay + (slot(stop - 1, capacity) -> elem) else Overlay(slot(stop - 1, capacity) -> elem), start, stop - 1, autoTrimming) // as it is reversed start is really stop and stop is really start
+
+  override def prependedAll[B >: A](xs: collection.Iterable[B]): ArraySeq[B] = prependedAll0(xs)
+
+  private def prependedAll0[B >: A](xs: collection.IterableOnce[B], knownSize: Int = -1): ArraySeq[B] =
+    xs match {
+      case _ if knownSize == 0 =>
+        this
+      case that: Iterable[B] if that.knownSize == 0 || that.isEmpty =>
+        this
+      case _ if knownSize == 1 =>
+        prepended(xs.iterator().next())
+      case that: Iterable[B] if that.knownSize == 1 =>
+        prepended(that.head)
+      case _ if isUncapacitated =>
+        from(xs, knownSize)
+      case that: ArraySeq[B] if this.isReversed || that.isReversed =>
+        from(View.Concat(that, this), this.knownSize + that.knownSize)
+      case that: ArraySeq[B] if this.underlay.prependedElements(that, this.start) =>
+        create(this.underlay, this.overlay, this.start - that.size, this.stop, autoTrimming)
+      case that: ArraySeq[B] if that.underlay.appendedElements(this, that.stop) =>
+        create(that.underlay, that.overlay, that.start, that.stop + this.size, autoTrimming)
+      case that: ArraySeq[B] =>
+        allocate(capacitate(this.size + that.size, autoTrimming.usePadding), underlay, overlay, start, stop, autoTrimming).prependedAll(that)
+      case that: Iterable[B] if knownSize > -1 || that.knownSize > -1 =>
+        from(View.Concat(that, this), that.knownSize + this.knownSize)
+      case _ if knownSize > -1 =>
+        from(new View.Patched(this, 0, xs, 0), knownSize + this.knownSize)
+      case _ =>
+        prependedAll0(from(xs, knownSize), knownSize)
+    }
+
+  override def appendedAll[B >: A](xs: collection.Iterable[B]): ArraySeq[B] = appendedAll0(xs)
+
+  private def appendedAll0[B >: A](xs: collection.IterableOnce[B], knownSize: Int = -1): ArraySeq[B] =
+    xs match {
+      case _ if knownSize == 0 =>
+        this
+      case that: Iterable[B] if that.knownSize == 0 || that.isEmpty =>
+        this
+      case _ if knownSize == 1 =>
+        appended(xs.iterator().next())
+      case that: Iterable[B] if that.knownSize == 1 =>
+        appended(that.head)
+      case _ if isUncapacitated =>
+        from(xs, knownSize)
+      case that: ArraySeq[B] if this.isReversed || that.isReversed =>
+        from(View.Concat(this, that), this.knownSize + that.knownSize)
+      case that: ArraySeq[B] if this.underlay.appendedElements(that, this.stop) =>
+        create(this.underlay, this.overlay, this.start, this.stop + that.size, autoTrimming)
+      case that: ArraySeq[B] if that.underlay.prependedElements(this, that.start) =>
+        create(that.underlay, that.overlay, that.start - this.size, that.stop, autoTrimming)
+      case that: ArraySeq[B] =>
+        allocate(capacitate(this.size + that.size, autoTrimming.usePadding), underlay, overlay, start, stop, autoTrimming).appendedAll(that)
+      case that: Iterable[B] if knownSize > -1 || that.knownSize > -1 =>
+        from(View.Concat(this, that), that.knownSize + this.knownSize)
+      case _ if knownSize > -1 =>
+        from(new View.Patched(this, this.knownSize, xs, 0), knownSize + this.knownSize)
+      case _ =>
+        appendedAll0(from(xs, knownSize), knownSize)
+    }
+
+  override def map[B](f: A => B): ArraySeq[B] = {
+    (size: @switch) match {
+      case 0 => create[B](autoTrimming)
+      case 1 => create[B](autoTrimming, f(at(0)))
+      case 2 => create[B](autoTrimming, f(at(0)), f(at(1)))
+      case 3 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)))
+      case 4 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)), f(at(3)))
+      case 5 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)), f(at(3)), f(at(4)))
+      case 6 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)), f(at(3)), f(at(4)), f(at(5)))
+      case 7 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)), f(at(3)), f(at(4)), f(at(5)), f(at(6)))
+      case 8 => create[B](autoTrimming, f(at(0)), f(at(1)), f(at(2)), f(at(3)), f(at(4)), f(at(5)), f(at(6)), f(at(7)))
+      case sz =>
+        if (sz <= 64) {
+          val capacity = capacitate(sz, autoTrimming.usePadding)
+          val array = new Array[Any](capacity)
+          var i = 0
+          while (i < sz) {
+            array(i) = f(at(i))
+            i += 1
+          }
+          create(array, 0, i, autoTrimming)
+        } else {
+          val capacity = capacitate(sz, autoTrimming.usePadding)
+          val array = new Array[Any](capacity)
+          val it = iterator()
+          var i = 0
+          while (it.hasNext) {
+            array(i) = f(it.next())
+            i += 1
+          }
+          create(array, 0, i, autoTrimming)
+        }
+    }
+  }
+
+  override def collect[B](pf: PartialFunction[A, B]): ArraySeq[B] = {
+    val sz = size
+    if (sz == 0) create[B](autoTrimming)
+    else {
+      // Copied from `strawman.collection.IterableOps.collectFirst`:
+      // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself
+      // (Tested to be lower-overhead than runWith.  Would be better yet to not need to (formally) allocate it)
+      val sentinel: scala.Function1[A, Any] = (a: A) => this
+      val builder = newBuilder[B](autoTrimming = autoTrimming)
+      var i = 0
+      while (i < sz) {
+        val elem = at(i)
+        val x = pf.applyOrElse(elem, sentinel)
+        if (x.asInstanceOf[AnyRef] ne sentinel) builder += x.asInstanceOf[B]
+        i += 1
+      }
+      builder.result()
+    }
+  }
+
+  override def flatMap[B](f: (A) => IterableOnce[B]) = {
+    val sz = size
+    if (sz == 0) create(autoTrimming)
+    else {
+      val builder = newBuilder[B](sz, autoTrimming)
+      var i = 0
+      while (i < sz) {
+        builder ++= f(at(i))
+        i += 1
+      }
+      builder.result()
+    }
+  }
+
+  override def distinctBy[B](f: A => B): ArraySeq[A] = {
+    (size: @switch) match {
+      case 0 => this
+      case 1 => this
+      case 2 =>
+        val a0 = at(0)
+        val a1 = at(1)
+        if (f(a0) == f(a1)) create[A](autoTrimming, a0)
+        else create[A](autoTrimming, a0, a1)
+      case 3 =>
+        val a0 = at(0)
+        val a1 = at(1)
+        val a2 = at(2)
+        val f0 = f(a0)
+        val f1 = f(a1)
+        val f2 = f(a2)
+        if (f0 == f1 && f0 == f2) create[A](autoTrimming, a0)
+        else if (f0 == f1 || f1 == f2) create[A](autoTrimming, a0, a2)
+        else create[A](autoTrimming, a0, a1, a2)
+      case sz =>
+        val builder = newBuilder[A](autoTrimming = autoTrimming)
+        val seen = mutable.HashSet.empty[B]
+        val sz = size
+        var i = 0
+        while (i < sz) {
+          val elem = at(i)
+          val id = f(elem)
+          if (!seen.contains(id)) {
+            seen.add(id)
+            builder += elem
+          }
+          i += 1
+        }
+        builder.result()
+    }
+  }
+
+  override def filter(p: (A) => Boolean) = {
+    val sz = size
+    if (sz == 0) this
+    else if (sz == 1) { if (p(at(0))) this else create(autoTrimming) }
+    else {
+      if (sz <= 32 ) {
+        val builder = newBuilder[A](autoTrimming = autoTrimming)
+        var i = 0
+        while (i < sz) {
+          val elem = at(i)
+          if (p(elem)) builder += elem
+          i += 1
+        }
+        builder.result()
+      } else {
+       val builder = newBuilder[A](autoTrimming = autoTrimming)
+        val it = iterator()
+        while (it.hasNext) {
+          val elem = it.next()
+          if (p(elem)) builder += elem
+        }
+        builder.result()
+      }
+    }
+  }
+
+  override def filterNot(p: (A) => Boolean) = filter(x => !p(x))
+
+  override def zipWithIndex = zip(Iterator.range(0, size), size)
+
+  override def zip[B](xs: collection.Iterable[B]): ArraySeq[(A, B)] = zip(xs, minOf(size, xs.size))
+
+  private def zip[B](xs: collection.IterableOnce[B], size: Int): ArraySeq[(A, B)] = {
+    (size: @switch) match {
+      case 0 => create[(A, B)](autoTrimming)
+      case 1 => create[(A, B)](autoTrimming, (at(0), xs.iterator().next()))
+      case 2 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()))
+      case 3 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()))
+      case 4 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()), (at(3), it.next()))
+      case 5 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()), (at(3), it.next()), (at(4), it.next()))
+      case 6 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()), (at(3), it.next()), (at(4), it.next()), (at(5), it.next()))
+      case 7 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()), (at(3), it.next()), (at(4), it.next()), (at(5), it.next()), (at(6), it.next()))
+      case 8 =>
+        val it = xs.iterator()
+        create[(A, B)](autoTrimming, (at(0), it.next()), (at(1), it.next()), (at(2), it.next()), (at(3), it.next()), (at(4), it.next()), (at(5), it.next()), (at(6), it.next()), (at(7), it.next()))
+      case sz =>
+        if (sz <= 32) {
+          val builder = newBuilder[(A, B)](sz, autoTrimming)
+          val jt = xs.iterator()
+          var i = 0
+          while (i < sz && jt.hasNext) {
+            builder += ((at(i), jt.next()))
+            i += 1
+          }
+          builder.result()
+        } else {
+          val builder = newBuilder[(A, B)](sz, autoTrimming)
+          val it = iterator()
+          val jt = xs.iterator()
+          while (it.hasNext && jt.hasNext) {
+            builder += ((it.next(), jt.next()))
+          }
+          builder.result()
+        }
+    }
+  }
+
+  override def unzip[L, R](implicit asPair: <:<[A, (L, R)]): (ArraySeq[L], ArraySeq[R]) = {
+    (size: @switch) match {
+      case 0 =>
+        (create[L](autoTrimming), create[R](autoTrimming))
+      case 1 =>
+        val (l0, r0) = asPair(at(0))
+        (create[L](autoTrimming, l0), create[R](autoTrimming, r0))
+      case 2 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        (create[L](autoTrimming, l0, l1), create[R](autoTrimming, r0, r1))
+      case 3 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        (create[L](autoTrimming, l0, l1, l2), create[R](autoTrimming, r0, r1, r2))
+      case 4 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        val (l3, r3) = asPair(at(3))
+        (create[L](autoTrimming, l0, l1, l2, l3), create[R](autoTrimming, r0, r1, r2, r3))
+      case 5 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        val (l3, r3) = asPair(at(3))
+        val (l4, r4) = asPair(at(4))
+        (create[L](autoTrimming, l0, l1, l2, l3, l4), create[R](autoTrimming, r0, r1, r2, r3, r4))
+      case 6 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        val (l3, r3) = asPair(at(3))
+        val (l4, r4) = asPair(at(4))
+        val (l5, r5) = asPair(at(5))
+        (create[L](autoTrimming, l0, l1, l2, l3, l4, l5), create[R](autoTrimming, r0, r1, r2, r3, r4, r5))
+      case 7 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        val (l3, r3) = asPair(at(3))
+        val (l4, r4) = asPair(at(4))
+        val (l5, r5) = asPair(at(5))
+        val (l6, r6) = asPair(at(6))
+        (create[L](autoTrimming, l0, l1, l2, l3, l4, l5, l6), create[R](autoTrimming, r0, r1, r2, r3, r4, r5, r6))
+      case 8 =>
+        val (l0, r0) = asPair(at(0))
+        val (l1, r1) = asPair(at(1))
+        val (l2, r2) = asPair(at(2))
+        val (l3, r3) = asPair(at(3))
+        val (l4, r4) = asPair(at(4))
+        val (l5, r5) = asPair(at(5))
+        val (l6, r6) = asPair(at(6))
+        val (l7, r7) = asPair(at(7))
+        (create[L](autoTrimming, l0, l1, l2, l3, l4, l5, l6, l7), create[R](autoTrimming, r0, r1, r2, r3, r4, r5, r6, r7))
+      case sz =>
+        if (sz <= 32) {
+          val cap = capacity
+          val l = new Array[Any](cap)
+          val r = new Array[Any](cap)
+          var i = 0
+          while (i < sz) {
+            val (l0, r0) = asPair(at(i))
+            l(i) = l0
+            r(i) = r0
+            i += 1
+          }
+          (create(l, 0, i, autoTrimming), create(r, 0, i, autoTrimming))
+        } else {
+          val cap = capacity
+          val l = new Array[Any](cap)
+          val r = new Array[Any](cap)
+          val it = iterator()
+          var i = 0
+          while (it.hasNext) {
+            val (l0, r0) = asPair(it.next())
+            l(i) = l0
+            r(i) = r0
+            i += 1
+          }
+          (create(l, 0, i, autoTrimming), create(r, 0, i, autoTrimming))
+        }
+    }
+  }
+
+  @`inline`
+  override def iterator(): Iterator[A] = iterator(start, stop)
+
+  ////@`inline` // Causes compile error on Dotty
+  private def iterator(x: Int, y: Int): Iterator[A] = {
+    if (x == y) Iterator.empty
+    else {
+      val cap = capacity
+      val sz = distance(x, y)
+      if (sz == 1) Iterator.single(at(0))
+      else if (x < y) {
+        if (x < 0) {
+          val frontStart = slot(x, cap)
+          val frontStop = if (y >= 0) cap else slot(y, cap)
+          val rearStart = slot(maxOf(x, 0), cap)
+          val rearStop = slot(maxOf(y, 0), cap)
+          new Iterator[A] {
+            private[this] var i = frontStart
+            private[this] var _hasNext = i >= frontStart && i < frontStop
+            override def hasNext = _hasNext
+            override def next() = {
+              if (!_hasNext) throw new NoSuchElementException("next on empty iterator")
+              val elem = if (overlay == null) underlay(i) else overlay.get(i).getOrElse(underlay(i))
+              i += 1
+              if (i == frontStop) {
+                i = rearStart
+                _hasNext = i < rearStop
+              } else if (i == rearStop) {
+                _hasNext = false
+              }
+              elem
+            }
+          }
+        } else {
+          val rearStart = slot(maxOf(x, 0), cap)
+          val rearStop = slot(maxOf(y, 0), cap)
+          new Iterator[A] {
+            private[this] var i = rearStart
+            private[this] var _hasNext = i >= rearStart && i < rearStop
+            override def hasNext = _hasNext
+            override def next() = {
+              if (!_hasNext) throw new NoSuchElementException("next on empty iterator")
+              val elem = if (overlay == null) underlay(i) else overlay.get(i).getOrElse(underlay(i))
+              i += 1
+              if (i >= rearStop) {
+                _hasNext = false
+              }
+              elem
+            }
+          }
+        }
+      } else {
+        if (x > 0) {
+          val frontStart = if (y >= 0) cap else slot(y, cap)
+          val frontStop = if (x >= 0) cap else slot(x, cap)
+          val rearStart = slot(maxOf(y, 0), cap)
+          val rearStop = slot(maxOf(x, 0), cap)
+          new Iterator[A] {
+            private[this] var i = rearStop - 1
+            private[this] var _hasNext = i >= rearStart && i < rearStop
+            override def hasNext = _hasNext
+            override def next() = {
+              if (!_hasNext) throw new NoSuchElementException("next on empty iterator")
+              val elem = if (overlay == null) underlay(i) else overlay.get(i).getOrElse(underlay(i))
+              if (i == rearStart) {
+                i = frontStop
+                _hasNext = i > frontStart
+              } else if (i == frontStart) {
+                _hasNext = false
+              }
+              i -= 1
+              elem
+            }
+          }
+        } else {
+          val frontStart = if (y >= 0) cap else slot(y, cap)
+          val frontStop = if (x >= 0) cap else slot(x, cap)
+          new Iterator[A] {
+            private[this] var i = frontStop -1
+            private[this] var _hasNext = i >= frontStart && i < frontStop
+            override def hasNext = _hasNext
+            override def next() = {
+              if (!_hasNext) throw new NoSuchElementException("next on empty iterator")
+              val elem = if (overlay == null) underlay(i) else overlay.get(i).getOrElse(underlay(i))
+              if (i <= frontStart) {
+                _hasNext = false
+              }
+              i -= 1
+              elem
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @`inline`
+  override def reverseIterator() = iterator(stop, start)
+
+  override def reverse: ArraySeq[A] =
+    if (size <= 1) this
+    else create(underlay, if (overlay != null) overlay else null, stop, start, autoTrimming)
+
+  override protected[this] def reversed: ArraySeq[A] = reverse
+
+  override def foldLeft[B](z: B)(op: (B, A) => B): B = {
+    (size: @switch) match {
+      case 0 => z
+      case 1 => op(z, at(0))
+      case 2 => op(op(z, at(0)), at(1))
+      case 3 => op(op(op(z, at(0)), at(1)), at(2))
+      case 4 => op(op(op(op(z, at(0)), at(1)), at(2)), at(3))
+      case 5 => op(op(op(op(op(z, at(0)), at(1)), at(2)), at(3)), at(4))
+      case 6 => op(op(op(op(op(op(z, at(0)), at(1)), at(2)), at(3)), at(4)), at(5))
+      case 7 => op(op(op(op(op(op(op(z, at(0)), at(1)), at(2)), at(3)), at(4)), at(5)), at(6))
+      case 8 => op(op(op(op(op(op(op(op(z, at(0)), at(1)), at(2)), at(3)), at(4)), at(5)), at(6)), at(7))
+      case sz =>
+        if (sz <= 32) {
+          var acc = z
+          var i = 0
+          while (i < sz) {
+            acc = op(acc, at(i))
+            i += 1
+          }
+          acc
+        } else {
+          var acc = z
+          val it = iterator()
+          while (it.hasNext) {
+            acc = op(acc, it.next())
+          }
+          acc
+        }
+      }
+  }
+
+  override def foldRight[B](z: B)(op: (A, B) => B): B = {
+    (size: @switch) match {
+      case 0 => z
+      case 1 => op(at(0), z)
+      case 2 => op(at(0), op(at(1), z))
+      case 3 => op(at(0), op(at(1), op(at(2), z)))
+      case 4 => op(at(0), op(at(1), op(at(2), op(at(3), z))))
+      case 5 => op(at(0), op(at(1), op(at(2), op(at(3), op(at(4), z)))))
+      case 6 => op(at(0), op(at(1), op(at(2), op(at(3), op(at(4), op(at(5), z))))))
+      case 7 => op(at(0), op(at(1), op(at(2), op(at(3), op(at(4), op(at(5), op(at(6), z)))))))
+      case 8 => op(at(0), op(at(1), op(at(2), op(at(3), op(at(4), op(at(5), op(at(6), op(at(7), z))))))))
+      case sz =>
+        if (sz <= 32) {
+          var acc = z
+          var i = sz - 1
+          while (i >= 0) {
+            acc = op(at(i), acc)
+            i -= 1
+          }
+          acc
+        } else {
+          var acc = z
+          val it = reverseIterator()
+          while (it.hasNext) {
+            acc = op(it.next(), acc)
+          }
+          acc
+        }
+    }
+  }
+
+  override def updated[B >: A](index: Int, elem: B): ArraySeq[B] = {
+    if (index < 0 || index >= size) throw new IndexOutOfBoundsException(index.toString)
+    else if (identical(elem, at(index))) this
+    else if (capacity <= 64) {
+      val array = underlay.elements.clone()
+      val (frontStart, frontStop, rearStart, rearStop) = segments(start, stop, size)
+      layout(null, overlay, start, stop, frontStart, distance(frontStart, frontStop), rearStart, distance(rearStart, rearStop), array)
+      array.update(slot(index, start, stop, capacity), elem)
+      create(array, start, stop, autoTrimming)
+    } else create(underlay, if (overlay != null) overlay + (slot(index, start, stop, capacity) -> elem) else Overlay(slot(index, start, stop, capacity) -> elem), start, stop, autoTrimming, trim = true)
+  }
+
+  override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): ArraySeq[B] = {
+    val sz = size
+    if (from < 0 || from > sz) throw new IndexOutOfBoundsException(from.toString)
+    else if (from == sz) coll.appendedAll0(other)
+    else if (from == 0 && maxOf(replaced, 0) == 0) prependedAll0(other)
+    else if (from == 0) coll.drop(replaced).prependedAll0(other)
+    else {
+      val c = coll.withoutAutoTrimming
+      val prefix = c.take(from)
+      val front = prefix.appendedAll0(other)
+      val suffix = c.slice(from + replaced, sz)
+      val whole = front.appendedAll0(suffix)
+      whole.withAutoTrimming(autoTrimming)
+    }
+  }
+
+  override def toArray[B >: A: ClassTag]: Array[B] =
+    copyToArray(new Array[B](this.size))
+
+  override def copyToArray[B >: A](array: Array[B], start: Int = 0): array.type = {
+    if (start < 0 || start > size)
+      throw new ArrayIndexOutOfBoundsException(start)
+    else if (isReversed) super.copyToArray(array, start)
+    else {
+      if (array.isInstanceOf[Array[AnyRef]]) {
+        val (srcFrontStart, srcFrontStop, srcRearStart, srcRearStop) = segments(start, stop, size)
+        val frontLength = distance(srcFrontStop, srcFrontStart)
+        val rearLength = distance(srcRearStop, srcRearStart)
+        layout(underlay, overlay, start, stop, srcFrontStart, frontLength, srcRearStart, rearLength, array.asInstanceOf[Array[Any]])
+      } else {
+        super.copyToArray(array, start)
+      }
+      array
+    }
+  }
+
+  def grow(size: Int, padded: Boolean = AutoTrimming.DefaultUsePadding): ArraySeq[A] = resize(size, padded)
+
+  def trim(padded: Boolean = false): ArraySeq[A] = resize(this.size, padded)
+
+  def resize(size: Int, padded: Boolean = true): ArraySeq[A] = {
+    val capacity = capacitate(size, padded)
+    if (size == 0) create(autoTrimming)
+    else if (capacity == this.capacity) this
+    else if (size < this.size) throw new IllegalArgumentException(s"Specified size of $size is smaller than the current size ${this.size}.")
+    else allocate(capacity, underlay, overlay, start, stop, autoTrimming)
+  }
+
+  override def iterableFactory: SeqFactory[ArraySeq] = ArraySeq
+
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ArraySeq[A] = ArraySeq.from(coll)
+
+  override protected[this] def newSpecificBuilder(): mutable.Builder[A, ArraySeq[A]] = newBuilder(size, autoTrimming = autoTrimming)
+
+  /**
+    * CAUTION! This method is highly dangerous since it resets the existing bounds of this instances underlay and removes any overlay. Only use when no other
+    * referrers to this instance exist with absolute certainty (for example during benchmarking to disregard any state
+    * affected in previous iterations).
+    */
+  def reset(): ArraySeq[A] = {
+    underlay.reset()
+    new ArraySeq[A](underlay, null, start, stop, autoTrimming)
+  }
+
+  override def className = "ArraySeq"
+}
+
+object ArraySeq extends SeqFactory[ArraySeq] {
+  val MinCapacity = 8
+
+  final case class AutoTrimming(
+      /**
+        * The minimum <code>size / capacity</code> percentage allowed before auto trimming.
+        * A value <code>&lt;= 0</code> means no auto trimming will take place based on usage percentage.
+        * a value <code>&gt;= 100</code> means all returned collections will be auto trimmed.
+        */
+      minUsagePercentage: Int = AutoTrimming.DefaultMinUsagePercentage,
+      /**
+        * The maximum <code>overlaySize / capacity</code> percentage allowed before auto trimming.
+        * A value <code>&lt;= 0</code> means all returned collections having an overlay will be auto
+        * trimmed,
+        * a value <code>&gt;= 100</code> means no auto trimming will take place based on overlay size
+        * percentage.
+        */
+      maxOverlaidPercentage: Int = AutoTrimming.DefaultMaxOverlaidPercentage,
+      /**
+        * Indicates whether to use padding or not.
+        * A value of <code>true</code> will only trim down to the smallest possible capacity (which is always
+        * a multiple of 2) capable of holding the current number of elements.
+        * A value of <code>false</code> will trim down as far as possible while still holding the current
+        * number of elements (note: the resulting instance can have a capacity smaller than 8).
+        */
+      usePadding: Boolean = AutoTrimming.DefaultUsePadding)
+  object AutoTrimming {
+    /**
+      * The default minimum <code>size / capacity</code> percentage allowed before auto trimming.
+      */
+    val DefaultMinUsagePercentage = 25
+    /**
+      * The default maximum <code>overlaySize / capacity</code> percentage allowed before auto trimming.
+      */
+    val DefaultMaxOverlaidPercentage = 50
+    /**
+      * The default <code>usePadding</code> to use when auto trimming.
+      */
+    val DefaultUsePadding = true
+  /**
+      * Never auto trim the returned instance. NOTE: This could lead to memory leakage (see documentation above for more information).
+      */
+    val Never = AutoTrimming(minUsagePercentage = 0, maxOverlaidPercentage = 100, usePadding = true)
+    /**
+      * Always auto trim the returned instance. NOTE: This could lead to bad performance (see documentation above for more information).
+    */
+    val Always = AutoTrimming(minUsagePercentage = 100, maxOverlaidPercentage = 0, usePadding = false)
+    /**
+      * Auto trim the returned instance using default values for the fields (see documentation above for more information).
+      */
+    val Default = AutoTrimming()
+  }
+
+  val Empty = create(Underlay.empty)
+  def empty[A <: Any]: ArraySeq[A] = Empty
+
+  private[immutable] final class Underlay[+A](array: scala.Array[Any], x: Int, y: Int) {
+    val start = minOf(x, y)
+    val stop = maxOf(x, y)
+
+    def toDebugString: String = s"${array.to(List).mkString("[", ", ", "]")}: Underlay(start: $start, stop: $stop, array: ${array.to(List).zipWithIndex.map(t => s"${t._2}: ${t._1}").mkString("[", ", ", "]").replace("null", "_")})"
+
+    override def toString = toDebugString
+
+    private[this] val bounds = new AtomicLong(pack(start, stop))
+
+    @`inline`
+    private[this] def pack(low: Int, high: Int): Long = low.toLong << 32 | (high & 0xffffffffL)
+    @`inline`
+    private[this] def unpackLow(l: Long): Int = (l >> 32).toInt
+    @`inline`
+    private[this] def unpackHigh(l: Long): Int = l.toInt
+
+    @`inline`
+    def capacity: Int = array.length
+
+    @`inline`
+    def elements: Array[Any] = array
+
+    @`inline`
+    def apply(s: Int): A = ScalaRunTime.array_apply(array, s).asInstanceOf[A]
+
+    @`inline`
+    def isFull: Boolean = {
+      val bnds = bounds.get()
+      isFull(unpackLow(bnds), unpackHigh(bnds))
+    }
+    @`inline`
+    def isFull(low: Int, high: Int): Boolean = distance(low, high) == capacity
+
+    def prependedElement[B >: A](elem: B, start: Int): Boolean = {
+      val bnds = bounds.get()
+      val low = unpackLow(bnds)
+      val high = unpackHigh(bnds)
+      val cap = capacity
+      if (low < start && identical(elem, apply(slot(start - 1, cap)))) true
+      else if (isFull(low, high)) false
+      else if (low > -cap && low == start && bounds.compareAndSet(bnds, pack(low - 1, high))) {
+        array(slot(start - 1, cap)) = elem
+        true
+      } else false
+    }
+
+    def appendedElement[B >: A](elem: B, stop: Int): Boolean = {
+      val bnds = bounds.get()
+      val low = unpackLow(bnds)
+      val high = unpackHigh(bnds)
+      val cap = capacity
+      if (high > stop && identical(elem, apply(slot(stop, cap)))) true
+      else if (isFull(low, high)) false
+      else if (high < cap && high == stop && bounds.compareAndSet(bnds, pack(low, high + 1))) {
+        array(slot(stop, cap)) = elem
+        true
+      } else false
+    }
+
+    def prependedElements[B >: A](that: ArraySeq[B], start: Int): Boolean = {
+      val bnds = bounds.get()
+      val low = unpackLow(bnds)
+      val high = unpackHigh(bnds)
+      val lowered = low - that.size
+      val cap = capacity
+      if (distance(lowered, high) > cap) false
+      else if (low == start && lowered >= -cap && bounds.compareAndSet(bnds, pack(lowered, high))) {
+        val (srcFrontStart, srcFrontStop, srcRearStart, srcRearStop) = segments(that.start, that.stop, that.capacity)
+        val dstFrontStart = slot(lowered, cap)
+        val frontLength = distance(srcFrontStop, srcFrontStart)
+        val dstRearStart = dstFrontStart + frontLength
+        val rearLength = srcRearStop - srcRearStart
+        layout(that.underlay, that.overlay, start, stop, srcFrontStart, frontLength, srcRearStart, rearLength, this.array, dstFrontStart, dstRearStart)
+        true
+      } else false
+    }
+
+    def appendedElements[B >: A](that: ArraySeq[B], stop: Int): Boolean = {
+      val bnds = bounds.get()
+      val low = unpackLow(bnds)
+      val high = unpackHigh(bnds)
+      val raised = high + that.size
+      val cap = capacity
+      if (distance(low, raised) > cap) false
+      else if (high == stop && raised <= cap && bounds.compareAndSet(bnds, pack(low, raised))) {
+        val (srcFrontStart, srcFrontStop, srcRearStart, srcRearStop) = segments(that.start, that.stop, that.capacity)
+        val dstFrontStart = slot(high, cap)
+        val frontLength = srcFrontStop - srcFrontStart
+        val dstRearStart = dstFrontStart + frontLength
+        val rearLength = srcRearStop - srcRearStart
+        layout(that.underlay, that.overlay, start, stop, srcFrontStart, frontLength, srcRearStart, rearLength, this.array, dstFrontStart, dstRearStart)
+        true
+      } else false
+    }
+
+    /**
+      * CAUTION! This method is highly dangerous since it resets the existing bounds of this instance. Only use when no other
+      * referrers to this instance exist with absolute certainty (for example during benchmarking to disregard any state
+      * affected in previous iterations).
+      */
+    def reset(): Unit = {
+      bounds.set(pack(start, stop))
+    }
+  }
+
+  private[immutable] object Underlay {
+    val Empty = new Underlay(Array.empty, 0, 0)
+    @`inline`
+    def empty[A <: Any]: Underlay[A] = Empty
+    @`inline`
+    def apply[A](array: Array[Any], stop: Int): Underlay[A] = new Underlay[A](array, 0, stop)
+    @`inline`
+    def apply[A](array: Array[Any], start: Int, stop: Int): Underlay[A] = new Underlay[A](array, start, stop)
+  }
+
+  private type Overlay[+A] = HashMap[Int, A]
+  private val Overlay = HashMap
+
+  //@`inline` // Causes compile error on Dotty
+  override def apply[A](xs: A*): ArraySeq[A] = {
+    (xs.size: @switch) match {
+      case 0 => Empty
+      case 1 => create(AutoTrimming.Default, xs(0))
+      case 2 => create(AutoTrimming.Default, xs(0), xs(1))
+      case 3 => create(AutoTrimming.Default, xs(0), xs(1), xs(2))
+      case 4 => create(AutoTrimming.Default, xs(0), xs(1), xs(2), xs(3))
+      case 5 => create(AutoTrimming.Default, xs(0), xs(1), xs(2), xs(3), xs(4))
+      case 6 => create(AutoTrimming.Default, xs(0), xs(1), xs(2), xs(3), xs(4), xs(5))
+      case 7 => create(AutoTrimming.Default, xs(0), xs(1), xs(2), xs(3), xs(4), xs(5), xs(6))
+      case 8 => create(AutoTrimming.Default, xs(0), xs(1), xs(2), xs(3), xs(4), xs(5), xs(6), xs(7))
+      case sz =>
+        val capacity = capacitate(sz)
+        val array = new Array[Any](capacity)
+        xs.copyToArray(array, 0, sz)
+        create(array, 0, sz)
+    }
+  }
+
+  def apply[A](it: Iterable[A]): ArraySeq[A] = from(it)
+
+  def apply[A](array: Array[A], index: Int = 0, length: Int = -1): ArraySeq[A] = {
+    val i = minOf(maxOf(index, 0), array.length)
+    val l = minOf(maxOf(length, 0), array.length - i)
+    if (l == 0) Empty
+    else {
+      val capacity = capacitate(l)
+      val arr = new Array[Any](capacity)
+      java.lang.System.arraycopy(array, i, arr, 0, l)
+      create(arr, 0, l)
+    }
+  }
+
+  @`inline`
+  private[this] def isExcessive(underlay: Underlay[_], start: Int, stop: Int, autoTrimming: AutoTrimming) = {
+    underlay.capacity > capacitate(1, autoTrimming.usePadding) &&
+      distance(start, stop) * 100 <= underlay.capacity * autoTrimming.minUsagePercentage
+  }
+
+  @`inline`
+  private[this] def isOverlaid(underlay: Underlay[_], overlay: Overlay[_], autoTrimming: AutoTrimming) = {
+    overlay != null &&
+      overlay.size * 100 >= underlay.capacity * autoTrimming.maxOverlaidPercentage
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming): ArraySeq[A] = {
+    empty[A].withAutoTrimming(autoTrimming)
+  }
+  
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 1
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    create(array, 0, 1, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 2
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    create(array, 0, 2, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 3
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    create(array, 0, 3, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A, a3: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 4
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    array(3) = a3
+    create(array, 0, 4, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A, a3: A, a4: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 5
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    array(3) = a3
+    array(4) = a4
+    create(array, 0, 5, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A, a3: A, a4: A, a5: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 6
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    array(3) = a3
+    array(4) = a4
+    array(5) = a5
+    create(array, 0, 6, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A, a3: A, a4: A, a5: A, a6: A): ArraySeq[A] = {
+    val capacity = if (autoTrimming.usePadding) 8 else 7
+    val array = new Array[Any](capacity)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    array(3) = a3
+    array(4) = a4
+    array(5) = a5
+    array(6) = a6
+    create(array, 0, 7, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](autoTrimming: AutoTrimming, a0: A, a1: A, a2: A, a3: A, a4: A, a5: A, a6: A, a7: A): ArraySeq[A] = {
+    val array = new Array[Any](8)
+    array(0) = a0
+    array(1) = a1
+    array(2) = a2
+    array(3) = a3
+    array(4) = a4
+    array(5) = a5
+    array(6) = a6
+    array(7) = a7
+    create(array, 0, 8, autoTrimming)
+  }
+
+  private def create[A](underlay: Underlay[A], overlay: Overlay[A], start: Int, stop: Int, autoTrimming: AutoTrimming, trim: Boolean): ArraySeq[A] = {
+    if (trim && (
+        isExcessive(underlay, start, stop, autoTrimming) ||
+        isOverlaid(underlay, overlay, autoTrimming)))
+      allocate(underlay, overlay, start, stop, autoTrimming)
+    else
+      create(underlay, overlay, start, stop, autoTrimming)
+  }
+
+  @`inline`
+  private def create[A](array: Array[Any], start: Int, stop: Int): ArraySeq[A] =
+    create(array, start, stop, AutoTrimming.Default)
+
+  @`inline`
+  private def create[A](array: Array[Any], start: Int, stop: Int, autoTrimming: AutoTrimming): ArraySeq[A] =
+    create(Underlay(array, start, stop), null, start, stop, autoTrimming)
+
+  @`inline`
+  private def create[A](underlay: Underlay[A]): ArraySeq[A] =
+    create(underlay, null, underlay.start, underlay.stop, AutoTrimming.Default)
+
+  // @`inline` // No inlining of private constructors in Dotty.
+  private def create[A](underlay: Underlay[A], overlay: Overlay[A], start: Int, stop: Int, autoTrimming: AutoTrimming): ArraySeq[A] =
+    new ArraySeq[A](underlay, overlay, start, stop, autoTrimming)
+
+  @`inline`
+  private def slot(i: Int, start: Int, stop: Int, capacity: Int): Int =
+    if (ArraySeq.isReversed(start, stop)) slot(start - i - 1, capacity)
+    else slot(start + i, capacity)
+
+  @`inline`
+  private def slot(p: Int, capacity: Int): Int =
+    if (p >= 0) p
+    else capacity + p
+
+  /*
+  //@`inline`
+  private def pow2(n: Int): Int = {
+    if (n <= MinCapacity) MinCapacity
+    else {
+      var pow = n - 1
+      pow |= (pow >>> 1)
+      pow |= (pow >>> 2)
+      pow |= (pow >>> 4)
+      pow |= (pow >>> 8)
+      pow |= (pow >>> 16)
+      pow += 1
+      if (pow < 0) pow >>>= 1
+      pow
+    }
+  }
+  */
+
+  @`inline`
+  private def capacitate(n: Int, padded: Boolean = AutoTrimming.DefaultUsePadding): Int = {
+    if (padded) {
+      if (n <= 0) 0
+      else if (n <= 8) 8
+      else if (n <= 16) 16
+      else if (n <= 32) 32
+      else if (n <= 64) 64
+      else if (n <= 128) 128
+      else {
+        var pow = n - 1
+        pow |= (pow >>> 1)
+        pow |= (pow >>> 2)
+        pow |= (pow >>> 4)
+        pow |= (pow >>> 8)
+        pow |= (pow >>> 16)
+        pow += 1
+        if (pow < 0) pow >>>= 1
+        pow
+      }
+    } else maxOf(n, 0)
+  }
+
+  @`inline`
+  private def allocate[A](underlay: Underlay[A], overlay: Overlay[A], start: Int, stop: Int, autoTrimming: AutoTrimming): ArraySeq[A] = {
+    allocate(capacitate(distance(start, stop), autoTrimming.usePadding), underlay, overlay, start, stop, autoTrimming)
+  }
+
+  private def allocate[A](capacity: Int, underlay: Underlay[A], overlay: Overlay[A], start: Int, stop: Int, autoTrimming: AutoTrimming): ArraySeq[A] = {
+    val (srcFrontStart, srcFrontStop, srcRearStart, srcRearStop) = segments(start, stop, underlay.capacity)
+    val array = new Array[Any](capacity)
+    val frontLength = distance(srcFrontStop, srcFrontStart)
+    val rearLength = distance(srcRearStop, srcRearStart)
+    layout(underlay, overlay, start, stop, srcFrontStart, frontLength, srcRearStart, rearLength, array)
+
+    // Shift polarity of frontLength when creating underlay (since negative values are used to count from the end of the array).
+    if (isReversed(start, stop))
+      create(array, rearLength, -frontLength, autoTrimming)
+    else
+      create(array, -frontLength, rearLength, autoTrimming)
+  }
+
+  //@`inline` // Causes compile error on Dotty
+  private def layout(underlay: Underlay[_], overlay: Overlay[_], start: Int, stop: Int, srcFrontStart: Int, frontLength: Int, srcRearStart: Int, rearLength: Int, dst: Array[Any], dstFrontStart: Int = -1, dstRearStart: Int = 0): Unit = {
+    if (underlay != null) {
+      if (rearLength > 0)
+        java.lang.System.arraycopy(underlay.elements, srcRearStart, dst, dstRearStart, rearLength)
+      if (frontLength > 0)
+        java.lang.System.arraycopy(underlay.elements, srcFrontStart, dst, if (dstFrontStart >= 0) dstFrontStart else dst.length - frontLength, frontLength)
+    }
+    if (overlay != null) {
+      val it = overlay.iterator()
+      while (it.hasNext) {
+        val (i, elem) = it.next()
+        var j = i - srcRearStart
+        if (j >= underlay.capacity) j -= underlay.capacity
+        dst(j) = elem
+      }
+    }
+  }
+
+  @`inline`
+  private def identical(a: Any, b: Any) = {
+    (a.isInstanceOf[AnyRef] && b.isInstanceOf[AnyRef] && a.asInstanceOf[AnyRef].eq(b.asInstanceOf[AnyRef])) ||
+    (a == b)
+  }
+
+  override def tabulate[A](n: Int)(f: Int => A): ArraySeq[A] = {
+    (n: @switch) match {
+      case 0 => Empty
+      case 1 => apply(f(0))
+      case 2 => apply(f(0), f(1))
+      case 3 => apply(f(0), f(1), f(2))
+      case 4 => apply(f(0), f(1), f(2), f(3))
+      case 5 => apply(f(0), f(1), f(2), f(3), f(4))
+      case 6 => apply(f(0), f(1), f(2), f(3), f(4), f(5))
+      case 7 => apply(f(0), f(1), f(2), f(3), f(4), f(5), f(6))
+      case 8 => apply(f(0), f(1), f(2), f(3), f(4), f(5), f(6), f(7))
+      case _ =>
+        val capacity = capacitate(n)
+        val array = new Array[Any](capacity)
+        var i = 0
+        while (i < n) {
+          array(i) = f(i)
+          i += 1
+        }
+        create(array, 0, n)
+    }
+  }
+
+  override def fill[A](n: Int)(elem: => A): ArraySeq[A] = tabulate(n)(_ => elem)
+
+  @`inline`
+  def from[A](xs: A*): ArraySeq[A] = from(View.Elems(xs: _*), -1)
+
+  @`inline`
+  def from[A](xs: collection.IterableOnce[A]): ArraySeq[A] = from(xs, -1)
+
+  def from[A](xs: collection.IterableOnce[A], knownSize: Int): ArraySeq[A] = xs match {
+    case that: ArraySeq[A] ⇒ that
+    case _ =>
+      val sz =
+        if (knownSize > 0) knownSize
+        else xs match {
+          case ys: Iterable[_] => ys.knownSize
+          case _ => -1
+        }
+      if (sz == 0) Empty
+      else if (sz == 1) ArraySeq(xs.iterator().next())
+      else {
+        val builder = newBuilder[A](sz)
+        builder ++= xs
+        builder.result()
+      }
+  }
+
+  /**
+    * CAUTION! This method is dangerous since it does not copy the provided array but instead uses the instance directly.
+    * Any later modifications to the provided array will show through to the returned `ArraySeq` instance.
+    * @param array array to use for element storage
+    * @param length the number of elements present in the array (defaults to -1 which will use the array length instead)
+    * @tparam A the element type to use
+    * @return a new instance using the provided array for element storage (or the empty `ArraySeq` if the provided array is empty).
+    */
+  def wrap[A](array: Array[Any], length: Int = -1): ArraySeq[A] =
+    if (array.length == 0) Empty
+    else {
+      val sz = if (length > -1) length else array.length
+      create(array, 0, sz)
+    }
+
+  /** A class to build instances of `ArraySeq`.  This builder is reusable. */
+  final class Builder[A] private[ArraySeq] (private var sizeHint: Int, autoTrimming: AutoTrimming) extends ReusableBuilder[A, ArraySeq[A]] {
+    private var length = 0
+    private var capacity = 0
+    private var elems: Array[Any] = _
+
+    override def clear() = {
+      sizeHint = -1
+      length = 0
+      capacity = 0
+      elems = null
+    }
+
+    override def sizeHint(size: Int) = {
+      sizeHint = size
+    }
+
+    override def add(elem: A) = {
+      if (length == capacity) {
+        capacity = capacitate(maxOf(length + 1, sizeHint))
+        val array = new Array[Any](capacity)
+        if (length > 0) java.lang.System.arraycopy(elems, 0, array, 0, length)
+        elems = array
+      }
+      elems(length) = elem
+      length += 1
+      this
+    }
+
+    override def addAll(xs: IterableOnce[A]) = {
+      val it = xs.iterator()
+      while (it.hasNext)
+        add(it.next())
+      this
+  }
+
+    override def result(): ArraySeq[A] = {
+      if (length == 0) create(autoTrimming)
+      else {
+        val array = elems
+        elems = null
+        if (!autoTrimming.usePadding && length < array.length) create(array, 0, length, autoTrimming).trim()
+        else create(array, 0, length, autoTrimming)
+      }
+    }
+  }
+
+  def newBuilder[A](): Builder[A] = newBuilder(-1, AutoTrimming.Default)
+  def newBuilder[A](sizeHint: Int = -1, autoTrimming: AutoTrimming = AutoTrimming.Default): Builder[A] = new Builder[A](sizeHint, autoTrimming)
+
+  @`inline`
+  private def isReversed(start: Int, stop: Int): Boolean = start > stop
+
+  @`inline`
+  private def segments(start: Int, stop: Int, capacity: Int): (Int, Int, Int, Int) = {
+    val x = minOf(start, stop)
+    val y = maxOf(start, stop)
+    if (x < 0 && y <= 0) (capacity + x, capacity + y, 0, 0)
+    else if (x < 0) (capacity + x, capacity, 0, y)
+    else if (y < 0) (capacity + y, capacity, 0, x)
+    else (0, 0, x, y)
+  }
+
+  @`inline`
+  private def distance(x: Int, y: Int): Int =
+    if (x < y) y - x
+    else x - y
+
+  @`inline`
+  private def maxOf(x: Int, y: Int): Int = if (x >= y) x else y
+  @`inline`
+  private def minOf(x: Int, y: Int): Int = if (x <= y) x else y
+}

--- a/collections/src/test/scala/strawman/collection/immutable/ArraySeqTest.scala
+++ b/collections/src/test/scala/strawman/collection/immutable/ArraySeqTest.scala
@@ -1,0 +1,1313 @@
+package strawman
+package collection
+package immutable
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.{Any, Exception, Int, NoSuchElementException, IndexOutOfBoundsException, Nothing, Unit}
+import scala.Predef.{identity, intWrapper, ArrowAssoc}
+import scala.runtime.RichInt
+import scala.util.Try
+import scala.util.control.NonFatal
+import strawman.collection.immutable.ArraySeq.AutoTrimming
+
+class ArraySeqTest {
+  val O = null
+
+  @Test
+  def testEmpty(): Unit = {
+    assertEquals("apply with no arguments is equal to empty", ArraySeq.empty, ArraySeq())
+    assertEquals("apply with no arguments has size 0", 0, ArraySeq().size)
+    assertEquals("apply with no arguments has empty iterator", false, ArraySeq.empty.iterator().hasNext)
+  }
+
+  @Test
+  def testApply(): Unit = {
+    assertEquals("apply with 00 arguments has correct elements array", List(), ArraySeq().array.to(List))
+    assertEquals("apply with 01 argument  has correct elements array", List(1, O, O, O, O, O, O, O), ArraySeq(1).array.to(List))
+    assertEquals("apply with 02 arguments has correct elements array", List(1, 2, O, O, O, O, O, O), ArraySeq(1, 2).array.to(List))
+    assertEquals("apply with 03 arguments has correct elements array", List(1, 2, 3, O, O, O, O, O), ArraySeq(1, 2, 3).array.to(List))
+    assertEquals("apply with 04 arguments has correct elements array", List(1, 2, 3, 4, O, O, O, O), ArraySeq(1, 2, 3, 4).array.to(List))
+    assertEquals("apply with 05 arguments has correct elements array", List(1, 2, 3, 4, 5, O, O, O), ArraySeq(1, 2, 3, 4, 5).array.to(List))
+    assertEquals("apply with 06 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, O, O), ArraySeq(1, 2, 3, 4, 5, 6).array.to(List))
+    assertEquals("apply with 07 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, O), ArraySeq(1, 2, 3, 4, 5, 6, 7).array.to(List))
+    assertEquals("apply with 08 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, 8), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8).array.to(List))
+    assertEquals("apply with 09 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, 8, 9, O, O, O, O, O, O, O), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).array.to(List))
+    assertEquals("apply with 10 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, O, O, O, O, O, O), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).array.to(List))
+    assertEquals("apply with 11 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, O, O, O, O, O), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).array.to(List))
+    assertEquals("apply with 11 arguments has correct elements array", List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, O, O, O, O), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).array.to(List))
+  }
+
+  @Test
+  def testBuild(): Unit = {
+    assertEquals("empty", ArraySeq.empty, ArraySeq.newBuilder().result())
+    assertEquals("single", ArraySeq(2), ArraySeq.newBuilder().add(2).result())
+    assertEquals("multiple one by one", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq.newBuilder().add(1).add(2).add(3).add(4).add(5).add(6).add(7).add(8).add(9).add(10).add(11).add(12).result())
+    assertEquals("multiple all at once", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq.newBuilder().addAll(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)).result())
+  }
+
+  @Test
+  def testExpandFront(): Unit = {
+    val O = null
+    val a = 1 +: 2 +: ArraySeq(3, 4, 5, 6) :+ 7
+    assertEquals("no unnecessary expansion", List(3, 4, 5, 6, 7, 0, 1, 2), (0 +: a).array.to(List))
+    val b = 1 +: 2 +: ArraySeq(3, 4, 5, 6) :+ 7 :+ 8
+    assertEquals("expands correctly 1", List(3, 4, 5, 6, 7, 8, O, O, O, O, O, O, O, 0, 1, 2), (0 +: b).array.to(List))
+    val c = 1 +: 2 +: ArraySeq(3, 4, 5, 6, 7, 8)
+    assertEquals("expands correctly 2", List(3, 4, 5, 6, 7, 8, O, O, O, O, O, O, O, 0, 1, 2), (0 +: c).array.to(List))
+    val d = 1 +: 2 +: ArraySeq(3, 4, 5, 6, 7, 8, 9, 10)
+    assertEquals("expands correctly 3", List(3, 4, 5, 6, 7, 8, 9, 10, O, O, O, O, O, 0, 1, 2), (0 +: d).array.to(List))
+    val e = 0 +: 1 +: 2 +: ArraySeq(3, 4, 5, 6, 7, 8, 9)
+    assertEquals("expands correctly 4", List(3, 4, 5, 6, 7, 8, 9, O, O, O, O, O, -1, 0, 1, 2), (-1 +: e).array.to(List))
+    val f = 0 +: 1 +: 2 +: ArraySeq(3)
+    assertEquals("expands correctly 5", List(3, O, O, O, -1, 0, 1, 2), (-1 +: f).array.to(List))
+    val g = ArraySeq(1, 2, 3, 4, 5, 6, 7, 8)
+    val h = g.dropRight(7)
+    assertEquals("expands correctly 6", List(1, O, O, O, O, O, O, 0), (0 +: h).array.to(List))
+    val i = g.dropRight(8)
+    assertEquals("expands correctly 7", List(O, O, O, O, O, O, O, 0), (0 +: i).array.to(List))
+  }
+
+  @Test
+  def testExpandEnd(): Unit = {
+    val a = 2 +: ArraySeq(3, 4, 5, 6) :+ 7 :+ 8
+    assertEquals("no unnecessary expansion", List(3, 4, 5, 6, 7, 8, 9, 2), (a :+ 9).array.to(List))
+    val b = 1 +: 2 +: ArraySeq(3, 4, 5, 6) :+ 7 :+ 8
+    assertEquals("expands correctly 1", List(3, 4, 5, 6, 7, 8, 9, O, O, O, O, O, O, O, 1, 2), (b :+ 9).array.to(List))
+    val c = ArraySeq(3, 4, 5, 6) :+ 7 :+ 8
+    assertEquals("expands correctly 2", List(3, 4, 5, 6, 7 ,8, 9, O), (c :+ 9).array.to(List))
+    val d = ArraySeq(0, 1, 2, 3, 4) :+ 5 :+ 6 :+ 7
+    assertEquals("expands correctly 3", List(0, 1, 2, 3, 4, 5, 6, 7, 8, O, O, O, O, O, O, O), (d :+ 8).array.to(List))
+    val g = ArraySeq(1, 2, 3, 4, 5, 6, 7, 8)
+    val h = g.drop(7)
+    assertEquals("expands correctly 4", List(8, 9, O, O, O, O, O, O), (h :+ 9).array.to(List))
+    val i = g.drop(8)
+    assertEquals("expands correctly 5", List(9, O, O, O, O, O, O, O), (i :+ 9).array.to(List))
+  }
+
+  @Test
+  def testSingleElement(): Unit = {
+    assertEquals("apply with single argument has length 1", 1, ArraySeq(1).length)
+    val it = ArraySeq(1).iterator()
+    assertTrue("apply with single argument has single element iterator", it.hasNext)
+    assertEquals("apply with single argument has single element iterator with correct element", 1, it.next())
+    assertFalse("apply with single argument has only single element iterator", it.hasNext)
+    val rit = ArraySeq(1).reverse.iterator()
+    assertTrue("apply with reversed single argument has single element iterator with correct element",
+      rit.hasNext && rit.next() == 1)
+    assertFalse("apply with reversed single argument has only single element iterator", rit.hasNext)
+    assertEquals("apply with single argument has correct element at index 0", 1, ArraySeq(1)(0))
+    assertEquals("apply with reversed single argument has correct element at index 0", 1, ArraySeq(1).reverse.apply(0))
+    assertEquals("apply with single argument has correct element as head", 1, ArraySeq(1).head)
+    assertEquals("apply with reversed single argument has correct element as head", 1, ArraySeq(1).reverse.head)
+    assertEquals("apply with single argument has empty tail", ArraySeq.empty, ArraySeq(1).tail)
+    assertEquals("apply with reversed single argument has empty tail", ArraySeq.empty, ArraySeq(1).reverse.tail)
+  }
+
+  @Test
+  def testReverse(): Unit = {
+    assertEquals("reverse empty is empty", ArraySeq.empty, ArraySeq.empty.reverse)
+    assertEquals("reverse effectively empty is empty", ArraySeq.empty, ArraySeq(1, 2, 3).filter(_ == 4).reverse)
+    assertEquals("reverse single is same", ArraySeq(1), ArraySeq(1).reverse)
+    assertEquals("reverse effectively single is same", ArraySeq(1), ArraySeq(1, 2).take(1).reverse)
+    assertEquals("reverse double is correct", ArraySeq(2, 1), ArraySeq(1, 2).reverse)
+    assertEquals("reverse effectively double is correct", ArraySeq(2, 1), ArraySeq(1, 2, 3).take(2).reverse)
+    assertEquals("reverse large is correct", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0), ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).reverse)
+    val reverse = ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).reverse
+    val reverse2 = reverse.reverse
+    assertEquals("reverse reverse large is correct", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), reverse2)
+  }
+
+  @Test
+  def testHeadsAndTails(): Unit = {
+    assertTrue("empty tail fails", Try(ArraySeq.empty.tail).isFailure)
+    assertTrue("empty reverse tail fails", Try(ArraySeq.empty.reverse.tail).isFailure)
+    assertEquals("tail", ArraySeq(2, 3, 4), ArraySeq(1, 2, 3, 4).tail)
+    val r = ArraySeq(1, 2, 3, 4).reverse
+    assertEquals("reverse tail", ArraySeq(3, 2, 1), r.tail)
+    assertEquals("tail tail", ArraySeq(3, 4), ArraySeq(1, 2, 3, 4).tail.tail)
+    assertEquals("tail reverse tail", ArraySeq(3, 2), ArraySeq(1, 2, 3, 4).tail.reverse.tail)
+    assertEquals("tail tail tail", ArraySeq(4), ArraySeq(1, 2, 3, 4).tail.tail.tail)
+    assertEquals("tail tail reverse tail", ArraySeq(3), ArraySeq(1, 2, 3, 4).tail.tail.reverse.tail)
+    assertEquals("tail tail tail tail", ArraySeq.empty, ArraySeq(1, 2, 3, 4).tail.tail.tail.tail)
+    assertEquals("tail tail tail reverse tail", ArraySeq.empty, ArraySeq(1, 2, 3, 4).tail.tail.tail.reverse.tail)
+    assertTrue("empty head fails", Try(ArraySeq.empty.head).isFailure)
+    assertEquals("head", 1, ArraySeq(1, 2, 3, 4).head)
+    assertEquals("reverse head", 4, ArraySeq(1, 2, 3, 4).reverse.head)
+    assertEquals("reverse tail head", 3, ArraySeq(1, 2, 3, 4).reverse.tail.head)
+    assertEquals("tail tail head", 3, ArraySeq(1, 2, 3, 4).tail.tail.head)
+    assertEquals("reverse tail tail reverse head", 1, ArraySeq(1, 2, 3, 4).reverse.tail.tail.reverse.head)
+    assertEquals("tail tail tail head", 4, ArraySeq(1, 2, 3, 4).tail.tail.tail.head)
+    assertEquals("tail reverse tail reverse tail reverse head", 3, ArraySeq(1, 2, 3, 4).tail.reverse.tail.reverse.tail.reverse.head)
+  }
+
+  @Test
+  def testTakeAndDrop(): Unit = {
+    assertEquals("take 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).take(0))
+    assertEquals("reverse take 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).reverse.take(0))
+    assertEquals("take 1", ArraySeq(1), ArraySeq(1, 2, 3, 4).take(1))
+    assertEquals("reverse take 1", ArraySeq(4), ArraySeq(1, 2, 3, 4).reverse.take(1))
+    assertEquals("take 2", ArraySeq(1, 2), ArraySeq(1, 2, 3, 4).take(2))
+    assertEquals("reverse take 2", ArraySeq(4, 3), ArraySeq(1, 2, 3, 4).reverse.take(2))
+    assertEquals("drop 0", ArraySeq(1, 2, 3, 4), ArraySeq(1, 2, 3, 4).drop(0))
+    assertEquals("reverse drop 0", ArraySeq(4, 3, 2, 1), ArraySeq(1, 2, 3, 4).reverse.drop(0))
+    assertEquals("drop 1", ArraySeq(2, 3, 4), ArraySeq(1, 2, 3, 4).drop(1))
+    assertEquals("reverse drop 1", ArraySeq(3, 2, 1), ArraySeq(1, 2, 3, 4).reverse.drop(1))
+    assertEquals("drop 2", ArraySeq(3, 4), ArraySeq(1, 2, 3, 4).drop(2))
+    assertEquals("reverse drop 2", ArraySeq(2, 1), ArraySeq(1, 2, 3, 4).reverse.drop(2))
+    assertEquals("drop 1 take 1", ArraySeq(2), ArraySeq(1, 2, 3, 4).drop(1).take(1))
+    assertEquals("reverse drop 1 take 1", ArraySeq(3), ArraySeq(1, 2, 3, 4).reverse.drop(1).take(1))
+    assertEquals("drop 2 take 1", ArraySeq(3), ArraySeq(1, 2, 3, 4).drop(2).take(1))
+    assertEquals("reverse drop 2 take 1", ArraySeq(2), ArraySeq(1, 2, 3, 4).reverse.drop(2).take(1))
+    assertEquals("drop 2 take 2", ArraySeq(3, 4), ArraySeq(1, 2, 3, 4).drop(2).take(2))
+    assertEquals("reverse drop 2 take 2", ArraySeq(2, 1), ArraySeq(1, 2, 3, 4).reverse.drop(2).take(2))
+    assertEquals("drop 2 take 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).drop(2).take(0))
+    assertEquals("reverse drop 2 take 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).reverse.drop(2).take(0))
+    assertEquals("drop 2 take 2 drop 1 take 1", ArraySeq(4), ArraySeq(1, 2, 3, 4).drop(2).take(2).drop(1).take(1))
+    assertEquals("reverse drop 2 take 2 drop 1 take 1", ArraySeq(1), ArraySeq(1, 2, 3, 4).reverse.drop(2).take(2).drop(1).take(1))
+  }
+
+  @Test
+  def testFilter(): Unit = {
+    assertEquals("filter empty", ArraySeq.empty, ArraySeq().filter(_ != null))
+    assertEquals("filter single inclusive", ArraySeq(2), ArraySeq(2).filter(_ > 1))
+    assertEquals("filter single exclusive", ArraySeq(), ArraySeq(1).filter(_ > 1))
+    assertEquals("filter multiple even", ArraySeq(2, 4), ArraySeq(1, 2, 3, 4).filter(_ % 2 == 0))
+    assertEquals("reverse filter multiple even", ArraySeq(4, 2), ArraySeq(1, 2, 3, 4).reverse.filter(_ % 2 == 0))
+    assertEquals("filter multiple odd", ArraySeq(1, 3), ArraySeq(1, 2, 3, 4).filter(_ % 2 == 1))
+    assertEquals("reverse filter multiple odd", ArraySeq(3, 1), ArraySeq(1, 2, 3, 4).reverse.filter(_ % 2 == 1))
+  }
+
+  @Test
+  def testMap(): Unit = {
+    assertEquals("map empty", ArraySeq.empty, ArraySeq().map(identity))
+    assertEquals("reverse map empty", ArraySeq.empty, ArraySeq().reverse.map(identity))
+    assertEquals("map single", ArraySeq(4), ArraySeq(2).map(n => n * n))
+    assertEquals("reverse map single", ArraySeq(4), ArraySeq(2).reverse.map(n => n * n))
+    assertEquals("map multiple", ArraySeq(1, 4, 9, 16), ArraySeq(1, 2, 3, 4).map(n => n * n))
+    assertEquals("reverse map multiple", ArraySeq(16, 9, 4, 1), ArraySeq(1, 2, 3, 4).reverse.map(n => n * n))
+  }
+
+  @Test
+  def testCollect(): Unit = {
+    assertEquals("empty", ArraySeq.empty, ArraySeq().collect { case n => n })
+    assertEquals("reverse empty", ArraySeq.empty, ArraySeq().reverse.collect { case n => n })
+    assertEquals("single", ArraySeq(4), ArraySeq(2).collect { case n => n * n })
+    assertEquals("single miss", ArraySeq(2), ArraySeq(2).collect {
+      case n if n != 2 => n * n
+      case n => n
+    } )
+    assertEquals("reverse single", ArraySeq(4), ArraySeq(2).reverse.collect { case n => n * n})
+    assertEquals("reverse single miss", ArraySeq(2), ArraySeq(2).reverse.collect {
+      case n if n != 2 => n * n
+      case n => n
+    })
+    assertEquals("multiple mixed", ArraySeq(1, 2, 9, 16), ArraySeq(1, 2, 3, 4).collect {
+      case n if n != 2 => n * n
+      case n => n
+    })
+    assertEquals("reverse multiple mixed", ArraySeq(16, 9, 2, 1), ArraySeq(1, 2, 3, 4).reverse.collect {
+      case n if n != 2 => n * n
+      case n => n
+    })
+  }
+
+  @Test
+  def testFlatMap(): Unit = {
+    assertEquals("flatmap empty", ArraySeq.empty, ArraySeq().flatMap((x: Any) => ArraySeq(x)))
+    assertEquals("flatmap single", ArraySeq(2), ArraySeq(2).flatMap(n => ArraySeq(n)))
+    assertEquals("flatmap multiple", ArraySeq(2, 4, 4, 16), ArraySeq(1, 2, 3, 4).flatMap {
+      case n if n % 2 == 0 => ArraySeq(n, n * n)
+      case _ => ArraySeq.empty
+    })
+    assertEquals("reverse flatmap multiple", ArraySeq(4, 16, 2, 4), ArraySeq(1, 2, 3, 4).reverse.flatMap {
+      case n if n % 2 == 0 => ArraySeq(n, n * n)
+      case _ => ArraySeq.empty
+    })
+  }
+
+  @Test
+  def testFill(): Unit = {
+    assertEquals("fill empty", ArraySeq.empty, ArraySeq.fill(0)(9))
+    assertEquals("fill single", ArraySeq(9), ArraySeq.fill(1)(9))
+    assertEquals("fill multiple", ArraySeq(9, 9, 9), ArraySeq.fill(3)(9))
+    assertEquals("fill multiple reverse", ArraySeq(9, 9, 9), ArraySeq.fill(3)(9).reverse)
+  }
+
+  @Test
+  def testPrepend(): Unit = {
+    assertEquals("prepend on empty", ArraySeq(1), 1 +: ArraySeq.empty)
+    assertEquals("prepend on empty reversed", ArraySeq(1), 1 +: ArraySeq.empty.reverse)
+    assertEquals("prepend single", ArraySeq(1, 2, 3, 4), 1 +: ArraySeq(2, 3, 4))
+    assertEquals("prepend single on reversed", ArraySeq(1, 4, 3, 2), 1 +: ArraySeq(2, 3, 4).reverse)
+    assertEquals("prepend multiple", ArraySeq(0, 1, 2, 3, 4), 0 +: 1 +: ArraySeq(2, 3, 4))
+    assertEquals("prepend multiple on reversed", ArraySeq(0, 1, 4, 3, 2), 0 +: 1 +: ArraySeq(2, 3, 4).reverse)
+    assertEquals(
+      "prepend multiple over beginning of array",
+      ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6),
+      -2 +: -1 +: 0 +: ArraySeq(1, 2, 3, 4, 5, 6))
+    val x = -1 +: 0 +: ArraySeq(1, 2, 3, 4, 5, 6).reverse
+    assertEquals(
+      "prepend multiple over beginning of array on reversed",
+      ArraySeq(-2, -1, 0, 6, 5, 4, 3, 2, 1),
+      -2 +: x)
+  }
+
+  @Test
+  def testAppend(): Unit = {
+    assertEquals("append on empty", ArraySeq(1), ArraySeq.empty :+ 1)
+    assertEquals("append on empty reversed", ArraySeq(1), ArraySeq.empty.reverse :+ 1)
+    assertEquals("append single", ArraySeq(1, 2, 3, 4), ArraySeq(1, 2, 3) :+ 4)
+    assertEquals("append single on reversed", ArraySeq(3, 2, 1, 4), ArraySeq(1, 2, 3).reverse :+ 4)
+    assertEquals("append multiple", ArraySeq(1, 2, 3, 4, 5), ArraySeq(1, 2, 3) :+ 4 :+ 5)
+    assertEquals("append multiple on reversed", ArraySeq(3, 2, 1, 4, 5), ArraySeq(1, 2, 3).reverse :+ 4 :+ 5)
+    assertEquals(
+      "append multiple over ending of array",
+      ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+      ArraySeq(1, 2, 3, 4, 5, 6) :+ 7 :+ 8 :+ 9 :+ 10)
+    assertEquals(
+      "append multiple over ending of array reversed",
+      ArraySeq(6, 5, 4, 3, 2, 1, 7, 8, 9, 10),
+      ArraySeq(1, 2, 3, 4, 5, 6).reverse :+ 7 :+ 8 :+ 9 :+ 10)
+  }
+
+  @Test
+  def testAppendAll(): Unit = {
+    assertEquals("on empty", ArraySeq(1, 2, 3), ArraySeq.empty :++ List(1, 2, 3))
+    assertEquals("on reversed empty", ArraySeq(1, 2, 3), ArraySeq.empty.reverse :++ List(1, 2, 3))
+    assertEquals("on single", ArraySeq(1, 2, 3, 4), ArraySeq(1) :++ List(2, 3, 4))
+    assertEquals("on reversed single", ArraySeq(1, 2, 3, 4), ArraySeq(1).reverse :++ List(2, 3, 4))
+    assertEquals("on multiple", ArraySeq(1, 2, 3, 4, 5, 6), ArraySeq(1, 2, 3) :++ List(4, 5, 6))
+    assertEquals("on reversed multiple", ArraySeq(3, 2, 1, 4, 5, 6), ArraySeq(1, 2, 3).reverse :++ List(4, 5, 6))
+    assertEquals("on multiple over rear", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), ArraySeq(1, 2, 3, 4, 5, 6, 7) :++ List(8, 9, 10, 11))
+    assertEquals("on reversed multiple over rear", ArraySeq(7, 6, 5, 4, 3, 2, 1, 8, 9, 10, 11), ArraySeq(1, 2, 3, 4, 5, 6, 7).reverse :++ List(8, 9, 10, 11))
+  }
+
+  @Test
+  def testPrependAll(): Unit = {
+    assertEquals("on empty", ArraySeq(1, 2, 3), List(1, 2, 3) ++: ArraySeq.empty)
+    assertEquals("on reversed empty", ArraySeq(1, 2, 3), List(1, 2, 3) ++: ArraySeq.empty.reverse)
+    assertEquals("on single", ArraySeq(1, 2, 3, 4), List(1, 2, 3) ++: ArraySeq(4))
+    assertEquals("on reversed single", ArraySeq(1, 2, 3, 4), List(1, 2, 3) ++: ArraySeq(4).reverse)
+    assertEquals("on multiple", ArraySeq(1, 2, 3, 4, 5, 6), List(1, 2, 3) ++: ArraySeq(4, 5, 6))
+    assertEquals("on reversed multiple", ArraySeq(1, 2, 3, 6, 5, 4), List(1, 2, 3) ++: ArraySeq(4, 5, 6).reverse)
+    assertEquals("on multiple over front", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), List(1, 2, 3, 4) ++: ArraySeq(5, 6, 7, 8, 9, 10, 11))
+    assertEquals("on reversed multiple over front", ArraySeq(1, 2, 3, 4, 11, 10, 9, 8, 7, 6, 5), List(1, 2, 3, 4) ++: ArraySeq(5, 6, 7, 8, 9, 10, 11).reverse)
+    assertEquals("with list on empty", ArraySeq(1, 2, 3), List(1, 2, 3) ++: ArraySeq.empty)
+    assertEquals("with multiple lists", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4), List(-3, -2) ++: List(-1, 0) ++: 1 +: ArraySeq(2, 3, 4))
+    assertEquals("with multiple lists reversed", ArraySeq(-3, -2, 4, 3, 2, 1, 0, -1), List(-3, -2) ++: (List(-1, 0) ++: 1 +: ArraySeq(2, 3, 4)).reverse)
+  }
+
+  @Test
+  def testPrependAndAppendEqual(): Unit = {
+    assertEquals("prepend equal on empty", ArraySeq(1), 1 +: (1 +: ArraySeq.empty).tail)
+    assertEquals("append equal on empty", ArraySeq(1), (ArraySeq.empty :+ 1).take(0) :+ 1)
+    assertEquals("prepend equal on single", ArraySeq(0, 1), 0 +: (0 +: ArraySeq(1)).tail)
+    assertEquals("append equal on single", ArraySeq(1, 2), (ArraySeq(1) :+ 2).take(1) :+ 2)
+    val a = ArraySeq(1, 2, 3)
+    val b = 0 +: a
+    val c = b.tail
+    val d = 0 +: c
+    val e = -1 +: b
+    val f = -2 +: d
+    assertEquals("prepend equal", ArraySeq(1, 2, 3), a)
+    assertEquals("prepend equal", ArraySeq(0, 1, 2, 3), b)
+    assertEquals("prepend equal", ArraySeq(1, 2, 3), c)
+    assertEquals("prepend equal", ArraySeq(0, 1, 2, 3), d)
+    assertTrue("prepend eq arrays", b.array eq d.array)
+    assertEquals("prepend equal", ArraySeq(-1, 0, 1, 2, 3), e)
+    assertEquals("prepend equal", ArraySeq(-2, 0, 1, 2, 3), f)
+  }
+
+  @Test
+  def testConcat(): Unit = {
+    val eight = ArraySeq(1, 2, 3, 4, 5, 6, 7, 8)
+    assertEquals("concat eight with self", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8), eight ++ eight)
+    assertEquals("concat empty with empty", ArraySeq.empty, ArraySeq.empty[Nothing] ++ ArraySeq.empty) // Explicit type annotation needed to avoid dotty bug.
+    assertEquals("concat empty with single", ArraySeq(1), ArraySeq.empty ++ ArraySeq(1))
+    assertEquals("concat single with empty", ArraySeq(1), ArraySeq(1) ++ ArraySeq.empty)
+    assertEquals("concat empty with multiple", ArraySeq(1, 2, 3), ArraySeq.empty ++ ArraySeq(1, 2, 3))
+    assertEquals("concat multiple with empty", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3) ++ ArraySeq.empty)
+    assertEquals("concat single with single", ArraySeq(1, 2), ArraySeq(1) ++ ArraySeq(2))
+    assertEquals("concat single with multiple", ArraySeq(1, 2, 3, 4), ArraySeq(1) ++ (ArraySeq(2) :+ 3 :+ 4))
+    assertEquals("concat multiple with single", ArraySeq(1, 2, 3, 4), (ArraySeq(1) :+ 2 :+ 3) ++ ArraySeq(4))
+    assertEquals("concat multiple with mix", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4), ArraySeq(-3, -2) ++ ArraySeq(-1, 0) ++ (1 +: ArraySeq(2, 3, 4)))
+    assertEquals("concat multiple with mix reversed", ArraySeq(-3, -2, 0, -1, 1, 4, 3, 2), ArraySeq(-3, -2) ++ ArraySeq(-1, 0).reverse ++ (1 +: ArraySeq(2, 3, 4).reverse))
+    val full = 1 +: 2 +: ArraySeq(3, 4, 5, 6) :+ 7 :+ 8
+    assertEquals("concat empty with full", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8), ArraySeq.empty ++ full)
+    assertEquals("concat full with empty", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8), full ++ ArraySeq.empty)
+    assertEquals("concat single with full", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8), ArraySeq(0) ++ full)
+    assertEquals("concat full with single", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), full ++ ArraySeq(9))
+    assertEquals("concat full with full", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8), full ++ full)
+    assertEquals("concat full with full reversed", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1), full ++ full.reverse)
+    assertEquals("concat full reversed with full", ArraySeq(8, 7, 6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8), full.reverse ++ full)
+    assertEquals("concat full with full mapped reversed", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 64, 49, 36, 25, 16, 9, 4, 1), full ++ full.reverse.map(x => x * x))
+    assertEquals("concat full mapped reversed with full", ArraySeq(64, 49, 36, 25, 16, 9, 4, 1, 1, 2, 3, 4, 5, 6, 7, 8), full.reverse.map(x => x * x) ++ full)
+    val large = -1 +: 0 +: full :+ 9 :+ 10 :+ 11
+    assertEquals(
+      "concat large with multiple",
+      ArraySeq(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+      large ++ ArraySeq(12, 13, 14))
+    assertEquals(
+      "concat large with itself reversed",
+      ArraySeq(-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1),
+      large ++ large.reverse)
+  }
+
+  @Test
+  def testImmutablity(): Unit = {
+    val a = ArraySeq()
+    assertEquals("immutablity of empty", ArraySeq.empty, a)
+    val b = 1 +: a
+    assertEquals("immutablity of empty", ArraySeq(1), b)
+    val c = a :+ 2
+    assertEquals("immutablity of empty", ArraySeq(2), c)
+    val d = ArraySeq(2, 3)
+    assertEquals("immutablity of multiple", ArraySeq(2, 3), d)
+    val e = 0 +: 1 +: d
+    assertEquals("immutablity of multiple", ArraySeq(0, 1, 2, 3), e)
+    val f = d :+ 4 :+ 5
+    assertEquals("immutablity of multiple", ArraySeq(2, 3, 4, 5), f)
+    val g = 0 +: 1 +: f
+    assertEquals("immutablity of multiple", ArraySeq(0, 1, 2, 3, 4, 5), g)
+
+    assertEquals("immutablity of empty still", ArraySeq.empty, a)
+    assertEquals("immutablity of empty still", ArraySeq(1), b)
+    assertEquals("immutablity of empty still", ArraySeq(2), c)
+    assertEquals("immutablity of multiple still", ArraySeq(2, 3), d)
+    assertEquals("immutablity of multiple still", ArraySeq(0, 1, 2, 3), e)
+    assertEquals("immutablity of multiple still", ArraySeq(2, 3, 4, 5), f)
+    assertEquals("immutablity of multiple still", ArraySeq(0, 1, 2, 3, 4, 5), g)
+  }
+
+  @Test
+  def testLarge(): Unit = {
+    val a = ArraySeq.tabulate(10)(identity)
+    val ar = a.reverse
+    assertEquals("large a", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), a)
+    assertEquals("large a reversed", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0), ar)
+    assertEquals("large a equals its reversed reverse", a, ar.reverse)
+    val b = -2 +: -1 +: a
+    val br = ar :+ -1 :+ -2
+    assertEquals("large b", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), b)
+    assertEquals("large b reversed", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), br)
+    assertEquals("large b equals its reversed reverse", b, br.reverse)
+    val b2 = -4 +: -3 +: -2 +: -1 +: a
+    val b2r = ar :+ -1 :+ -2 :+ -3 :+ -4
+    assertEquals("large b2", ArraySeq(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), b2)
+    assertEquals("large b2 reversed", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4), b2r)
+    assertEquals("large b2 equals its reversed reverse", b2, b2r.reverse)
+    val c = b :+ 10
+    val cr = 10 +: br
+    assertEquals("large c", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c)
+    assertEquals("large c reversed", ArraySeq(10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), cr)
+    assertEquals("large c equals its reversed reverse", c, cr.reverse)
+    val d2 = b2 :+ 10 :+ 11 :+ 12
+    val d2r = 12 +: 11 +: 10 +: b2r
+    assertEquals("large d2", ArraySeq(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), d2)
+    assertEquals("large d2 reversed", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4), d2r)
+    assertEquals("large d2 equals its reversed reverse", d2, d2r.reverse)
+    val d = b :+ 10 :+ 11
+    val dr = 11 +: 10 +: br
+    assertEquals("large d", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), d)
+    assertEquals("large d reversed", ArraySeq(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), dr)
+    assertEquals("large d equals its reversed reverse", d, dr.reverse)
+    val e = c :+ 11
+    val er = 11 +: cr
+    assertEquals("large e", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), e)
+    assertEquals("large e reversed", ArraySeq(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), er)
+    assertEquals("large e equals its reversed reverse", e, er.reverse)
+    val f = -3 +: c
+    val fr = cr :+ -3
+    assertEquals("large f", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f)
+    assertEquals("large f reversed", ArraySeq(10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3), fr)
+    assertEquals("large f equals its reversed reverse", f, fr.reverse)
+    val g = e.tail.tail.tail
+    val gr = er.tail.tail.tail
+    assertEquals("large g", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), g)
+    assertEquals("large g reversed", ArraySeq(8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), gr)
+    val h = (g.tail ++ g.tail.tail.tail).tail
+    val h2 = (gr.tail.reverse ++ g.tail.reverse).tail.tail
+    assertEquals("large h", ArraySeq(3, 4, 5, 6, 7, 8, 9, 10, 11, 4, 5, 6, 7, 8, 9, 10, 11), h)
+    assertEquals("large h2", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2), h2)
+
+    assertEquals("large a still", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), a)
+    assertEquals("large a reversed still", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0), ar)
+    assertEquals("large a equals its reversed reverse still", a, ar.reverse)
+    assertEquals("large b still", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), b)
+    assertEquals("large b reversed still", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), br)
+    assertEquals("large b equals its reversed reverse still", b, br.reverse)
+    assertEquals("large b2 still", ArraySeq(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9), b2)
+    assertEquals("large b2 reversed still", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4), b2r)
+    assertEquals("large b2 equals its reversed reverse still", b2, b2r.reverse)
+    assertEquals("large c still", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), c)
+    assertEquals("large c reversed still", ArraySeq(10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), cr)
+    assertEquals("large c equals its reversed reverse still", c, cr.reverse)
+    assertEquals("large d2 still", ArraySeq(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), d2)
+    assertEquals("large d2 reversed still", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4), d2r)
+    assertEquals("large d2 equals its reversed reverse still", d2, d2r.reverse)
+    assertEquals("large d still", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), d)
+    assertEquals("large d reversed still", ArraySeq(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), dr)
+    assertEquals("large d equals its reversed reverse still", d, dr.reverse)
+    assertEquals("large e still", ArraySeq(-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), e)
+    assertEquals("large e reversed still", ArraySeq(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), er)
+    assertEquals("large e equals its reversed reverse still", e, er.reverse)
+    assertEquals("large f still", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), f)
+    assertEquals("large f reversed still", ArraySeq(10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3), fr)
+    assertEquals("large f equals its reversed reverse still", f, fr.reverse)
+    assertEquals("large g still", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), g)
+    assertEquals("large g reversed still", ArraySeq(8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2), gr)
+    assertEquals("large h still", ArraySeq(3, 4, 5, 6, 7, 8, 9, 10, 11, 4, 5, 6, 7, 8, 9, 10, 11), h)
+    assertEquals("large h reversed still", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2), h2)
+    assertEquals("large h equals its reversed reverse", h, h.reverse.reverse)
+    assertEquals("large h2 equals its reversed reverse", h2, h2.reverse.reverse)
+  }
+
+  @Test
+  def testIterator(): Unit = {
+    var it = ArraySeq.empty[Int].iterator()
+    assertFalse("empty has empty iterator", it.hasNext)
+
+    it = ArraySeq.empty[Int].reverse.iterator()
+    assertFalse("empty reverse has empty iterator", it.hasNext)
+
+    it = ArraySeq(1).iterator()
+    assertTrue("single has non empty iterator", it.hasNext)
+    assertEquals("single iterator has correct element", 1, it.next())
+    assertFalse("single iterator has only one element", it.hasNext)
+
+    it = (1 +: ArraySeq.empty).iterator()
+    assertTrue("single prepended has non empty iterator", it.hasNext)
+    assertEquals("single prepended iterator has correct element", 1, it.next())
+    assertFalse("single prepended iterator has only one element", it.hasNext)
+
+    it = (ArraySeq.empty :+ 1).iterator()
+    assertTrue("single appended has non empty iterator", it.hasNext)
+    assertEquals("single appended iterator has correct element", 1, it.next())
+    assertFalse("single appended iterator has only one element", it.hasNext)
+
+    it = ArraySeq(1).reverse.iterator()
+    assertTrue("single reverse has non empty iterator", it.hasNext)
+    assertEquals("single reverse iterator has correct element", 1, it.next())
+    assertFalse("single reverse iterator has only one element", it.hasNext)
+
+    it = ArraySeq(1, 2).iterator()
+    assertTrue("double has non empty iterator", it.hasNext)
+    assertEquals("double iterator has correct first element", 1, it.next())
+    assertEquals("double iterator has correct second element", 2, it.next())
+    assertFalse("double iterator has only correct elements", it.hasNext)
+    val reversed = ArraySeq(1, 2).reverse
+    it = reversed.iterator()
+    assertTrue("double reverse has non empty iterator", it.hasNext)
+    assertEquals("double reverse iterator has correct first element", 2, it.next())
+    assertEquals("double reverse iterator has correct second element", 1, it.next())
+    assertFalse("double reverse iterator has only correct elements", it.hasNext)
+
+    it = (0 +: 1 +: ArraySeq(2, 3, 4, 5, 6, 7, 8, 9) :+ 10 :+ 11).iterator()
+    assertTrue("large has non empty iterator", it.hasNext)
+    assertTrue(
+      "large iterator has correct elements",
+      it.sameElements(List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)))
+    assertFalse("large iterator iterator has only correct elements", it.hasNext)
+
+    it = (0 +: 1 +: ArraySeq(2, 3, 4, 5, 6, 7, 8, 9) :+ 10 :+ 11).reverse.iterator()
+    assertTrue("large reverse has non empty iterator", it.hasNext)
+    assertTrue(
+      "large reverse iterator has correct elements",
+      it.sameElements(List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).reverse))
+    assertFalse("large reverse iterator iterator has only correct elements", it.hasNext)
+
+    class A()
+    class B() extends A()
+    val a1 = new A()
+    val a2 = new A()
+    val b = new B()
+    val it3= (ArraySeq(a1, a2) :+ b).iterator()
+    assertTrue("subs has non empty iterator", it3.hasNext)
+    assertTrue(
+      "subs iterator has correct elements",
+      it3.sameElements(List(a1, a2, b)))
+
+    // Test iterator index bounds checking
+    it = ArraySeq.empty[Int].iterator()
+    try {
+      it.next()
+      fail("should be out of bounds")
+    } catch {
+      case _: NoSuchElementException => // expected
+      case NonFatal(e) =>
+        fail("wrong exception: " + e)
+        e.printStackTrace()
+    }
+
+    it = ArraySeq(1, 2, 3, 4).dropRight(1).iterator()
+    try {
+      it.next()
+      it.next()
+      it.next()
+      it.next() // should be out of bounds
+      fail("should be out of bounds")
+    } catch {
+      case _: NoSuchElementException => // expected
+      case _: IndexOutOfBoundsException => // expected
+      case NonFatal(e) =>
+        fail("wrong exception: " + e)
+        e.printStackTrace()
+    }
+
+    val a3 = ArraySeq.range(1, 63)
+    val b3 = a3 :++ ArraySeq(63, 64, 65, 66)
+    val c3 = a3 :+ 0
+    val d3 = c3 :++ ArraySeq(64, 65, 66)
+    val e3 = c3 :++ ArraySeq(64, -1, 66)
+    val bl3 = List.newBuilder().++=(b3.iterator()).result()
+    val cl3 = List.newBuilder().++=(c3.iterator()).result()
+    val dl3 = List.newBuilder().++=(d3.iterator()).result()
+    val el3 = List.newBuilder().++=(e3.iterator()).result()
+    assertEquals("after expansion with append all", List.range(1, 67), bl3)
+    assertEquals("after expansion with append all then overlay to original", List.range(1, 63) :+ 0, cl3)
+    assertEquals("after expansion with append all then overlay to original and append all with only identical", List.range(1, 63) :++ List(0, 64, 65, 66), dl3)
+    assertEquals("after expansion with append all then overlay to original and append all with mixed", List.range(1, 63) :++ List(0, 64, -1, 66), el3)
+
+    val a3r = ArraySeq.range(1, 63).reverse
+    val b3r = ArraySeq(63, 64, 65, 66).reverse ++: a3r
+    val c3r = 0 +: a3r
+    val d3r = ArraySeq(64, 65, 66).reverse ++: c3r
+    val e3r = ArraySeq(64, -1, 66).reverse ++: c3r
+    val bl3r = List.newBuilder().++=(b3r.iterator()).result()
+    val cl3r = List.newBuilder().++=(c3r.iterator()).result()
+    val dl3r = List.newBuilder().++=(d3r.iterator()).result()
+    val el3r = List.newBuilder().++=(e3r.iterator()).result()
+    assertEquals("after expansion with append all", List.range(1, 67).reverse, bl3r)
+    assertEquals("after expansion with append all then overlay to original", (List.range(1, 63) :+ 0).reverse, cl3r)
+    assertEquals("after expansion with append all then overlay to original and append all with only identical", (List.range(1, 63) :++ List(0, 64, 65, 66)).reverse, dl3r)
+    assertEquals("after expansion with append all then overlay to original and append all with mixed", (List.range(1, 63) :++ List(0, 64, -1, 66)).reverse, el3r)
+  }
+
+  @Test
+  def testReverseIterator(): Unit = {
+    var it = ArraySeq.empty[Int].reverseIterator()
+    assertFalse("empty has empty reversed iterator", it.hasNext)
+
+    it = ArraySeq.empty[Int].reverse.reverseIterator()
+    assertFalse("empty reverse has empty reversed iterator", it.hasNext)
+
+    it = ArraySeq(1).reverseIterator()
+    assertTrue("single has non empty reversed iterator", it.hasNext)
+    assertEquals("single reversed iterator has correct element", 1, it.next())
+    assertFalse("single reversed iterator has only one element", it.hasNext)
+
+    it = (1 +: ArraySeq.empty).reverseIterator()
+    assertTrue("single prepended has non empty reversed iterator", it.hasNext)
+    assertEquals("single prepended reversed iterator has correct element", 1, it.next())
+    assertFalse("single prepended reversed iterator has only one element", it.hasNext)
+
+    it = (ArraySeq.empty :+ 1).reverseIterator()
+    assertTrue("single appended has non empty reversed iterator", it.hasNext)
+    assertEquals("single appended reversed iterator has correct element", 1, it.next())
+    assertFalse("single appended reversed iterator has only one element", it.hasNext)
+
+    it = ArraySeq(1).reverse.reverseIterator()
+    assertTrue("single reverse has non empty reversed iterator", it.hasNext)
+    assertEquals("single reverse reversed iterator has correct element", 1, it.next())
+    assertFalse("single reverse reversed iterator has only one element", it.hasNext)
+
+    it = ArraySeq(1, 2).reverseIterator()
+    assertTrue("double has non empty reversed iterator", it.hasNext)
+    assertEquals("double reversed iterator has correct first element", 2, it.next())
+    assertEquals("double reversed iterator has correct second element", 1, it.next())
+    assertFalse("double reversed iterator has only correct elements", it.hasNext)
+    val reversed = ArraySeq(1, 2).reverse
+    it = reversed.reverseIterator()
+    assertTrue("double reverse has non empty reversed iterator", it.hasNext)
+    assertEquals("double reverse reversed iterator has correct first element", 1, it.next())
+    assertEquals("double reverse reversed iterator has correct second element", 2, it.next())
+    assertFalse("double reverse reversed iterator has only correct elements", it.hasNext)
+
+    it = (0 +: 1 +: ArraySeq(2, 3, 4, 5, 6, 7, 8, 9) :+ 10 :+ 11).reverseIterator()
+    assertTrue("large has non empty reversed iterator", it.hasNext)
+    assertTrue(
+      "large reversed iterator has correct elements",
+      it.sameElements(List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).reverse))
+    assertFalse("large reversed iterator has only correct elements", it.hasNext)
+
+    it = (0 +: 1 +: ArraySeq(2, 3, 4, 5, 6, 7, 8, 9) :+ 10 :+ 11).reverse.reverseIterator()
+    assertTrue("large reverse has non empty reversed iterator", it.hasNext)
+    assertTrue(
+      "large reverse reversed iterator has correct elements",
+      it.sameElements(List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)))
+    assertFalse("large reverse reversed iterator iterator has only correct elements", it.hasNext)
+
+    class A()
+    class B() extends A()
+    val a1 = new A()
+    val a2 = new A()
+    val b = new B()
+    val it3= (ArraySeq(a1, a2) :+ b).reverseIterator()
+    assertTrue("subs has non empty reversed iterator", it3.hasNext)
+    assertTrue(
+      "subs reversed iterator has correct elements",
+      it3.sameElements(List(a1, a2, b).reverse))
+
+    // Test iterator index bounds checking
+    it = ArraySeq.empty[Int].reverseIterator()
+    try {
+      it.next()
+      fail("should be out of bounds")
+    } catch {
+      case _: NoSuchElementException => // expected
+      case NonFatal(e) =>
+        fail("wrong exception: " + e)
+        e.printStackTrace()
+    }
+
+    it = ArraySeq(1, 2, 3, 4).dropRight(1).reverseIterator()
+    try {
+      it.next()
+      it.next()
+      it.next()
+      it.next() // should be out of bounds
+      fail("should be out of bounds")
+    } catch {
+      case _: NoSuchElementException => // expected
+      case _: IndexOutOfBoundsException => // expected
+      case NonFatal(e) =>
+        fail("wrong exception: " + e)
+        e.printStackTrace()
+    }
+
+    val a3 = ArraySeq.range(1, 63).reverse
+    val b3 = ArraySeq(63, 64, 65, 66).reverse :++ a3
+    val c3 = 0 +: a3
+    val d3 = ArraySeq(64, 65, 66).reverse :++ c3
+    val e3 = ArraySeq(64, -1, 66).reverse :++ c3
+    val bl3 = List.newBuilder().++=(b3.reverseIterator()).result()
+    val cl3 = List.newBuilder().++=(c3.reverseIterator()).result()
+    val dl3 = List.newBuilder().++=(d3.reverseIterator()).result()
+    val el3 = List.newBuilder().++=(e3.reverseIterator()).result()
+    assertEquals("after expansion with append all", List.range(1, 67), bl3)
+    assertEquals("after expansion with append all then overlay to original", List.range(1, 63) :+ 0, cl3)
+    assertEquals("after expansion with append all then overlay to original and append all with only identical", List.range(1, 63) :++ List(0, 64, 65, 66), dl3)
+    assertEquals("after expansion with append all then overlay to original and append all with mixed", List.range(1, 63) :++ List(0, 64, -1, 66), el3)
+
+    val a3r = ArraySeq.range(1, 63).reverse
+    val b3r = ArraySeq(63, 64, 65, 66).reverse ++: a3r
+    val c3r = 0 +: a3r
+    val d3r = ArraySeq(64, 65, 66).reverse ++: c3r
+    val e3r = ArraySeq(64, -1, 66).reverse ++: c3r
+    val bl3r = List.newBuilder().++=(b3r.reverseIterator()).result()
+    val cl3r = List.newBuilder().++=(c3r.reverseIterator()).result()
+    val dl3r = List.newBuilder().++=(d3r.reverseIterator()).result()
+    val el3r = List.newBuilder().++=(e3r.reverseIterator()).result()
+    assertEquals("after expansion with append all", List.range(1, 67), bl3r)
+    assertEquals("after expansion with append all then overlay to original", List.range(1, 63) :+ 0, cl3r)
+    assertEquals("after expansion with append all then overlay to original and append all with only identical", List.range(1, 63) :++ List(0, 64, 65, 66), dl3r)
+    assertEquals("after expansion with append all then overlay to original and append all with mixed", List.range(1, 63) :++ List(0, 64, -1, 66), el3r)
+  }
+
+  @Test
+  def testForeach(): Unit = {
+    var n = 0
+    ArraySeq.empty[Int].foreach(_ => n += 1)
+    assertEquals("empty foreach", 0, n)
+    ArraySeq(1).foreach(x => n += x)
+    assertEquals("single foreach", 1, n)
+    ArraySeq(2, 3, 4, 5, 6).foreach(x => n += x)
+    assertEquals("multiple foreach", 21, n)
+    var m = 6
+    ArraySeq(1, 2, 3).reverse.foreach(x => m -= x)
+    assertEquals("multiple foreach reversed", 0, m)
+  }
+
+  @Test
+  def testIndexWhere(): Unit = {
+    assertEquals("empty index where", -1, ArraySeq.empty[Int].indexWhere(_ => true))
+    assertEquals("empty reversed index where", -1, ArraySeq.empty[Int].reverse.indexWhere(_ => true))
+    assertEquals("single index where exists", 0, ArraySeq(1).indexWhere(x => x == 1))
+    assertEquals("single index reversed where exists", 0, ArraySeq(1).reverse.indexWhere(x => x == 1))
+    assertEquals("single index where not exists", -1, ArraySeq(1).indexWhere(x => x == 2))
+    assertEquals("single index reversed where not exists", -1, ArraySeq(1).reverse.indexWhere(x => x == 2))
+    assertEquals("multiple index where exists", 1, ArraySeq(1, 2, 3, 4).indexWhere(x => x % 2 == 0))
+    assertEquals("multiple index reversed where exists", 0, ArraySeq(1, 2, 3, 4).reverse.indexWhere(x => x % 2 == 0))
+    assertEquals("multiple index where not exists", -1, ArraySeq(1, 2, 3, 4).indexWhere(x => x == 5))
+    assertEquals("multiple index reversed where not exists", -1, ArraySeq(1, 2, 3, 4).reverse.indexWhere(x => x == 5))
+    assertEquals("multiple index where exists with from", 3, ArraySeq(1, 2, 3, 4).indexWhere(x => x % 2 == 0, 2))
+    assertEquals("multiple index reversed where exists with from", 2, ArraySeq(1, 2, 3, 4).reverse.indexWhere(x => x % 2 == 0, 2))
+    assertEquals("multiple index where not exists with from", -1, ArraySeq(1, 2, 3, 4).indexWhere(x => x == 5, 2))
+    assertEquals("multiple index reversed where not exists with from", -1, ArraySeq(1, 2, 3, 4).reverse.indexWhere(x => x == 5, 2))
+  }
+
+  @Test
+  def testLastIndexWhere(): Unit = {
+    assertEquals("empty last index where", -1, ArraySeq.empty[Int].lastIndexWhere(_ => true))
+    assertEquals("single last index where exists", 0, ArraySeq(1).lastIndexWhere(x => x == 1))
+    assertEquals("single last index where not exists", -1, ArraySeq(1).lastIndexWhere(x => x == 2))
+    assertEquals("multiple last index where exists", 3, ArraySeq(1, 2, 3, 4).lastIndexWhere(x => x % 2 == 0))
+    assertEquals("multiple last index where not exists", -1, ArraySeq(1, 2, 3, 4).lastIndexWhere(x => x == 5))
+    assertEquals("multiple last index where exists with end", 1, ArraySeq(1, 2, 3, 4).lastIndexWhere(x => x % 2 == 0, 2))
+    assertEquals("multiple last index where not exists with end", -1, ArraySeq(1, 2, 3, 4).lastIndexWhere(x => x == 5, 2))
+  }
+
+  @Test
+  def testFoldLeft(): Unit = {
+    assertEquals("empty fold left", 0, ArraySeq.empty[Int].foldLeft(0) {
+      case (acc, x) => acc - x
+    })
+    assertEquals("single fold left", -1, ArraySeq(1).foldLeft(0) {
+      case (acc, x) => acc - x
+    })
+    assertEquals("multiple fold left", -10, ArraySeq(1, 2, 3, 4).foldLeft(0) {
+      case (acc, x) => acc - x
+    })
+  }
+
+  @Test
+  def testFoldRight(): Unit = {
+    assertEquals("empty fold right", 0, ArraySeq.empty[Int].foldRight(0) {
+      case (x, acc) => x - acc
+    })
+    assertEquals("single fold right", 1, ArraySeq(1).foldRight(0) {
+      case (x, acc) => x - acc
+    })
+    assertEquals("multiple fold right", -2, ArraySeq(1, 2, 3, 4).foldRight(0) {
+      case (x, acc) => x - acc
+    })
+  }
+
+  @Test
+  def testFrom(): Unit = {
+    assertEquals("empty list is empty", ArraySeq.empty, ArraySeq.from(List.empty))
+    assertEquals("empty scala list is empty", ArraySeq.empty, ArraySeq.from(Nil))
+    assertEquals("empty lazy list is empty", ArraySeq.empty, ArraySeq.from[Int](LazyList.empty))
+  }
+
+  @Test
+  def testTrim(): Unit = {
+    assertEquals("empty trimmed is empty", ArraySeq.empty, ArraySeq.from(List.empty).trim())
+    assertEquals("single trimmed has elements array of correct length", 1, ArraySeq(1).trim().array.length)
+    assertEquals("single trimmed has elements array with correct element", 1, ArraySeq(1).trim().array(0))
+    assertEquals("multiple trimmed has elements array of correct length", 3, ArraySeq(1, 2, 3).trim().array.length)
+    assertEquals("multiple trimmed has elements array with correct element", 1, ArraySeq(1, 2, 3).trim().array(0))
+    assertEquals("multiple trimmed has elements array with correct element", 2, ArraySeq(1, 2, 3).trim().array(1))
+    assertEquals("multiple trimmed has elements array with correct element", 3, ArraySeq(1, 2, 3).trim().array(2))
+  }
+
+  @Test
+  def testPrependEqElement(): Unit = {
+    val a = ArraySeq(1, 2, 3)
+    val b = 1 +: a.tail
+    val c = 0 +: a.tail
+    val d = -1 +: a.tail
+    val e = -1 +: d.tail
+    val f = -1 +: a.tail
+    assertSame("prepend equal single on tail equals original", a.array, b.array)
+    assertNotSame("prepend non equal single on tail does not equal original", a, c)
+    assertSame("prepend equal single on tail equals original", d.array, e.array)
+    assertNotSame("prepend non equal single on tail does not equal original", d, f)
+    val ar = a.reverse
+    val br = 1 +: ar.tail
+    val cr = 0 +: ar.tail
+    val dr = -1 +: ar.tail
+    val er = -1 +: dr.tail
+    val fr = -1 +: ar.tail
+    assertSame("prepend equal single on tail of reversed equals original", ar.array, br.array)
+    assertNotSame("prepend non equal single on tail of reversed does not equal original", ar, cr)
+    assertSame("prepend equal single on tail of reversed equals original", dr.array, er.array)
+    assertNotSame("prepend non equal single on tail of reversed does not equal original", dr, fr)
+  }
+
+  @Test
+  def testAppendEqElement(): Unit = {
+    val a = ArraySeq(1, 2, 3)
+    val b = a.take(2) :+ 3
+    val c = a.take(2) :+ 4
+    val d = a.take(2) :+ 5
+    val e = d.take(2) :+ 5
+    val f = a.take(2) :+ 5
+    assertSame("append equal single on init equals original", a.array, b.array)
+    assertNotSame("append non equal single on init does not equal original", a, c)
+    assertSame("append equal single on init equals original", d.array, e.array)
+    assertNotSame("append non equal single on init does not equal original", d, f)
+    val ar = a.reverse
+    val br = ar.take(2) :+ 3
+    val cr = ar.take(2) :+ 4
+    val dr = ar.take(2) :+ 5
+    val er = dr.take(2) :+ 5
+    val fr = ar.take(2) :+ 5
+    assertSame("append equal single on init of reversed equals original", ar.array, br.array)
+    assertNotSame("append non equal single on init of reversed does not equal original", ar, cr)
+    assertSame("append equal single on init of reversed equals original", dr.array, er.array)
+    assertNotSame("append non equal single on init of reversed does not equal original", dr, fr)
+  }
+
+  @Test
+  def testLast(): Unit = {
+    assertTrue("empty last fails", Try(ArraySeq.empty.last).isFailure)
+    assertEquals("single last", 1, ArraySeq(1).last)
+    assertEquals("single reversed last", 1, ArraySeq(1).reverse.last)
+    assertEquals("multiple last", 3, ArraySeq(1, 2, 3).last)
+    assertEquals("multiple reversed last", 1, ArraySeq(1, 2, 3).reverse.last)
+  }
+
+  @Test
+  def testInit(): Unit = {
+    assertTrue("empty init fails", Try(ArraySeq.empty.init).isFailure)
+    assertEquals("single init", ArraySeq.empty, ArraySeq(1).init)
+    assertEquals("single reversed init", ArraySeq.empty, ArraySeq(1).reverse.init)
+    assertEquals("multiple init", ArraySeq(1, 2), ArraySeq(1, 2, 3).init)
+    val r = ArraySeq(1, 2, 3).reverse
+    val in = r.init
+    assertEquals("multiple reverse init", ArraySeq(3, 2), in)
+  }
+
+  @Test
+  def testSlice(): Unit = {
+    assertEquals("empty slice of single is empty", ArraySeq.empty, ArraySeq(1).slice(0, 0))
+    assertEquals("empty slice of single reversed is empty", ArraySeq.empty, ArraySeq(1).reverse.slice(0, 0))
+    assertEquals("empty slice of multiple is empty", ArraySeq.empty, ArraySeq(1, 2, 3).slice(1, 1))
+    assertEquals("empty slice of multiple reversed is empty", ArraySeq.empty, ArraySeq(1, 2, 3).reverse.slice(1, 1))
+    assertEquals("single slice of single", ArraySeq(1), ArraySeq(1).slice(0, 1))
+    assertEquals("single slice of single reversed", ArraySeq(1), ArraySeq(1).slice(0, 1))
+    assertEquals("single slice of multiple", ArraySeq(3), ArraySeq(1, 2, 3).slice(2, 3))
+    assertEquals("single slice of multiple reversed", ArraySeq(1), ArraySeq(1, 2, 3).reverse.slice(2, 3))
+    assertEquals("multiple slice of multiple", ArraySeq(2, 3), ArraySeq(1, 2, 3).slice(1, 3))
+    assertEquals("multiple slice of multiple reversed", ArraySeq(2, 1), ArraySeq(1, 2, 3).reverse.slice(1, 3))
+    var sx = 4 +: ArraySeq(1, 2, 3).reverse
+    assertEquals("multiple slice of multiple reversed with prepended", ArraySeq(3, 2), sx.slice(1, 3))
+    sx = ArraySeq(1, 2, 3).reverse :+ 0
+    assertEquals("multiple slice of multiple reversed with append", ArraySeq(2, 1), sx.slice(1, 3))
+    assertEquals("multiple slice of full", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3).slice(0, 3))
+    assertEquals("multiple slice of full reversed", ArraySeq(3, 2, 1), ArraySeq(1, 2, 3).reverse.slice(0, 3))
+    assertEquals("multiple slice of full with overlay", ArraySeq(4, 2, 3), ArraySeq(1, 2, 3).updated(0, 4).slice(0, 3))
+    assertEquals("multiple slice of full with overlay reversed", ArraySeq(3, 2, 4), ArraySeq(1, 2, 3).updated(0, 4).reverse.slice(0, 3))
+    assertEquals("multiple slice of full with reversed overlay", ArraySeq(4, 2, 1), ArraySeq(1, 2, 3).reverse.updated(0, 4).slice(0, 3))
+  }
+
+  @Test
+  def testTakeRightAndDropRight(): Unit = {
+    assertEquals("take right 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).takeRight(0))
+    assertEquals("take right 1", ArraySeq(4), ArraySeq(1, 2, 3, 4).takeRight(1))
+    assertEquals("take right 2", ArraySeq(3, 4), ArraySeq(1, 2, 3, 4).takeRight(2))
+    assertEquals("drop right 0", ArraySeq(1, 2, 3, 4), ArraySeq(1, 2, 3, 4).dropRight(0))
+    assertEquals("drop right 1", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3, 4).dropRight(1))
+    assertEquals("drop right 2", ArraySeq(1, 2), ArraySeq(1, 2, 3, 4).dropRight(2))
+    assertEquals("drop right 1 take right 1", ArraySeq(3), ArraySeq(1, 2, 3, 4).dropRight(1).takeRight(1))
+    assertEquals("drop right 2 take right 1", ArraySeq(2), ArraySeq(1, 2, 3, 4).dropRight(2).takeRight(1))
+    assertEquals("drop right 2 take right 2", ArraySeq(1, 2), ArraySeq(1, 2, 3, 4).dropRight(2).takeRight(2))
+    assertEquals("drop right 2 take right 0", ArraySeq.empty, ArraySeq(1, 2, 3, 4).dropRight(2).takeRight(0))
+    assertEquals("drop right 2 take right 2 drop right 1 take right 1", ArraySeq(1), ArraySeq(1, 2, 3, 4).dropRight(2).takeRight(2).dropRight(1).takeRight(1))
+  }
+
+  @Test
+  def testPatchToFront(): Unit = {
+    assertEquals("Empty with empty at front", ArraySeq.empty, ArraySeq.empty.patch(0, ArraySeq.empty, 0))
+    assertEquals("Empty reversed with empty at front", ArraySeq.empty, ArraySeq.empty.reverse.patch(0, ArraySeq.empty, 0))
+    assertEquals("Empty with empty reversed at front", ArraySeq.empty, ArraySeq.empty.patch(0, ArraySeq.empty.reverse, 0))
+    assertEquals("Empty reversed with empty reversed at front", ArraySeq.empty, ArraySeq.empty.reverse.patch(0, ArraySeq.empty.reverse, 0))
+    assertEquals("Empty with single at front", ArraySeq(1), ArraySeq.empty.patch(0, ArraySeq(1), 0))
+    assertEquals("Empty reversed with single at front", ArraySeq(1), ArraySeq.empty.reverse.patch(0, ArraySeq(1), 0))
+    assertEquals("Empty with single reversed at front", ArraySeq(1), ArraySeq.empty.patch(0, ArraySeq(1).reverse, 0))
+    assertEquals("Empty reversed with single reversed at front", ArraySeq(1), ArraySeq.empty.reverse.patch(0, ArraySeq(1).reverse, 0))
+    assertEquals("Single with empty at front replacing 0", ArraySeq(1), ArraySeq(1).patch(0, ArraySeq.empty, 0))
+    assertEquals("Single with empty at front replacing 0", ArraySeq(1), ArraySeq(1).patch(0, ArraySeq.empty, 0))
+    assertEquals("Single with empty at front replacing 1", ArraySeq.empty, ArraySeq(1).patch(0, ArraySeq.empty, 1))
+    assertEquals("Single with single at front replacing 0", ArraySeq(1, 2), ArraySeq(2).patch(0, ArraySeq(1), 0))
+    assertEquals("Single reversed with single at front replacing 0", ArraySeq(1, 2), ArraySeq(2).reverse.patch(0, ArraySeq(1), 0))
+    assertEquals("Single with single at front replacing 1", ArraySeq(1), ArraySeq(2).patch(0, ArraySeq(1), 1))
+    assertEquals("Single reversed with single at front replacing 1", ArraySeq(1), ArraySeq(2).reverse.patch(0, ArraySeq(1), 1))
+    assertEquals("Single with single at front replacing 2", ArraySeq(1), ArraySeq(2).patch(0, ArraySeq(1), 2))
+    assertEquals("Single with single at front replacing max", ArraySeq(1), ArraySeq(2).patch(0, ArraySeq(1), 245))
+    assertEquals("Single with multiple at front replacing 0", ArraySeq(1, 2, 3, 4), ArraySeq(4).patch(0, ArraySeq(1, 2, 3), 0))
+    assertEquals("Single with multiple at front replacing 1", ArraySeq(1, 2, 3), ArraySeq(4).patch(0, ArraySeq(1, 2, 3), 1))
+    assertEquals("Single with multiple at front replacing 2", ArraySeq(1, 2, 3), ArraySeq(4).patch(0, ArraySeq(1, 2, 3), 2))
+    assertEquals("Single with multiple at front replacing max", ArraySeq(1, 2, 3), ArraySeq(2).patch(0, ArraySeq(1, 2, 3), 245))
+    assertEquals("Multiple with empty at front replacing 0", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3).patch(0, ArraySeq.empty, 0))
+    assertEquals("Multiple with empty at front replacing 1", ArraySeq(2, 3), ArraySeq(1, 2, 3).patch(0, ArraySeq.empty, 1))
+    assertEquals("Multiple with single at front replacing 0", ArraySeq(4, 1, 2, 3), ArraySeq(1, 2, 3).patch(0, ArraySeq(4), 0))
+    assertEquals("Multiple with single at front replacing 1", ArraySeq(4, 2, 3), ArraySeq(1, 2, 3).patch(0, ArraySeq(4), 1))
+    assertEquals("Multiple with single at front replacing 2", ArraySeq(4, 3), ArraySeq(1, 2, 3).patch(0, ArraySeq(4), 2))
+    assertEquals("Multiple with single at front replacing max", ArraySeq(4), ArraySeq(1, 2, 3).patch(0, ArraySeq(4), 245))
+  }
+  @Test
+  def testPatchToRear(): Unit = {
+    assertEquals("Empty with empty at rear", ArraySeq.empty, ArraySeq.empty.patch(0, ArraySeq.empty, 0))
+    assertEquals("Empty reversed with empty at rear", ArraySeq.empty, ArraySeq.empty.reverse.patch(0, ArraySeq.empty, 0))
+    assertEquals("Empty with single at rear", ArraySeq(1), ArraySeq.empty.patch(0, ArraySeq(1), 0))
+    assertEquals("Empty reversed with single at rear", ArraySeq(1), ArraySeq.empty.reverse.patch(0, ArraySeq(1), 0))
+    assertEquals("Single with empty at rear", ArraySeq(1), ArraySeq(1).patch(1, ArraySeq.empty, 0))
+    assertEquals("Single reversed with empty at rear", ArraySeq(1), ArraySeq(1).reverse.patch(1, ArraySeq.empty, 0))
+    assertEquals("Single with single at rear replacing 0", ArraySeq(2, 1), ArraySeq(2).patch(1, ArraySeq(1), 0))
+    assertEquals("Single reversed with single at rear replacing 0", ArraySeq(2, 1), ArraySeq(2).reverse.patch(1, ArraySeq(1), 0))
+    assertEquals("Single with multiple at rear", ArraySeq(4, 1, 2, 3), ArraySeq(4).patch(1, ArraySeq(1, 2, 3), 0))
+    assertEquals("Single reversed with multiple at rear", ArraySeq(4, 1, 2, 3), ArraySeq(4).reverse.patch(1, ArraySeq(1, 2, 3), 0))
+    assertEquals("Multiple with empty at rear", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3).patch(3, ArraySeq.empty, 0))
+    assertEquals("Multiple reversed with empty at rear", ArraySeq(3, 2, 1), ArraySeq(1, 2, 3).reverse.patch(3, ArraySeq.empty, 0))
+    assertEquals("Multiple with single at rear", ArraySeq(1, 2, 3, 4), ArraySeq(1, 2, 3).patch(3, ArraySeq(4), 0))
+    assertEquals("Multiple reversed with single at rear", ArraySeq(3, 2, 1, 4), ArraySeq(1, 2, 3).reverse.patch(3, ArraySeq(4), 0))
+    assertEquals("Multiple with multiple at rear", ArraySeq(1, 2, 3, 4, 5, 6), ArraySeq(1, 2, 3).patch(3, ArraySeq(4, 5, 6), 0))
+    assertEquals("Multiple reversed with multiple at rear", ArraySeq(3, 2, 1, 4, 5, 6), ArraySeq(1, 2, 3).reverse.patch(3, ArraySeq(4, 5, 6), 0))
+  }
+  @Test
+  def testPatchInMiddle(): Unit = {
+    assertEquals("Multiple with empty in middle replacing 0", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3).patch(1, ArraySeq.empty, 0))
+    assertEquals("Multiple reversed with empty in middle replacing 0", ArraySeq(3, 2, 1), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq.empty, 0))
+    var xs = ArraySeq(1, 2, 3)
+    var ys = xs.patch(1, ArraySeq.empty, 1)
+    assertEquals("Multiple with empty in middle replacing 1", ArraySeq(1, 3), ys)
+    xs = ArraySeq(1, 2, 3, 4, 5, 6).reverse
+    ys = xs.patch(1, ArraySeq.empty, 1)
+    assertEquals("Multiple reversed with empty in middle replacing 1", ArraySeq(6, 4, 3, 2, 1), ys)
+    xs = ArraySeq(1, 2, 3).reverse
+    ys = xs.patch(1, ArraySeq.empty, 1)
+    assertEquals("Multiple reversed with empty in middle replacing 1", ArraySeq(3, 1), ys)
+    assertEquals("Multiple with empty in middle replacing max", ArraySeq(1), ArraySeq(1, 2, 3).patch(1, ArraySeq.empty, 245))
+    assertEquals("Multiple reversed with empty in middle replacing max", ArraySeq(3), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq.empty, 245))
+    assertEquals("Multiple with single in middle replacing 0", ArraySeq(1, 4, 2, 3), ArraySeq(1, 2, 3).patch(1, ArraySeq(4), 0))
+    xs = ArraySeq(1, 2, 3).reverse
+    ys = xs.patch(1, ArraySeq(4), 0)
+    assertEquals("Multiple reversed with single in middle replacing 0", ArraySeq(3, 4, 2, 1), ys)
+    assertEquals("Multiple with single in middle replacing 1", ArraySeq(1, 4, 3), ArraySeq(1, 2, 3).patch(1, ArraySeq(4), 1))
+    assertEquals("Multiple reversed with single in middle replacing 1", ArraySeq(3, 4, 1), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq(4), 1))
+    assertEquals("Multiple with single in middle replacing max", ArraySeq(1, 4), ArraySeq(1, 2, 3).patch(1, ArraySeq(4), 245))
+    assertEquals("Multiple reversed with single in middle replacing max", ArraySeq(3, 4), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq(4), 245))
+    assertEquals("Multiple with multiple in middle replacing 0", ArraySeq(1, 4, 5, 6, 2, 3), ArraySeq(1, 2, 3).patch(1, ArraySeq(4, 5, 6), 0))
+    assertEquals("Multiple reversed with multiple in middle replacing 0", ArraySeq(3, 4, 5, 6, 2, 1), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq(4, 5, 6), 0))
+    assertEquals("Multiple with multiple in middle replacing 1", ArraySeq(1, 4, 5, 6, 3), ArraySeq(1, 2, 3).patch(1, ArraySeq(4, 5, 6), 1))
+    assertEquals("Multiple reversed with multiple in middle replacing 1", ArraySeq(3, 4, 5, 6, 1), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq(4, 5, 6), 1))
+    assertEquals("Multiple with multiple in middle replacing max", ArraySeq(1, 4, 5, 6), ArraySeq(1, 2, 3).patch(1, ArraySeq(4, 5, 6), 245))
+    assertEquals("Multiple reversed with multiple in middle replacing max", ArraySeq(3, 4, 5, 6), ArraySeq(1, 2, 3).reverse.patch(1, ArraySeq(4, 5, 6), 245))
+  }
+  @Test
+  def testAutoTrimming(): Unit = {
+    val autoTrimming = AutoTrimming(minUsagePercentage = 25)
+    val s6 = ArraySeq(1, 2, 3, 4, 5, 6).withAutoTrimming(autoTrimming)
+    assertEquals("1 out of 8 is not trimmed", 8, s6.slice(0, 1).array.length)
+    assertEquals("2 out of 8 is not trimmed", 8, s6.slice(0, 2).array.length)
+    assertEquals("3 out of 8 is not trimmed", 8, s6.slice(0, 3).array.length)
+    val s32 = ArraySeq.tabulate(32)(identity).withAutoTrimming(autoTrimming)
+    assertEquals("2 out of 32 is trimmed to 8", 8, s32.slice(0, 2).array.length)
+    assertEquals("8 out of 32 is trimmed to 8", 8, s32.slice(0, 8).array.length)
+    assertEquals("9 out of 32 is not trimmed", 32, s32.slice(0, 9).array.length)
+    var s = ArraySeq.empty[Int].withAutoTrimming(autoTrimming)
+    for (i <- 0 until 512) {
+      if (i % 2 == 0) s = s :+ i
+      else s = i +: s
+    }
+    assertEquals("512 is correct capacity", 512, s.array.length)
+    for (i <- 0 until 31) {
+      s = s.tail
+    }
+    assertEquals("after removing 31 out of 512 capacity is still 512", 512, s.array.length)
+    s = s.tail
+    assertEquals("after removing 32 out of 512 capacity is still 512", 512, s.array.length)
+    s = s.tail
+    assertEquals("after removing 33 out of 512 capacity is still 512", 512, s.array.length)
+    for (i <- 33 until 255) {
+      s = s.tail
+    }
+    assertEquals("after removing 255 out of 512 capacity is still 512", 512, s.array.length)
+    s = s.tail
+    assertEquals("after removing 256 out of 512 capacity is still 512", 512, s.array.length)
+    s = s.tail
+    assertEquals("after removing 257 out of 512 capacity is still 512", 512, s.array.length)
+    for (i <- 257 until 383) {
+      s = s.tail
+    }
+    assertEquals("after removing 383 out of 512 capacity is still 512", 512, s.array.length)
+    s = s.tail
+    assertEquals("after removing 384 out of 512 capacity is 128", 128, s.array.length)
+    s = s.tail
+    assertEquals("after removing 385 out of 512 capacity is 128", 128, s.array.length)
+    s = s.slice(0, 2)
+    assertEquals("after keeping 2 out of 128 capacity is 8", 8, s.array.length)
+    val s2 = ArraySeq.range(0, 32).withoutAutoTrimming
+    assertEquals("2 out of 32 is not trimmed", 32, s2.slice(0, 2).array.length)
+    assertEquals("8 out of 32 is not trimmed", 32, s2.slice(0, 8).array.length)
+    assertEquals("9 out of 32 is not trimmed", 32, s2.slice(0, 9).array.length)
+    assertEquals("24 out of 32 is not trimmed", 32, s2.slice(0, 24).array.length)
+    val s3 = s2.withAutoTrimming(AutoTrimming(minUsagePercentage = 75))
+    assertEquals("2 out of 32 is trimmed to 8", 8, s3.slice(0, 2).array.length)
+    assertEquals("8 out of 32 is trimmed to 8", 8, s3.slice(0, 8).array.length)
+    assertEquals("9 out of 32 is trimmed to 16", 16, s3.slice(0, 9).array.length)
+
+    assertEquals("2 out of 32 with function is trimmed to 8", 8, s3.withoutAutoTrimming { s3 =>
+      var s = s3.slice(0, 2)
+      assertEquals("2 out of 32 in function is not trimmed", 32, s.array.length)
+      s
+    }.array.length)
+  }
+  @Test
+  def testPadTo(): Unit = {
+    assertEquals("empty to 0 is empty", ArraySeq.empty, ArraySeq.empty.padTo(0, 0))
+    assertEquals("empty to 3", ArraySeq(0, 0, 0), ArraySeq.empty.padTo(3, 0))
+    assertEquals("single to 0 is same", ArraySeq(2), ArraySeq(2).padTo(0, 0))
+    assertEquals("single to 1 is same", ArraySeq(2), ArraySeq(2).padTo(1, 0))
+    assertEquals("single to 2", ArraySeq(2, 0), ArraySeq(2).padTo(2, 0))
+    assertEquals("single to 3", ArraySeq(2, 0, 0), ArraySeq(2).padTo(3, 0))
+    assertEquals("multiple to 0 is same", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).padTo(0, 0))
+    assertEquals("reversed multiple to 0 is same", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).reverse.padTo(0, 0))
+    assertEquals("multiple to 1 is same", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).padTo(1, 0))
+    assertEquals("reversed multiple to 1 is same", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).reverse.padTo(1, 0))
+    assertEquals("multiple to 12 is same", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).padTo(12, 0))
+    assertEquals("reversed multiple to 12 is same", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).reverse.padTo(12, 0))
+    assertEquals("multiple to 24", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).padTo(24, 0))
+    assertEquals("reversed multiple to 24", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).reverse.padTo(24, 0))
+  }
+
+  @Test
+  def testDistinct(): Unit = {
+    assertEquals("empty is empty", ArraySeq.empty, ArraySeq.empty.distinct)
+    assertEquals("single is same", ArraySeq(2), ArraySeq(2).distinct)
+    assertEquals("multiple without duplicates is same", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).distinct)
+    assertEquals("reversed multiple without duplicates is same", ArraySeq(12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).reverse.distinct)
+    assertEquals("multiple with duplicates", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8), ArraySeq(1, 2, 3, 4, 5, 6, 1, 2, 7, 6, 8).distinct)
+    assertEquals("reversed multiple with duplicates", ArraySeq(8, 6, 7, 2, 1, 5, 4, 3), ArraySeq(1, 2, 3, 4, 5, 6, 1, 2, 7, 6, 8).reverse.distinct)
+  }
+
+  @Test
+  def testReset(): Unit = {
+    var a = ArraySeq(1, 2, 3)
+    assertEquals("a", ArraySeq(1, 2, 3), a)
+    assertEquals("a.array", List(1, 2, 3, O, O, O, O, O), a.array.to(List))
+    a = a.reset()
+    assertEquals("a after resetting", ArraySeq(1, 2, 3), a)
+    assertEquals("a.array after resetting", List(1, 2, 3, O, O, O, O, O), a.array.to(List))
+    val b = a :+ 4
+    assertEquals("a after appending", ArraySeq(1, 2, 3), a)
+    assertEquals("b after appending", ArraySeq(1, 2, 3, 4), b)
+    assertEquals("a.array after appending", List(1, 2, 3, 4, O, O, O, O), a.array.to(List))
+    a = a.reset()
+    assertEquals("a after appending and resetting", ArraySeq(1, 2, 3), a)
+    assertEquals("b after appending and resetting", ArraySeq(1, 2, 3, 4), b)
+    assertEquals("a.array after appending and resetting", List(1, 2, 3, 4, O, O, O, O), a.array.to(List))
+    val c = a :+ 5
+    assertEquals("a after appending and resetting and appending", ArraySeq(1, 2, 3), a)
+    assertEquals("b after appending and resetting and appending", ArraySeq(1, 2, 3, 5), b)
+    assertEquals("c after appending and resetting and appending", ArraySeq(1, 2, 3, 5), c)
+    assertEquals("a.array after appending and resetting and appending", List(1, 2, 3, 5, O, O, O, O), a.array.to(List))
+  }
+
+  @Test
+  def testOverlayPrepend(): Unit = {
+    val a = ArraySeq(1, 2, 3)
+    val b = 0 +: a
+    val c = 8 +: a
+    val s = c.toString
+    val d = -1 +: b
+    val e = -1 +: c
+    assertEquals("b has correct elements", ArraySeq(0, 1, 2, 3), b)
+    assertEquals("c has correct elements", ArraySeq(8, 1, 2, 3), c)
+    assertEquals("d has correct elements", ArraySeq(-1, 0, 1, 2, 3), d)
+    assertEquals("e has correct elements", ArraySeq(-1, 8, 1, 2, 3), e)
+    assertSame("d and e has same array", d.array, e.array)
+    val ar = a.reverse
+    val br = 0 +: ar
+    val cr = 8 +: ar
+    val dr = -1 +: br
+    val er = -1 +: cr
+    assertEquals("br has correct elements", ArraySeq(0, 3, 2, 1), br)
+    assertEquals("cr has correct elements", ArraySeq(8, 3, 2, 1), cr)
+    assertEquals("dr has correct elements", ArraySeq(-1, 0, 3, 2, 1), dr)
+    assertEquals("er has correct elements", ArraySeq(-1, 8, 3, 2, 1), er)
+    assertSame("dr and er has same array", dr.array, er.array)
+  }
+
+  @Test
+  def testOverlayPrependExpand(): Unit = {
+    val a = ArraySeq(1, 2, 3, 4, 5, 6, 7)
+    val b = 0 +: a
+    val c = 8 +: a
+    val d = -1 +: b
+    val e = -1 +: c
+    assertEquals("b has correct elements", ArraySeq(0, 1, 2, 3, 4, 5, 6, 7), b)
+    assertEquals("c has correct elements", ArraySeq(8, 1, 2, 3, 4, 5, 6, 7), c)
+    assertEquals("d has correct elements", ArraySeq(-1, 0, 1, 2, 3, 4, 5, 6, 7), d)
+    assertEquals("e has correct elements", ArraySeq(-1, 8, 1, 2, 3, 4, 5, 6, 7), e)
+    val ar = a.reverse
+    val br = 0 +: ar
+    val cr = 8 +: ar
+    val dr = -1 +: br
+    val er = -1 +: cr
+    assertEquals("br has correct elements", ArraySeq(0, 7, 6, 5, 4, 3, 2, 1), br)
+    assertEquals("cr has correct elements", ArraySeq(8, 7, 6, 5, 4, 3, 2, 1), cr)
+    assertEquals("dr has correct elements", ArraySeq(-1, 0, 7, 6, 5, 4, 3, 2, 1), dr)
+    assertEquals("er has correct elements", ArraySeq(-1, 8, 7, 6, 5, 4, 3, 2, 1), er)
+  }
+
+  @Test
+  def testOverlayAppend(): Unit = {
+    val a = ArraySeq(1, 2, 3)
+    val b = a :+ 4
+    val c = a :+ 8
+    val d = b :+ 5
+    val e = c :+ 5
+    assertEquals("b has correct elements", ArraySeq(1, 2, 3, 4), b)
+    assertEquals("c has correct elements", ArraySeq(1, 2, 3, 8), c)
+    assertEquals("d has correct elements", ArraySeq(1, 2, 3, 4, 5), d)
+    assertEquals("e has correct elements", ArraySeq(1, 2, 3, 8, 5), e)
+    assertSame("d and e has same array", d.array, e.array)
+    val ar = a.reverse
+    val br = ar :+ 4
+    val cr = ar :+ 8
+    val dr = br :+ 5
+    val er = cr :+ 5
+    assertEquals("br has correct elements", ArraySeq(3, 2, 1, 4), br)
+    assertEquals("cr has correct elements", ArraySeq(3, 2, 1, 8), cr)
+    assertEquals("dr has correct elements", ArraySeq(3, 2, 1, 4, 5), dr)
+    assertEquals("er has correct elements", ArraySeq(3, 2, 1, 8, 5), er)
+    assertSame("dr and er has same array", dr.array, er.array)
+  }
+
+  @Test
+  def testOverlayAppendExpand(): Unit = {
+    val a = ArraySeq(-3, -2, -1, 0, 1, 2, 3)
+    val b = a :+ 4
+    val c = a :+ 8
+    val d = b :+ 5
+    val e = c :+ 5
+    assertEquals("b has correct elements", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4), b)
+    assertEquals("c has correct elements", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 8), c)
+    assertEquals("d has correct elements", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 4, 5), d)
+    assertEquals("e has correct elements", ArraySeq(-3, -2, -1, 0, 1, 2, 3, 8, 5), e)
+    val ar = a.reverse
+    val br = ar :+ 4
+    val cr = ar :+ 8
+    val dr = br :+ 5
+    val x = dr.foreach(-_)
+    val er = cr :+ 5
+    assertEquals("br has correct elements", ArraySeq(3, 2, 1, 0, -1, -2, -3, 4), br)
+    assertEquals("cr has correct elements", ArraySeq(3, 2, 1, 0, -1, -2, -3, 8), cr)
+    assertEquals("dr has correct elements", ArraySeq(3, 2, 1, 0, -1, -2, -3, 4, 5), dr)
+    assertEquals("er has correct elements", ArraySeq(3, 2, 1, 0, -1, -2, -3, 8, 5), er)
+  }
+
+  @Test
+  def testUpdated(): Unit = {
+    assertEquals("single", ArraySeq(0), ArraySeq(1).updated(0, 0))
+    assertEquals("single reversed", ArraySeq(0), ArraySeq(1).reverse.updated(0, 0))
+    assertEquals("small first", ArraySeq(0, 2, 3), ArraySeq(1, 2, 3).updated(0, 0))
+    assertEquals("small first reversed", ArraySeq(0, 2, 1), ArraySeq(1, 2, 3).reverse.updated(0, 0))
+    assertEquals("small middle", ArraySeq(1, 0, 3), ArraySeq(1, 2, 3).updated(1, 0))
+    assertEquals("small middle reversed", ArraySeq(3, 0, 1), ArraySeq(1, 2, 3).reverse.updated(1, 0))
+    assertEquals("small last", ArraySeq(1, 2, 0), ArraySeq(1, 2, 3).updated(2, 0))
+    assertEquals("small last reversed", ArraySeq(3, 2, 0), ArraySeq(1, 2, 3).reverse.updated(2, 0))
+    assertEquals("large first", ArraySeq(0, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).updated(0, 0))
+    assertEquals("large first reversed", ArraySeq(0, 8, 7, 6, 5, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).reverse.updated(0, 0))
+    assertEquals("large middle", ArraySeq(1, 2, 3, 4, 0, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).updated(4, 0))
+    assertEquals("large middle reversed", ArraySeq(9, 8, 7, 6, 0, 4, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).reverse.updated(4, 0))
+    assertEquals("large last", ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 0), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).updated(8, 0))
+    assertEquals("large last reversed", ArraySeq(9, 8, 7, 6, 5, 4, 3, 2, 0), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).reverse.updated(8, 0))
+    assertEquals("large many", ArraySeq(0, 1, 2, 3, 4, 5, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).updated(0, 0).updated(1, 1).updated(2, 2).updated(3, 3).updated(4, 4).updated(5, 5))
+    assertEquals("large many reversed", ArraySeq(0, 1, 2, 3, 4, 5, 3, 2, 1), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9).reverse.updated(0, 0).updated(1, 1).updated(2, 2).updated(3, 3).updated(4, 4).updated(5, 5))
+    val xs = ArraySeq.range(0, 100)
+    val ys = ArraySeq.range(0, 100)
+    assertEquals("large last repeated", ys.updated(99, 4), xs.updated(99, 0).updated(99, 1).updated(99, 2).updated(99, 3).updated(99, 4))
+  }
+
+  @Test
+  def testMaxOverlayPercentage(): Unit = {
+    val s = ArraySeq.range(1, 65)
+    var t = s
+    var u = s.take(8).map(-_) ++: s.drop(8)
+    for (i <- 1 to 8) t = t.updated(i - 1, -i)
+    assertEquals("will produce correct results when updating 8 / 64", u, t)
+    var xs = u.to(List)
+    var ys = t.array.to(List)
+    t = s
+    u = s.take(32).map(-_) ++: s.drop(32)
+    for (i <- 1 to 31) t = t.updated(i - 1, -i)
+    t = t.updated(31, -32)
+    assertEquals("will produce correct results when updating 32 / 64", u, t)
+    xs = u.to(List)
+    ys = t.array.to(List)
+    assertEquals("will merge overlay when updating 32 / 64", xs, ys)
+    t = s
+    u = s.take(64).map(-_)
+    for (i <- 1 to 63) t = t.updated(i - 1, -i)
+    t = t.updated(63, -64)
+    assertEquals("will produce correct results when updating 48 / 64", u, t)
+    xs = u.to(List)
+    ys = t.array.to(List)
+    assertEquals("will merge overlay when updating 48 / 64", xs, ys)
+  }
+
+  @Test
+  def testMkString(): Unit = {
+    assertEquals("empty", "[]", ArraySeq.empty.mkString("[", ", ", "]"))
+    assertEquals("single", "[1]", ArraySeq(1).mkString("[", ", ", "]"))
+    val xs = ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+    assertEquals("multiple", "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]", xs.mkString("[", ", ", "]"))
+    val xsr = xs.reverse
+    assertEquals("multiple reversed", "[12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]", xsr.mkString("[", ", ", "]"))
+    val ysr = ArraySeq(1, 2, 3).reverse :+ 4
+    assertEquals("append single on reversed", "[3, 2, 1, 4]", ysr.mkString("[", ", ", "]"))
+  }
+
+  @Test
+  def testEquals(): Unit = {
+    assertEquals("empty with empty", ArraySeq.empty, ArraySeq.empty)
+    assertEquals("empty with empty reversed", ArraySeq.empty, ArraySeq.empty.reverse)
+    assertEquals("empty with empty with auto triming", ArraySeq.empty, ArraySeq.empty.withAutoTrimming(AutoTrimming.Always))
+    assertEquals("empty with empty with auto triming reversed", ArraySeq.empty, ArraySeq.empty.withAutoTrimming(AutoTrimming.Always).reverse)
+    assertEquals("empty with empty without auto triming", ArraySeq.empty, ArraySeq.empty.withoutAutoTrimming)
+    assertEquals("empty with empty without auto triming reversed", ArraySeq.empty, ArraySeq.empty.withoutAutoTrimming.reverse)
+    assertEquals("empty with empty apply", ArraySeq.empty, ArraySeq())
+    assertEquals("empty with empty apply reversed", ArraySeq.empty, ArraySeq().reverse)
+    assertEquals("empty with empty slice", ArraySeq.empty, ArraySeq(1, 2, 3).slice(0, 0))
+    assertEquals("empty with empty reversed slice", ArraySeq.empty, ArraySeq(1, 2, 3).reverse.slice(0, 0))
+    assertEquals("single with single", ArraySeq(1), ArraySeq(1))
+    assertEquals("single with single reversed", ArraySeq(1), ArraySeq(1).reverse)
+    assertEquals("single with single without auto triming", ArraySeq(1), ArraySeq(1).withoutAutoTrimming)
+    assertEquals("single with single without auto triming reversed", ArraySeq(1), ArraySeq(1).withoutAutoTrimming.reverse)
+    assertEquals("single with single slice", ArraySeq(1), ArraySeq(1, 2, 3).slice(0, 1))
+    assertEquals("single with single reversed slice", ArraySeq(1), ArraySeq(3, 2, 1).reverse.slice(0, 1))
+    assertEquals("multiple with multiple", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3))
+    assertEquals("multiple with multiple reversed", ArraySeq(1, 2, 3), ArraySeq(3, 2, 1).reverse)
+    assertEquals("multiple with multiple slice", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3, 4, 5, 6).slice(0, 3))
+    assertEquals("multiple with multiple reversed slice", ArraySeq(1, 2, 3), ArraySeq(6, 5, 4, 3, 2, 1).reverse.slice(0, 3))
+  }
+
+  @Test
+  def testTakeWhile(): Unit = {
+    assertEquals("empty with true", ArraySeq.empty, ArraySeq.empty[Int].takeWhile(_ => true))
+    assertEquals("empty with false", ArraySeq.empty, ArraySeq.empty[Int].takeWhile(_ => false))
+    assertEquals("single with true", ArraySeq(1), ArraySeq(1).takeWhile(_ => true))
+    assertEquals("single with false", ArraySeq.empty, ArraySeq(1).takeWhile(_ => false))
+    assertEquals("multiple with true", ArraySeq(1, 2, 3), ArraySeq(1, 2, 3).takeWhile(_ => true))
+    assertEquals("multiple with false", ArraySeq.empty, ArraySeq(1).takeWhile(_ => false))
+    assertEquals("multiple with predicate", ArraySeq(1, 2), ArraySeq(1, 2, 3, 4, 5, 6).takeWhile(_ < 3))
+  }
+
+  @Test
+  def testZip(): Unit = {
+    assertEquals("empty with empty", ArraySeq.empty, ArraySeq.empty.zip(ArraySeq.empty))
+    assertEquals("empty with single", ArraySeq.empty, ArraySeq.empty.zip(ArraySeq(1)))
+    assertEquals("empty with multiple", ArraySeq.empty, ArraySeq.empty.zip(ArraySeq(1, 2, 3)))
+    assertEquals("single with empty", ArraySeq.empty, ArraySeq(1).zip(ArraySeq.empty))
+    assertEquals("single with single", ArraySeq(1 -> 2), ArraySeq(1).zip(ArraySeq(2)))
+    assertEquals("single with multiple", ArraySeq(1 -> 2), ArraySeq(1).zip(ArraySeq(2, 3, 4)))
+    assertEquals("multiple with empty", ArraySeq.empty, ArraySeq(1, 2, 3).zip(ArraySeq.empty))
+    assertEquals("multiple with single", ArraySeq(1 -> 2), ArraySeq(1, 2, 3).zip(ArraySeq(2)))
+    assertEquals("multiple with multiple", ArraySeq(1 -> 2, 2 -> 3, 3 -> 4), ArraySeq(1, 2, 3).zip(ArraySeq(2, 3, 4)))
+    assertEquals("multiple reversed with empty", ArraySeq.empty, ArraySeq(1, 2, 3).reverse.zip(ArraySeq.empty))
+    assertEquals("multiple reversed with single", ArraySeq(3 -> 2), ArraySeq(1, 2, 3).reverse.zip(ArraySeq(2)))
+    assertEquals("multiple reversed with multiple", ArraySeq(3 -> 2, 2 -> 3, 1 -> 4), ArraySeq(1, 2, 3).reverse.zip(ArraySeq(2, 3, 4)))
+  }
+
+  @Test
+  def testUnzip(): Unit = {
+    assertEquals("empty", ArraySeq.empty -> ArraySeq.empty, ArraySeq.empty.unzip)
+    assertEquals("single", ArraySeq(1) -> ArraySeq(2), ArraySeq(1 -> 2).unzip)
+    assertEquals("multiple", ArraySeq(1, 2, 3) -> ArraySeq(2, 3, 4), ArraySeq(1 -> 2, 2 -> 3, 3 -> 4).unzip)
+    assertEquals("multiple reversed", ArraySeq(3, 2, 1) -> ArraySeq(4, 3, 2), ArraySeq(1 -> 2, 2 -> 3, 3 -> 4).reverse.unzip)
+  }
+
+  @Test
+  def testAutoTrimmingAlways(): Unit = {
+    assertEquals("empty", List.empty, ArraySeq.empty.withAutoTrimming(AutoTrimming.Always).array.to(List))
+    assertEquals("single", List(1), ArraySeq(1).withAutoTrimming(AutoTrimming.Always).array.to(List))
+    assertEquals("multiple", List(1, 2, 3), ArraySeq(1, 2, 3).withAutoTrimming(AutoTrimming.Always).array.to(List))
+    assertEquals("multiple over edge", List.range(1, 11), (ArraySeq(1, 2, 3, 4, 5, 6, 7).withAutoTrimming(AutoTrimming.Always) :+ 8 :+ 9 :+ 10).array.to(List))
+  }
+}

--- a/collections/src/test/scala/strawman/collection/test/Test.scala
+++ b/collections/src/test/scala/strawman/collection/test/Test.scala
@@ -6,7 +6,7 @@ import java.lang.String
 import scala.{Any, Array, Boolean, Char, Either, Int, Left, Nothing, Option, StringContext, Unit}
 import scala.Predef.{assert, charWrapper, identity, println}
 import collection._
-import collection.immutable.{ImmutableArray, LazyList, List, Nil, Range, Vector}
+import collection.immutable.{ImmutableArray, LazyList, List, Nil, Range, Vector, ArraySeq}
 import collection.mutable.{ArrayBuffer, ListBuffer}
 import org.junit.Test
 
@@ -269,6 +269,48 @@ class StrawmanTest {
     println(xs17.view)
   }
 
+  def arraySeqOps(xs: ArraySeq[Int]): Unit = {
+    val x1 = xs.foldLeft("")(_ + _)
+    val y1: String = x1
+    val x2 = xs.foldRight("")(_ + _)
+    val y2: String = x2
+    val x3 = xs.indexWhere(_ % 2 == 0)
+    val y3: Int = x3
+    val x4 = xs.head
+    val y4: Int = x4
+    val x5 = xs.to(List)
+    val y5: List[Int] = x5
+    val (xs6, xs7) = xs.partition(_ % 2 == 0)
+    val ys6: ArraySeq[Int] = xs6
+    val ys7: ArraySeq[Int] = xs7
+    val xs8 = xs.drop(2)
+    val ys8: ArraySeq[Int] = xs8
+    val xs10 = xs.flatMap(x => List(x, -x))
+    val ys10: ArraySeq[Int] = xs10
+    val xs11 = xs ++ xs
+    val ys11: ArraySeq[Int] = xs11
+    val xs13 = Nil ++ xs
+    val ys13: List[Int] = xs13
+    val xs14 = xs ++ (("a": Any) :: Nil)
+    val ys14: ArraySeq[Any] = xs14
+    val xs16 = xs.reverse
+    val ys16: ArraySeq[Int] = xs16
+    println("-ARRAYSEQ------")
+    println(x1)
+    println(x2)
+    println(x3)
+    println(x4)
+    println(x5)
+    println(xs6.view)
+    println(xs7.view)
+    println(xs8.view)
+    println(xs10.view)
+    println(xs11.view)
+    println(xs13)
+    println(xs14.view)
+    println(xs16.view)
+  }
+
   def immutableSeqOps(xs: immutable.Seq[Int]): Unit = {
     val xs1 = xs :+ 42
     assert(xs1 == (xs ++ immutable.Seq(42)))
@@ -466,6 +508,22 @@ class StrawmanTest {
     assert(lazeCountS==lazeCountL)
   }
 
+  def equality(): Unit = {
+    val list: Iterable[Int] = List(1, 2, 3)
+    val lazyList: Iterable[Int] = LazyList(1, 2, 3)
+    val buffer = ArrayBuffer(1, 2, 3)
+    val range = Range.inclusive(1, 3)
+    assert(list == lazyList)
+    assert(list.## == lazyList.##)
+    assert(list == (buffer: Iterable[Int]))
+    assert(list.## == buffer.##)
+    assert(list == (range: Iterable[Int]))
+    assert(list.## == range.##)
+    buffer += 4
+    assert(list != (buffer: Iterable[Int]))
+    assert(list.## != buffer.##)
+  }
+
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
     iterableOps(xs)
     val xs1 = xs.map((x: Int) => x.toString) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
@@ -574,6 +632,8 @@ class StrawmanTest {
     immutableSeqOps(intsArr)
     immutableArrayOps(intsArr)
     lazyListOps(intsLzy)
+    arraySeqOps(ArraySeq(1, 2, 3))
+    equality()
     distinct()
     linearSeqSize()
   }

--- a/test/junit/src/test/scala/strawman/collection/IndexedSeqTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IndexedSeqTest.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 
 import scala.Predef.{genericArrayOps => _, augmentString => _, classOf, intWrapper, Manifest, manifest}
-import strawman.collection.immutable.{List, Nil, Vector}
+import strawman.collection.immutable.{List, Nil, Vector, ArraySeq}
 
 import org.junit.Test
 import org.junit.Ignore
@@ -570,6 +570,15 @@ package IndexedTestImpl {
 
     override protected def underTest(size: Int): Vector[String] = {
       var res = Vector.newBuilder[String]
+      for (i <- 0 until size)
+        res += expectedValueAtIndex(i)
+      res.result()
+    }
+  }
+  class ArraySeqTest extends ImmutableIndexedSeqTest[ArraySeq[String], String]  with StringTestData {
+
+    override protected def underTest(size: Int): ArraySeq[String] = {
+      var res = ArraySeq.newBuilder[String]
       for (i <- 0 until size)
         res += expectedValueAtIndex(i)
       res.result()

--- a/test/junit/src/test/scala/strawman/collection/ReusableBuildersTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/ReusableBuildersTest.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import strawman.collection.immutable.{List, Nil, Vector}
+import strawman.collection.immutable.{List, Nil, Vector, ArraySeq}
 import scala.Predef.{genericArrayOps => _, classOf, assert, intWrapper}
 
 import org.junit.runner.RunWith

--- a/test/junit/src/test/scala/strawman/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ArraySeqTest.scala
@@ -1,0 +1,30 @@
+package strawman.collection.immutable
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class ArraySeqTest {
+
+  @Test
+  def hasCorrectDropAndTakeMethods(): Unit = {
+    val v = ArraySeq(0) ++ ArraySeq(1 to 64: _*)
+
+    assertEquals(ArraySeq(0, 1), v take 2)
+    assertEquals(ArraySeq(63, 64), v takeRight 2)
+    assertEquals(ArraySeq(2 to 64: _*), v drop 2)
+    assertEquals(ArraySeq(0 to 62: _*), v dropRight 2)
+
+    assertEquals(v, v take Int.MaxValue)
+    assertEquals(v, v takeRight Int.MaxValue)
+    assertEquals(ArraySeq.empty[Int], v drop Int.MaxValue)
+    assertEquals(ArraySeq.empty[Int], v dropRight Int.MaxValue)
+
+    assertEquals(ArraySeq.empty[Int], v take Int.MinValue)
+    assertEquals(ArraySeq.empty[Int], v takeRight Int.MinValue)
+    assertEquals(v, v drop Int.MinValue)
+    assertEquals(v, v dropRight Int.MinValue)
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArraySeqTest.scala
@@ -1,0 +1,44 @@
+package strawman.collection.mutable
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.immutable.{List, ArraySeq}
+
+@RunWith(classOf[JUnit4])
+/* Test for scala/bug#8014 and ++ in general  */
+class ArraySeqTest {
+  val noArraySeq = ArraySeq.empty[Int]
+  val xArraySeq = ArraySeq(1, 2, 3)
+  val smallArraySeq = ArraySeq.range(0,3)
+  val bigArraySeq = ArraySeq.range(0,64)
+  val smsm = ArraySeq.tabulate(2 * smallArraySeq.length)(i => (i % smallArraySeq.length))
+  val smbig = ArraySeq.tabulate(smallArraySeq.length + bigArraySeq.length)(i =>
+    if (i < smallArraySeq.length) i else i - smallArraySeq.length
+  )
+  val bigsm = ArraySeq.tabulate(smallArraySeq.length + bigArraySeq.length)(i =>
+    if (i < bigArraySeq.length) i else i - bigArraySeq.length
+  )
+  val bigbig = ArraySeq.tabulate(2 * bigArraySeq.length)(i => (i % bigArraySeq.length))
+
+
+  val arraySeqs = List(noArraySeq, smallArraySeq, bigArraySeq)
+  val ans = List(
+    arraySeqs,
+    List(smallArraySeq, smsm, smbig),
+    List(bigArraySeq, bigsm, bigbig)
+  )
+
+  @Test
+  def ArraySeqCat(): Unit = {
+    val cats = arraySeqs.map(a => arraySeqs.map(a ++ _))
+    assert( cats == ans )
+  }
+
+  @Test
+  def arrayCat(): Unit = {
+    val ars = arraySeqs.map(_.toArray)
+    val cats = arraySeqs.map(a => ars.map(a ++ _))
+    assert( cats == ans )
+  }
+}


### PR DESCRIPTION
An _ArraySeq_ is an (ostensible) immutable array-like collection designed to support the following performance characteristics:
  * constant time `head`, `last`, `tail`*, `init`*, `take`*, `takeRight`*, `takeWhile`*, `drop`*, `dropRight`*, `dropWhile`*, `slice`* and `reverse` (* = depending on the auto-trimming mode in use)
  * amortised constant time `prepended`/`prependedAll`, `appended`/`appendedAll` and `concat` (depending on the complexity of `java.lang.System.arraycopy`)
  * efficient indexed access
  * linear time iteration (i.e. `iterator` and `foreach`) with low constant factors
  * reasonable memory usage (approximately double that of an array with the same number of elements)

Elements can be added to both the front and the rear of the underlying array (via `prepended`/`prependedAll` and `appended`/`appendedAll`/`concat` respectively), but never more than once for any given array slot. For any operation trying to use an already occupied slot (such as `appended`, `prepended` or `updated`) an overlay is provided that can store the index and element pair using a `HashMap` (thus avoiding having to copy the underlying array).
The overlay will only be allowed to grow according to the used auto-trimming mode, after which it will be merged with the underlying array on the next transformation operation.

To guarantee that only a single thread can write to an array slot an atomic long is used to guard the low and high index assignments.

When the underlying array is too small to fit a requested addition a new array is allocated (the size is dependent on the auto trimming mode used).

To ensure that no longer accessible array slots (i.e. on the returned instance of a `slice`-based operation) are freed, trimming can be used. Trimming can either be performed manually (via the `trim` method) or automatically (by specifying an auto-trimming mode at creation or via the `withAutoTrimming` method).

The automatic trimming can be customized via these three properties:

Property | Default | Description
-------- | ------- | -----------
`minUsagePercentage` | `25` | The minimum `size / capacity` percentage allowed before auto trimming.
`maxOverlaidPercentage` | `50` | The maximum `overlaySize / capacity´ percentage allowed before auto trimming.
`usePadding` | `true` | Indicates whether to use padding or not.

There exists three predefined auto trimming modes:
  * `AutoTrimming.Always` will use auto trimming for all transformation operations and never use an overlay nor any padding. Safe but slow.
  * `AutoTrimming.Default` will use auto trimming for all transformation operations where the size of the returned instance is at most 25% of the capacity of the underlay, and will use an overlay with a size of at most 50% of the capacity of the underlay, and will use padding. Somewhat leaky but fast except for creating small slices.
 * `AutoTrimming.Never` will never use auto trimming, and will allow the overlay to grow to the same size as the capacity of the underlay, and will use padding. Leaky but fast.

**Examples**
```scala
// expression                                              (array, start, stop)
ArraySeq()                                             ==> ([], 0, 0)
ArraySeq() :+ a                                        ==> ([a, _, _, _, _, _, _, _], 0, 1)
a +: ArraySeq()                                        ==> ([_, _, _, _, _, _, _, a], -1, 0)
ArraySeq() :++ Seq(a, b, c, d)                         ==> ([a, b, c, d, _, _, _, _], 0, 4)
Seq(a, b, c, d) ++: ArraySeq()                         ==> ([_, _, _, _, a, b, c, d], -4, 0)
Seq(a, b, c, d) ++: ArraySeq() :++ Seq(e, f, g, h)     ==> ([e, f, g, h, a, b, c, d], -4, 4)
ArraySeq(a, b, c, d, e, f, g, h)                       ==> ([a, b, c, d, e, f, g, h], 0, 8)
ArraySeq() :++ Seq(a, b, c, d, e, f, g, h)             ==> ([a, b, c, d, e, f, g, h], 0, 8)
Seq(a, b, c, d, e, f, g, h) ++: ArraySeq()             ==> ([a, b, c, d, e, f, g, h], -8, 0)
(Seq(a, b, c, d) ++: ArraySeq()).slice(1, 3)           ==> ([_, _, _, _, a, b, c, d], -3, -1)
(ArraySeq() :++ Seq(a, b, c, d)).slice(1, 3)           ==> ([a, b, c, d, _, _, _, _], 1, 3)
(Seq(a, b) ++: ArraySeq() :++ Seq(c, d)).slice(1, 3)   ==> ([c, d, _, _, _, _, a, b], -1, 1)
```