### PR TITLE
HashSet, ListSet and TreeSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 
 ## Implemented operations (on the relevant collection types)
 
-### Terminal operations
+### Operations not returning a collection
 
 - [x] `forall`
 - [x] `foreach`
@@ -89,7 +89,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 - [x] `sum`
 - [x] `to`
 
-### Transformations keeping the same element type
+### Transformations to collections having the same element type
 
 - [x] `drop`
 - [x] `filter`

--- a/README.md
+++ b/README.md
@@ -45,3 +45,67 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHOT"
 ~~~
+
+## Implemented collection types
+
+- [x] `List`
+- [x] `LazyList` (aka `Stream` in 2.12)
+- [ ] `Queue`
+- [ ] `Stack`
+- [x] `ArrayOps`
+- [x] `StringOps`
+- [x] `ArrayBuffer`
+- [x] `ListBuffer`
+- [ ] `UnrolledBuffer`
+- [ ] `LinkedList`
+- [ ] `DoubleLinkedList`
+- [ ] `Range` / `NumericRange`
+- [ ] `HashMap`
+- [ ] `TreeMap`
+- [ ] `IntMap` / `LongMap` (?)
+- [ ] `ListMap`
+- [ ] `MultiMap`
+- [ ] `HashSet`
+- [ ] `ListSet`
+- [ ] `TreeSet`
+- [ ] `EqSet`
+- [ ] `BitSet`
+- [x] `View`
+
+## Implemented operations (on the relevant collection types)
+
+### Terminal operations
+
+- [x] `forall`
+- [x] `foreach`
+- [x] `foldLeft`
+- [x] `foldRight`
+- [x] `head`
+- [x] `indexWhere`
+- [x] `isEmpty` / `nonEmpty`
+- [x] `last`
+- [x] `mkString`
+- [x] `size`
+- [x] `sum`
+- [x] `to`
+
+### Transformations keeping the same element type
+
+- [x] `drop`
+- [x] `filter`
+- [x] `partition`
+- [x] `splitAt`
+- [x] `tail`
+- [x] `take`
+- [ ] `groupBy`
+
+### Transformations to collections that can have a different element type
+
+- [x] `++` / `concat`
+- [x] `flatMap`
+- [x] `map`
+- [x] `zip`
+
+### In-place mutating operations
+
+TODO

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 - [ ] `IntMap` / `LongMap` (?)
 - [ ] `ListMap`
 - [ ] `MultiMap`
-- [ ] `HashSet`
-- [ ] `ListSet`
-- [ ] `TreeSet`
+- [x] `HashSet`
+- [x] `ListSet`
+- [x] `TreeSet`
 - [ ] `EqSet`
 - [ ] `BitSet`
 - [x] `View`
@@ -76,6 +76,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 
 ### Operations not returning a collection
 
+- [x] `firstKey`
 - [x] `forall`
 - [x] `foreach`
 - [x] `foldLeft`
@@ -84,6 +85,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 - [x] `indexWhere`
 - [x] `isEmpty` / `nonEmpty`
 - [x] `last`
+- [x] `lastKey`
 - [x] `mkString`
 - [x] `size`
 - [x] `sum`
@@ -92,8 +94,10 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 ### Transformations to collections having the same element type
 
 - [x] `drop`
+- [x] `empty`
 - [x] `filter`
 - [x] `partition`
+- [x] `range`
 - [x] `splitAt`
 - [x] `tail`
 - [x] `take`

--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -3,7 +3,7 @@ package bench
 import strawman.collection.immutable.{LazyList, List}
 
 import scala.{Any, AnyRef, App, Int, Long, Seq, StringContext}
-import scala.Predef.{ArrowAssoc, println}
+import scala.Predef.{ArrowAssoc, println, intWrapper}
 import scala.compat.Platform
 import java.lang.Runtime
 import java.nio.file.{Files, Paths}
@@ -40,6 +40,8 @@ object MemoryFootprint extends App {
       "scala.List"  -> benchmark(scala.List.fill(_)(obj)),
       "List"        -> benchmark(List.fill(_)(obj)),
       "LazyList"    -> benchmark(LazyList.fill(_)(obj)),
+      "scala.HashSet" -> benchmark(n => scala.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
+      "HashSet"     -> benchmark(n => scala.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
       "ArrayBuffer" -> benchmark(ArrayBuffer.fill(_)(obj)),
       "ListBuffer"  -> benchmark(ListBuffer.fill(_)(obj))
     )

--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -37,13 +37,15 @@ object MemoryFootprint extends App {
 
   val memories =
     scala.Predef.Map(
-      "scala.List"  -> benchmark(scala.List.fill(_)(obj)),
-      "List"        -> benchmark(List.fill(_)(obj)),
-      "LazyList"    -> benchmark(LazyList.fill(_)(obj)),
+      "scala.List"    -> benchmark(scala.List.fill(_)(obj)),
+      "List"          -> benchmark(List.fill(_)(obj)),
+      "LazyList"      -> benchmark(LazyList.fill(_)(obj)),
       "scala.HashSet" -> benchmark(n => scala.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
-      "HashSet"     -> benchmark(n => scala.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
-      "ArrayBuffer" -> benchmark(ArrayBuffer.fill(_)(obj)),
-      "ListBuffer"  -> benchmark(ListBuffer.fill(_)(obj))
+      "HashSet"       -> benchmark(n => collection.immutable.HashSet((1 to n).map(_.toString): _*)),
+      "scala.TreeSet" -> benchmark(n => scala.collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
+      "TreeSet"       -> benchmark(n => collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
+      "ArrayBuffer"   -> benchmark(ArrayBuffer.fill(_)(obj)),
+      "ListBuffer"    -> benchmark(ListBuffer.fill(_)(obj))
     )
 
   // We use a format similar to the one used by JMH so that

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -1,0 +1,57 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.{Any, AnyRef, Int, Unit}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class HashSetBenchmark {
+
+  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  var size: Int = _
+
+  var xs: HashSet[AnyRef] = _
+  var obj: Any = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    xs = HashSet((1 to size).map(_.toString): _*)
+    obj = ""
+  }
+
+  @Benchmark
+  def cons(): Any = {
+    var ys = HashSet.empty[Any]
+    var i = 0
+    while (i < size) {
+      ys = ys + obj // Note: we should test different cases: colliding values as well as non-colliding values, etc.
+      i += 1
+    }
+    ys
+  }
+
+  @Benchmark
+  def uncons(): Any = xs.tail
+
+  @Benchmark
+  def concat(): Any = xs ++ xs
+
+  @Benchmark
+  def foreach(): Any = {
+    var n = 0
+    xs.foreach(x => if (x eq null) n += 1)
+    n
+  }
+
+  @Benchmark
+  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -27,10 +27,10 @@ class HashSetBenchmark {
   def initData(): Unit = {
     def freshCollection() = HashSet((1 to size).map(_.toLong): _*)
     xs = freshCollection()
-    xss = scala.Array.fill(1000)(freshCollection())
-    if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
-    }
+//    xss = scala.Array.fill(1000)(freshCollection())
+//    if (size > 0) {
+//      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+//    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -28,7 +28,9 @@ class HashSetBenchmark {
     def freshCollection() = HashSet((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class HashSetBenchmark {
 
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: HashSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -3,8 +3,9 @@ package strawman.collection.immutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
 
-import scala.{Any, AnyRef, Int, Unit}
+import scala.{Any, AnyRef, Int, Long, Unit}
 import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
@@ -15,43 +16,45 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class HashSetBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: HashSet[AnyRef] = _
-  var obj: Any = _
+  var xs: HashSet[Long] = _
+  var xss: scala.Array[HashSet[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = HashSet((1 to size).map(_.toString): _*)
-    obj = ""
+    def freshCollection() = HashSet((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
   @Benchmark
-  def cons(): Any = {
-    var ys = HashSet.empty[Any]
-    var i = 0
+//  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = HashSet.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys = ys + obj // Note: we should test different cases: colliding values as well as non-colliding values, etc.
-      i += 1
+      ys = ys + i
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
+  def foreach(bh: Blackhole): Unit = {
+    xs.foreach(x => bh.consume(x))
   }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
@@ -28,7 +28,9 @@ class LazyListBenchmark {
     def freshCollection() = LazyList((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
@@ -3,7 +3,10 @@ package strawman.collection.immutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import scala.{Any, AnyRef, Int, Unit}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -13,46 +16,65 @@ import scala.{Any, AnyRef, Int, Unit}
 @State(Scope.Benchmark)
 class LazyListBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: LazyList[AnyRef] = _
-  var obj: Any = _
+  var xs: LazyList[Long] = _
+  var xss: scala.Array[LazyList[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = LazyList.fill(size)("")
-    obj = ""
+    def freshCollection() = LazyList((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
   @Benchmark
-  def cons(): Any = {
-    var ys = LazyList.empty[Any]
-    var i = 0
+  //  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = LazyList.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys = obj #:: ys
-      i += 1
+      ys = i #:: ys
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
+  def foreach(bh: Blackhole): Unit = {
+    xs.foreach(x => bh.consume(x))
   }
 
   @Benchmark
-  def lookup(): Any = xs(size - 1)
+  @OperationsPerInvocation(1000)
+  def lookupLast(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xss(i)(size - 1))
+      i = i + 1
+    }
+  }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  @OperationsPerInvocation(1000)
+  def randomLookup(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs(randomIndices(i)))
+      i = i + 1
+    }
+  }
+
+  @Benchmark
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -3,8 +3,10 @@ package strawman.collection.immutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
 
-import scala.{Any, AnyRef, Int, Unit}
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -14,57 +16,73 @@ import scala.{Any, AnyRef, Int, Unit}
 @State(Scope.Benchmark)
 class ListBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: List[AnyRef] = _
-  var obj: Any = _
+  var xs: List[Long] = _
+  var xss: scala.Array[List[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = List.fill(size)("")
-    obj = ""
+    def freshCollection() = List((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
   @Benchmark
-  def cons(): Any = {
-    var ys = List.empty[Any]
-    var i = 0
+//  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = List.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys = obj :: ys
-      i += 1
+      ys = i :: ys
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
-  }
+  def foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
 
   @Benchmark
-  def foreach_while(): Any = {
-    var n = 0
+//  @OperationsPerInvocation(size)
+  def foreach_while(bh: Blackhole): Unit = {
     var ys = xs
     while (ys.nonEmpty) {
-      if (ys.head eq null) n += 1
+      bh.consume(ys.head)
       ys = ys.tail
     }
-    n
   }
 
   @Benchmark
-  def lookup(): Any = xs(size - 1)
+  @OperationsPerInvocation(1000)
+  def lookupLast(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xss(i)(size - 1))
+      i = i + 1
+    }
+  }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  @OperationsPerInvocation(1000)
+  def randomLookup(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs(randomIndices(i)))
+      i = i + 1
+    }
+  }
+
+  @Benchmark
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -28,7 +28,9 @@ class ListBenchmark {
     def freshCollection() = List((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -1,0 +1,57 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.{Any, AnyRef, Int, Unit}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class ScalaHashSetBenchmark {
+
+  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  var size: Int = _
+
+  var xs: scala.collection.immutable.HashSet[AnyRef] = _
+  var obj: Any = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    xs = scala.collection.immutable.HashSet((1 to size).map(_.toString): _*)
+    obj = ""
+  }
+
+  @Benchmark
+  def cons(): Any = {
+    var ys = scala.collection.immutable.HashSet.empty[Any]
+    var i = 0
+    while (i < size) {
+      ys = ys + obj // Note: we should test different cases: colliding values as well as non-colliding values, etc.
+      i += 1
+    }
+    ys
+  }
+
+  @Benchmark
+  def uncons(): Any = xs.tail
+
+  @Benchmark
+  def concat(): Any = xs ++ xs
+
+  @Benchmark
+  def foreach(): Any = {
+    var n = 0
+    xs.foreach(x => if (x eq null) n += 1)
+    n
+  }
+
+  @Benchmark
+  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class ScalaHashSetBenchmark {
 
-  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.collection.immutable.HashSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -27,10 +27,10 @@ class ScalaHashSetBenchmark {
   def initData(): Unit = {
     def freshCollection() = scala.collection.immutable.HashSet((1 to size).map(_.toLong): _*)
     xs = freshCollection()
-    xss = scala.Array.fill(1000)(freshCollection())
-    if (size > 0) {
-      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
-    }
+//    xss = scala.Array.fill(1000)(freshCollection())
+//    if (size > 0) {
+//      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+//    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -28,7 +28,9 @@ class ScalaHashSetBenchmark {
     def freshCollection() = scala.collection.immutable.HashSet((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -28,7 +28,9 @@ class ScalaListBenchmark {
     def freshCollection() = scala.List((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -3,7 +3,10 @@ package strawman.collection.immutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import scala.{Any, AnyRef, Int, Unit}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -13,46 +16,73 @@ import scala.{Any, AnyRef, Int, Unit}
 @State(Scope.Benchmark)
 class ScalaListBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: scala.List[AnyRef] = _
-  var obj: Any = _
+  var xs: scala.List[Long] = _
+  var xss: scala.Array[scala.List[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = scala.List.fill(size)("")
-    obj = ""
+    def freshCollection() = scala.List((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
   @Benchmark
-  def cons(): Any = {
-    var ys = scala.List.empty[Any]
-    var i = 0
+  //  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = scala.List.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys = obj :: ys
-      i += 1
+      ys = i :: ys
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
+  def foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
+
+  @Benchmark
+  //  @OperationsPerInvocation(size)
+  def foreach_while(bh: Blackhole): Unit = {
+    var ys = xs
+    while (ys.nonEmpty) {
+      bh.consume(ys.head)
+      ys = ys.tail
+    }
   }
 
   @Benchmark
-  def lookup(): Any = xs(size - 1)
+  @OperationsPerInvocation(1000)
+  def lookupLast(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xss(i)(size - 1))
+      i = i + 1
+    }
+  }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  @OperationsPerInvocation(1000)
+  def randomLookup(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs(randomIndices(i)))
+      i = i + 1
+    }
+  }
+
+  @Benchmark
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -1,0 +1,62 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class ScalaTreeSetBenchmark {
+
+  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  var size: Int = _
+
+  var xs: scala.collection.immutable.TreeSet[Long] = _
+  var xss: scala.Array[TreeSet[Long]] = _
+  var randomIndices: scala.Array[Int] = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    def freshCollection() = scala.collection.immutable.TreeSet((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    //    xss = scala.Array.fill(1000)(freshCollection())
+    //    if (size > 0) {
+    //      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    //    }
+  }
+
+  @Benchmark
+  //  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = scala.collection.immutable.TreeSet.empty[Long]
+    var i = 0L
+    while (i < size) {
+      ys = ys + i // Note: In the case of TreeSet, always inserting elements that are already ordered creates a bias
+      i = i + 1
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
+
+  @Benchmark
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
+
+  @Benchmark
+  def foreach(bh: Blackhole): Unit = {
+    xs.foreach(x => bh.consume(x))
+  }
+
+  @Benchmark
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -1,0 +1,62 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class TreeSetBenchmark {
+
+  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  var size: Int = _
+
+  var xs: TreeSet[Long] = _
+  var xss: scala.Array[TreeSet[Long]] = _
+  var randomIndices: scala.Array[Int] = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+    def freshCollection() = TreeSet((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+//    xss = scala.Array.fill(1000)(freshCollection())
+//    if (size > 0) {
+//      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+//    }
+  }
+
+  @Benchmark
+//  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = TreeSet.empty[Long]
+    var i = 0L
+    while (i < size) {
+      ys = ys + i // Note: In the case of TreeSet, always inserting elements that are already ordered creates a bias
+      i = i + 1
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
+
+  @Benchmark
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
+
+  @Benchmark
+  def foreach(bh: Blackhole): Unit = {
+    xs.foreach(x => bh.consume(x))
+  }
+
+  @Benchmark
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -3,7 +3,10 @@ package strawman.collection.mutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import scala.{Any, AnyRef, Int, Unit}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -13,46 +16,64 @@ import scala.{Any, AnyRef, Int, Unit}
 @State(Scope.Benchmark)
 class ArrayBufferBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: ArrayBuffer[AnyRef] = _
-  var obj: Any = _
+  var xs: ArrayBuffer[Long] = _
+  var xss: scala.Array[ArrayBuffer[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = ArrayBuffer.fill(size)("")
-    obj = ""
+    def freshCollection() = ArrayBuffer((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
+
   @Benchmark
-  def cons(): Any = {
-    var ys = ArrayBuffer.empty[Any]
-    var i = 0
+  //  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = ArrayBuffer.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys += obj
-      i += 1
+      ys += i
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
+  def foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def lookupLast(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xss(i)(size - 1))
+      i = i + 1
+    }
   }
 
   @Benchmark
-  def lookup(): Any = xs(size - 1)
+  @OperationsPerInvocation(1000)
+  def randomLookup(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs(randomIndices(i)))
+      i = i + 1
+    }
+  }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -28,7 +28,9 @@ class ArrayBufferBenchmark {
     def freshCollection() = ArrayBuffer((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
 

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -28,7 +28,9 @@ class ListBufferBenchmark {
     def freshCollection() = ListBuffer((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
-    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    if (size > 0) {
+      randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
+    }
   }
 
   @Benchmark

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -3,7 +3,10 @@ package strawman.collection.mutable
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import scala.{Any, AnyRef, Int, Unit}
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit}
+import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -13,46 +16,63 @@ import scala.{Any, AnyRef, Int, Unit}
 @State(Scope.Benchmark)
 class ListBufferBenchmark {
 
-  @Param(scala.Array("8", "64", "512", "4096", "32768", "262144"/*, "2097152"*/))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
-  var xs: ListBuffer[AnyRef] = _
-  var obj: Any = _
+  var xs: ListBuffer[Long] = _
+  var xss: scala.Array[ListBuffer[Long]] = _
+  var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
   def initData(): Unit = {
-    xs = ListBuffer.fill(size)("")
-    obj = ""
+    def freshCollection() = ListBuffer((1 to size).map(_.toLong): _*)
+    xs = freshCollection()
+    xss = scala.Array.fill(1000)(freshCollection())
+    randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
   }
 
   @Benchmark
-  def cons(): Any = {
-    var ys = ListBuffer.empty[Any]
-    var i = 0
+//  @OperationsPerInvocation(size)
+  def cons(bh: Blackhole): Unit = {
+    var ys = ListBuffer.empty[Long]
+    var i = 0L
     while (i < size) {
-      ys += obj
-      i += 1
+      ys += i
+      i = i + 1
     }
-    ys
+    bh.consume(ys)
   }
 
   @Benchmark
-  def uncons(): Any = xs.tail
+  def uncons(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def concat(): Any = xs ++ xs
+  def concat(bh: Blackhole): Unit = bh.consume(xs ++ xs)
 
   @Benchmark
-  def foreach(): Any = {
-    var n = 0
-    xs.foreach(x => if (x eq null) n += 1)
-    n
+  def foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def lookupLast(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xss(i)(size - 1))
+      i = i + 1
+    }
   }
 
   @Benchmark
-  def lookup(): Any = xs(size - 1)
+  @OperationsPerInvocation(1000)
+  def randomLookup(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs(randomIndices(i)))
+      i = i + 1
+    }
+  }
 
   @Benchmark
-  def map(): Any = xs.map(x => if (x eq null) "foo" else "bar")
+  def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion in ThisBuild := "2.12.2-ebe1180-SNAPSHOT" // from https://github.co
 scalaBinaryVersion in ThisBuild := "2.12"
 
 scalacOptions in ThisBuild ++=
-  Seq("-deprecation", "-unchecked", "-Yno-imports", "-language:higherKinds", "-opt:l:classpath")
+  Seq("-deprecation", "-feature", "-unchecked", "-opt-warnings", "-Yno-imports", "-language:higherKinds", "-opt:l:classpath")
 
 testOptions in ThisBuild += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a")
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion in ThisBuild := "2.12.2-ebe1180-SNAPSHOT" // from https://github.co
 scalaBinaryVersion in ThisBuild := "2.12"
 
 scalacOptions in ThisBuild ++=
-  Seq("-deprecation", "-unchecked", "-Yno-imports", "-language:higherKinds")
+  Seq("-deprecation", "-unchecked", "-Yno-imports", "-language:higherKinds", "-opt:l:classpath")
 
 testOptions in ThisBuild += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a")
 

--- a/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/src/main/scala/strawman/collection/BuildFrom.scala
@@ -1,5 +1,7 @@
 package strawman.collection
 
+import scala.language.implicitConversions
+
 import scala.Any
 import scala.annotation.implicitNotFound
 import mutable.Builder

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,7 +3,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, Int, StringContext, Unit}
+import scala.{Any, Array, Boolean, Int, Numeric, StringContext, Unit}
 import java.lang.{String, UnsupportedOperationException}
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}
@@ -50,6 +50,8 @@ trait IterableOps[+A] extends Any {
    */
   def foreach[U](f: A => U): Unit = iterator().foreach(f)
 
+  def forall(p: A => Boolean): Boolean = iterator().forall(p)
+
   /** Fold left */
   def foldLeft[B](z: B)(op: (B, A) => B): B = iterator().foldLeft(z)(op)
 
@@ -67,6 +69,18 @@ trait IterableOps[+A] extends Any {
 
   /** The first element of the collection. */
   def head: A = iterator().next()
+
+  /** Selects the last element.
+    * $orderDependent
+    * @return The last element of this $coll.
+    * @throws NoSuchElementException If the $coll is empty.
+    */
+  def last: A = {
+    var lst = head
+    for (x <- this)
+      lst = x
+    lst
+  }
 
   /** The number of elements in this collection, if it can be cheaply computed,
     *  -1 otherwise. Cheaply usually means: Not requiring a collection traversal.
@@ -132,6 +146,25 @@ trait IterableOps[+A] extends Any {
 
   override def toString = s"$className(${mkString(", ")})"
 
+
+  /** Sums up the elements of this collection.
+    *
+    *   @param   num  an implicit parameter defining a set of numeric operations
+    *                 which includes the `+` operator to be used in forming the sum.
+    *   @tparam  B    the result type of the `+` operator.
+    *   @return       the sum of all elements of this $coll with respect to the `+` operator in `num`.
+    *
+    *   @usecase def sum: A
+    *     @inheritdoc
+    *
+    *     @return       the sum of all elements in this $coll of numbers of type `Int`.
+    *     Instead of `Int`, any other type `T` with an implicit `Numeric[T]` implementation
+    *     can be used as element type of the $coll and as result type of `sum`.
+    *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
+    *
+    */
+  def sum[B >: A](implicit num: Numeric[B]): B = foldLeft(num.zero)(num.plus)
+
 }
 
 
@@ -156,6 +189,20 @@ trait IterableMonoTransforms[+A, +Repr] extends Any {
   def partition(p: A => Boolean): (Repr, Repr) = {
     val pn = View.Partition(coll, p)
     (fromIterableWithSameElemType(pn.left), fromIterableWithSameElemType(pn.right))
+  }
+
+  /** Splits this $coll into two at a given position.
+    *  Note: `c splitAt n` is equivalent to (but possibly more efficient than)
+    *         `(c take n, c drop n)`.
+    *  $orderDependent
+    *
+    *  @param n the position at which to split.
+    *  @return  a pair of ${coll}s consisting of the first `n`
+    *           elements of this $coll, and the other elements.
+    */
+  def splitAt(n: Int): (Repr, Repr) = {
+    val sa = View.SplitAt(coll, n)
+    (fromIterableWithSameElemType(sa.left), fromIterableWithSameElemType(sa.right))
   }
 
   /** A collection containing the first `n` elements of this collection. */
@@ -262,7 +309,7 @@ trait PolyBuildable[+A, +C[_]] extends Any with FromIterable[C] {
 
 /** Base trait for strict collections that can be built using a builder for element types with an implicit evidence.
   * @tparam  A    the element type of the collection
-  * @tparam C     the type constructor of the underlying collection
+  * @tparam CC    the type constructor of the underlying collection
   */
 trait ConstrainedPolyBuildable[+A, +CC[_], Ev[_]] extends Any with ConstrainedFromIterable[CC, Ev] {
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -76,9 +76,9 @@ trait IterableOps[+A] extends Any {
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A = {
-    var lst = head
-    for (x <- this)
-      lst = x
+    val it = iterator()
+    var lst = it.next()
+    while (it.hasNext) lst = it.next()
     lst
   }
 
@@ -200,10 +200,7 @@ trait IterableMonoTransforms[+A, +Repr] extends Any {
     *  @return  a pair of ${coll}s consisting of the first `n`
     *           elements of this $coll, and the other elements.
     */
-  def splitAt(n: Int): (Repr, Repr) = {
-    val sa = View.SplitAt(coll, n)
-    (fromIterableWithSameElemType(sa.left), fromIterableWithSameElemType(sa.right))
-  }
+  def splitAt(n: Int): (Repr, Repr) = (take(n), drop(n))
 
   /** A collection containing the first `n` elements of this collection. */
   def take(n: Int): Repr = fromIterableWithSameElemType(View.Take(coll, n))

--- a/src/main/scala/strawman/collection/IterableFactories.scala
+++ b/src/main/scala/strawman/collection/IterableFactories.scala
@@ -25,7 +25,7 @@ trait BoundedIterableFactory[-B] { self =>
 
   def fromIterable[E <: B](it: Iterable[E]): To[E]
 
-  def empty[A <: B]: To[A] = fromIterable(View.Empty)
+  def empty[A <: B]: To[A]
 
   def apply[A <: B](xs: A*): To[A] = fromIterable(View.Elems(xs: _*))
 
@@ -42,7 +42,7 @@ trait IterableFactory[+C[_]] extends BoundedIterableFactory[Any] with FromIterab
 /** Base trait for companion objects of collections that require an implicit evidence */
 trait ConstrainedIterableFactory[+CC[X], Ev[_]] extends ConstrainedFromIterable[CC, Ev] {
 
-  def empty[A : Ev]: CC[A] = constrainedFromIterable(View.Empty)
+  def empty[A : Ev]: CC[A]
 
   def apply[A : Ev](xs: A*): CC[A] = constrainedFromIterable(View.Elems(xs: _*))
 

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -27,8 +27,13 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     res
   }
 
-  final def foldLeft[B](z: B)(op: (B, A) => B): B =
-    if (hasNext) foldLeft(op(z, next()))(op) else z
+  def foldLeft[B](z: B)(op: (B, A) => B): B = {
+    var result = z
+    while (hasNext) {
+      result = op(result, next())
+    }
+    result
+  }
 
   def foldRight[B](z: B)(op: (A, B) => B): B =
     if (hasNext) op(next(), foldRight(z)(op)) else z

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -27,12 +27,15 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     res
   }
 
-  def foldLeft[B](z: B)(op: (B, A) => B): B =
+  final def foldLeft[B](z: B)(op: (B, A) => B): B =
     if (hasNext) foldLeft(op(z, next()))(op) else z
+
   def foldRight[B](z: B)(op: (A, B) => B): B =
     if (hasNext) op(next(), foldRight(z)(op)) else z
+
   def foreach[U](f: A => U): Unit =
     while (hasNext) f(next())
+
   def indexWhere(p: A => Boolean): Int = {
     var i = 0
     while (hasNext) {
@@ -41,11 +44,13 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     }
     -1
   }
+
   def length = {
     var len = 0
     while (hasNext) { len += 1; next() }
     len
   }
+
   def filter(p: A => Boolean): Iterator[A] = new Iterator[A] {
     private var hd: A = _
     private var hdDefined: Boolean = false
@@ -66,6 +71,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       }
       else Iterator.empty.next()
   }
+
   def map[B](f: A => B): Iterator[B] = new Iterator[B] {
     def hasNext = self.hasNext
     def next() = f(self.next())
@@ -81,6 +87,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     def hasNext = current.hasNext
     def next() = current.next()
   }
+
   def ++[B >: A](xs: IterableOnce[B]): Iterator[B] = new Iterator[B] {
     private var myCurrent: Iterator[B] = self
     private var first = true
@@ -94,6 +101,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     def hasNext = current.hasNext
     def next() = current.next()
   }
+
   def take(n: Int): Iterator[A] = new Iterator[A] {
     private var i = 0
     def hasNext = self.hasNext && i < n
@@ -104,6 +112,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       }
       else Iterator.empty.next()
   }
+
   def drop(n: Int): Iterator[A] = {
     var i = 0
     while (i < n && hasNext) {
@@ -112,11 +121,13 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     }
     this
   }
+
   def zip[B](that: IterableOnce[B]): Iterator[(A, B)] = new Iterator[(A, B)] {
     val thatIterator = that.iterator()
     def hasNext = self.hasNext && thatIterator.hasNext
     def next() = (self.next(), thatIterator.next())
   }
+
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val those = that.iterator()
     while (hasNext && those.hasNext)

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -52,8 +52,7 @@ trait ConstrainedMapFactory[+C[_, _], Ev[_]] { self =>
   def constrainedFromIterable[K : Ev, V](it: Iterable[(K, V)]): C[K, V] =
     constrainedNewBuilder[K, V].++=(it).result
 
-  def empty[K : Ev, V]: C[K, V] =
-    constrainedNewBuilder[K, V].result
+  def empty[K : Ev, V]: C[K, V]
 
   def apply[K : Ev, V](elems: (K, V)*): C[K, V] =
     constrainedNewBuilder[K, V].++=(elems.toStrawman).result

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -20,6 +20,7 @@ trait Set[A]
 trait SetLike[A, +C[X] <: Set[X]]
   extends IterableLike[A, C]
     with SetMonoTransforms[A, C[A]]
+    with SetPolyTransforms[A, C]
     with (A => Boolean)
     with Equals {
 
@@ -59,7 +60,11 @@ trait SetMonoTransforms[A, +Repr]
 
   def & (that: Set[A]): Repr = this.filter(that)
 
-  def ++ (that: Set[A]): Repr
+}
+
+trait SetPolyTransforms[A, +C[X]] extends IterablePolyTransforms[A, C] {
+
+  def ++ (that: Set[A]): C[A]
 
 }
 

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -60,6 +60,11 @@ trait SetMonoTransforms[A, +Repr]
 
   def & (that: Set[A]): Repr = this.filter(that)
 
+  /** The empty set of the same type as this set
+    * @return  an empty set of type `Repr`.
+    */
+  def empty: Repr
+
 }
 
 trait SetPolyTransforms[A, +C[X]] extends IterablePolyTransforms[A, C] {

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,11 +1,17 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, Equals, Int}
+import scala.{Any, Boolean, Equals, inline, Int}
 import scala.util.hashing.MurmurHash3
 
-
-/** Base trait for set collections */
+/** Base trait for set collections.
+  *
+  * A set is a collection that contains no duplicate elements.
+  *
+  * @author Martin Odersky
+  * @author Aleksandar Prokopec
+  * @since 2.9
+  */
 trait Set[A]
   extends Iterable[A]
     with SetLike[A, Set]
@@ -14,13 +20,22 @@ trait Set[A]
 trait SetLike[A, +C[X] <: Set[X]]
   extends IterableLike[A, C]
     with SetMonoTransforms[A, C[A]]
+    with (A => Boolean)
     with Equals {
 
   protected def coll: C[A]
 
   def contains(elem: A): Boolean
 
-  def subsetOf(that: Set[A]): Boolean
+  /** Tests if some element is contained in this set.
+    *
+    *  This method is equivalent to `contains`. It allows sets to be interpreted as predicates.
+    *  @param elem the element to test for membership.
+    *  @return  `true` if `elem` is contained in this set, `false` otherwise.
+    */
+  @inline final def apply(elem: A): Boolean = this.contains(elem)
+
+  def subsetOf(that: Set[A]): Boolean = this.forall(that)
 
   def canEqual(that: Any) = true
 
@@ -42,7 +57,7 @@ trait SetLike[A, +C[X] <: Set[X]]
 trait SetMonoTransforms[A, +Repr]
   extends IterableMonoTransforms[A, Repr] {
 
-  def & (that: Set[A]): Repr
+  def & (that: Set[A]): Repr = this.filter(that)
 
   def ++ (that: Set[A]): Repr
 

--- a/src/main/scala/strawman/collection/Sorted.scala
+++ b/src/main/scala/strawman/collection/Sorted.scala
@@ -10,4 +10,11 @@ trait SortedLike[A, +Repr] {
   def ordering: Ordering[A]
 
   def range(from: A, until: A): Repr
+
+  /** Returns the first key of the collection. */
+  def firstKey: A
+
+  /** Returns the last key of the collection. */
+  def lastKey: A
+
 }

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -13,5 +13,11 @@ trait SortedSetLike[A, +C[X] <: SortedSet[X]]
     with ConstrainedIterablePolyTransforms[A, Set, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetMonoTransforms[A, C[A]] { // Override the return type of Set ops to return C[A]
+
   type Ev[X] = Ordering[X]
+
+  def firstKey: A = head
+
+  def lastKey: A = last
+
 }

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -74,6 +74,11 @@ object View {
     def iterator() = partition.underlying.iterator().filter(x => partition.p(x) == cond)
   }
 
+  case class SplitAt[A](underlying: Iterable[A], n: Int) {
+    val left = Take(underlying, n)
+    val right = Drop(underlying, n)
+  }
+
   /** A view that drops leading elements of the underlying collection. */
   case class Drop[A](underlying: Iterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().drop(n)

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -74,11 +74,6 @@ object View {
     def iterator() = partition.underlying.iterator().filter(x => partition.p(x) == cond)
   }
 
-  case class SplitAt[A](underlying: Iterable[A], n: Int) {
-    val left = Take(underlying, n)
-    val right = Drop(underlying, n)
-  }
-
   /** A view that drops leading elements of the underlying collection. */
   case class Drop[A](underlying: Iterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().drop(n)

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -19,4 +19,6 @@ object BitSet extends BoundedIterableFactory[Int] {
   def fromIterable[E <: Int](it: strawman.collection.Iterable[E]): BitSet = ???
 
   def newBuilder[E <: Int]: Builder[E, BitSet] = ???
+
+  def empty[A <: Int]: BitSet = ???
 }

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -30,16 +30,16 @@ sealed trait HashSet[A]
 
   import HashSet.nullToEmpty
 
-  // From IterablePolyTransforms
   def fromIterable[B](coll: collection.Iterable[B]): HashSet[B] = HashSet.fromIterable(coll)
   protected[this] def fromIterableWithSameElemType(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
-  // From SetLike
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
   def + (elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 
   def - (elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
+
+  override def empty: HashSet[A] = HashSet.empty
 
   override def tail: HashSet[A] = this - head
 
@@ -64,11 +64,15 @@ sealed trait HashSet[A]
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] = newBuilder[A].++=(it).result
+  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] =
+    it match {
+      case hs: HashSet[A] => hs
+      case _ => newBuilder[A].++=(it).result
+    }
 
   def newBuilder[A]: Builder[A, HashSet[A]] = new ImmutableSetBuilder[A, HashSet](empty[A])
 
-  override def empty[A <: Any]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+  def empty[A <: Any]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -2,40 +2,330 @@ package strawman
 
 package collection.immutable
 
-import strawman.collection.mutable.Builder
 import strawman.collection.{IterableFactory, Iterator}
+import strawman.collection.mutable.{Builder, ImmutableSetBuilder}
 
-import scala.{Any, Boolean}
-import scala.Predef.???
+import scala.{Any, AnyRef, Array, Boolean, inline, Int, NoSuchElementException, Serializable, SerialVersionUID, sys, Unit}
+import scala.Predef.assert
+import java.lang.Integer
 
-/** An immutable Set backed by a hash trie */
-class HashSet[A] extends Set[A] with SetLike[A, HashSet] {
+/** This class implements immutable sets using a hash trie.
+  *
+  *  '''Note:''' The builder of this hash set may return specialized representations for small sets.
+  *
+  *  @tparam A      the type of the elements contained in this hash set.
+  *
+  *  @author  Martin Odersky
+  *  @author  Tiark Rompf
+  *  @version 2.8
+  *  @since   2.3
+  *  @define Coll `immutable.HashSet`
+  *  @define coll immutable hash set
+  */
+@SerialVersionUID(2L)
+sealed trait HashSet[A]
+  extends Set[A]
+    with SetLike[A, HashSet]
+    with Serializable {
 
-  // From IterableOnce
-  def iterator(): Iterator[A] = ???
+  import HashSet.nullToEmpty
 
   // From IterablePolyTransforms
   def fromIterable[B](coll: collection.Iterable[B]): HashSet[B] = HashSet.fromIterable(coll)
   protected[this] def fromIterableWithSameElemType(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
   // From SetLike
-  def contains(elem: A): Boolean = ???
-  def subsetOf(that: collection.Set[A]): Boolean = ???
+  def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
-  // From SetMonoTransforms
-  def & (that: collection.Set[A]): HashSet[A] = ???
-  def ++ (that: collection.Set[A]): HashSet[A] = ???
+  def ++ (that: collection.Set[A]): HashSet[A] =
+    // FIXME Same implementation as in ListSet. We might want to factor them out in immutable.SetMonoTransforms
+    if (that.isEmpty) this
+    else that.foldLeft(this)(_ + _)
 
-  // From immutable.SetLike
-  def + (elem: A): HashSet[A] = ???
-  def - (elem: A): HashSet[A] = ???
+  def + (elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
+
+  def - (elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
+
+  protected def get0(key: A, hash: Int, level: Int): Boolean
+
+  protected def updated0(key: A, hash: Int, level: Int): HashSet[A]
+
+  protected def removed0(key: A, hash: Int, level: Int): HashSet[A]
+
+  protected def computeHash(key: A): Int = improve(elemHashCode(key))
+
+  protected final def improve(hcode: Int): Int = {
+    var h: Int = hcode + ~(hcode << 9)
+    h = h ^ (h >>> 14)
+    h = h + (h << 4)
+    h ^ (h >>> 10)
+  }
+
+  protected final def elemHashCode(elem: A): Int = elem.##
 
 }
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] = ???
+  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] = newBuilder[A].++=(it).result
 
-  def newBuilder[A]: Builder[A, HashSet[A]] = ???
+  def newBuilder[A]: Builder[A, HashSet[A]] = new ImmutableSetBuilder[A, HashSet](empty[A])
+
+  override def empty[A <: Any]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+
+  private object EmptyHashSet extends HashSet[Any] {
+
+    def iterator(): Iterator[Any] = Iterator.empty
+
+    override def foreach[U](f: Any => U): Unit = ()
+
+    override def head: Any = throw new NoSuchElementException("Empty Set")
+
+    override def tail: HashSet[Any] = throw new NoSuchElementException("Empty Set")
+
+    override def size: Int = 0
+
+    protected def get0(elem: Any, hash: Int, level: Int) = false
+
+    protected def updated0(elem: Any, hash: Int, level: Int) = new HashSet1(elem, hash)
+
+    protected def removed0(key: Any, hash: Int, level: Int) = this
+
+  }
+
+  /**
+    * Common superclass of HashSet1 and HashSetCollision1, which are the two possible leaves of the Trie
+    */
+  private[HashSet] sealed abstract class LeafHashSet[A] extends HashSet[A] {
+    private[HashSet] def hash:Int
+  }
+
+  private[immutable] final class HashSet1[A](private[HashSet] val key: A, private[HashSet] val hash: Int) extends LeafHashSet[A] {
+
+    def iterator(): Iterator[A] = Iterator.single(key)
+
+    override def size: Int = 1
+
+    protected def get0(key: A, hash: Int, level: Int) =
+      (hash == this.hash && key == this.key)
+
+    protected def updated0(key: A, hash: Int, level: Int) =
+      if (hash == this.hash && key == this.key) this
+      else {
+        if (hash != this.hash) {
+          makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level)
+        } else {
+          // 32-bit hash collision (rare, but not impossible)
+          new HashSetCollision1(hash, ListSet.empty + this.key + key)
+        }
+      }
+
+    protected def removed0(key: A, hash: Int, level: Int) =
+      if (hash == this.hash && key == this.key) null else this
+
+  }
+
+  private[immutable] final class HashSetCollision1[A](private[HashSet] val hash: Int, val ks: ListSet[A]) extends LeafHashSet[A] {
+
+    override def size = ks.size
+
+    protected def get0(key: A, hash: Int, level: Int) =
+      if (hash == this.hash) ks.contains(key) else false
+
+    protected def updated0(key: A, hash: Int, level: Int): HashSet[A] =
+      if (hash == this.hash) new HashSetCollision1(hash, ks + key)
+      else makeHashTrieSet(this.hash, this, hash, new HashSet1(key, hash), level)
+
+    protected def removed0(key: A, hash: Int, level: Int): HashSet[A] =
+      if (hash == this.hash) {
+        val ks1 = ks - key
+        ks1.size match {
+          case 0 =>
+            // the empty set
+            null
+          case 1 =>
+            // create a new HashSet1 with the hash we already know
+            new HashSet1(ks1.head, hash)
+          case size if size == ks.size =>
+            // Should only have HSC1 if size > 1
+            this
+          case _ =>
+            // create a new HashSetCollision with the hash we already know and the new keys
+            new HashSetCollision1(hash, ks1)
+        }
+      } else this
+
+    def iterator: Iterator[A] = ks.iterator
+    override def foreach[U](f: A => U): Unit = ks.foreach(f)
+
+    private def writeObject(out: java.io.ObjectOutputStream) {
+      // this cannot work - reading things in might produce different
+      // hash codes and remove the collision. however this is never called
+      // because no references to this class are ever handed out to client code
+      // and HashTrieSet serialization takes care of the situation
+      sys.error("cannot serialize an immutable.HashSet where all items have the same 32-bit hash code")
+      //out.writeObject(kvs)
+    }
+
+    private def readObject(in: java.io.ObjectInputStream) {
+      sys.error("cannot deserialize an immutable.HashSet where all items have the same 32-bit hash code")
+      //kvs = in.readObject().asInstanceOf[ListSet[A]]
+      //hash = computeHash(kvs.)
+    }
+
+  }
+
+
+  /**
+    * A branch node of the HashTrieSet with at least one and up to 32 children.
+    *
+    * @param bitmap encodes which element corresponds to which child
+    * @param elems the up to 32 children of this node.
+    *              the number of children must be identical to the number of 1 bits in bitmap
+    * @param size0 the total number of elements. This is stored just for performance reasons.
+    * @tparam A      the type of the elements contained in this hash set.
+    *
+    * How levels work:
+    *
+    * When looking up or adding elements, the part of the hashcode that is used to address the children array depends
+    * on how deep we are in the tree. This is accomplished by having a level parameter in all internal methods
+    * that starts at 0 and increases by 5 (32 = 2^5) every time we go deeper into the tree.
+    *
+    * hashcode (binary): 00000000000000000000000000000000
+    * level=0 (depth=0)                             ^^^^^
+    * level=5 (depth=1)                        ^^^^^
+    * level=10 (depth=2)                  ^^^^^
+    * ...
+    *
+    * Be careful: a non-toplevel HashTrieSet is not a self-contained set, so e.g. calling contains on it will not work!
+    * It relies on its depth in the Trie for which part of a hash to use to address the children, but this information
+    * (the level) is not stored due to storage efficiency reasons but has to be passed explicitly!
+    *
+    * How bitmap and elems correspond:
+    *
+    * A naive implementation of a HashTrieSet would always have an array of size 32 for children and leave the unused
+    * children empty (null). But that would be very wasteful regarding memory. Instead, only non-empty children are
+    * stored in elems, and the bitmap is used to encode which elem corresponds to which child bucket. The lowest 1 bit
+    * corresponds to the first element, the second-lowest to the second, etc.
+    *
+    * bitmap (binary): 00010000000000000000100000000000
+    * elems: [a,b]
+    * children:        ---b----------------a-----------
+    */
+  private[immutable] final class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], private val size0: Int)
+    extends HashSet[A] {
+    assert(Integer.bitCount(bitmap) == elems.length)
+    // assertion has to remain disabled until SI-6197 is solved
+    // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieSet[_]]))
+
+    def iterator(): Iterator[A] = new TrieIterator[A](elems.asInstanceOf[Array[Iterable[A]]]) {
+      final override def getElem(cc: AnyRef): A = cc.asInstanceOf[HashSet1[A]].key
+    }
+
+    override def size = size0
+
+    protected def get0(key: A, hash: Int, level: Int) = {
+      val index = (hash >>> level) & 0x1f
+      val mask = (1 << index)
+      if (bitmap == - 1) {
+        elems(index & 0x1f).get0(key, hash, level + 5)
+      } else if ((bitmap & mask) != 0) {
+        val offset = Integer.bitCount(bitmap & (mask-1))
+        elems(offset).get0(key, hash, level + 5)
+      } else
+        false
+    }
+
+    protected def updated0(key: A, hash: Int, level: Int) = {
+      val index = (hash >>> level) & 0x1f
+      val mask = (1 << index)
+      val offset = Integer.bitCount(bitmap & (mask-1))
+      if ((bitmap & mask) != 0) {
+        val sub = elems(offset)
+        val subNew = sub.updated0(key, hash, level + 5)
+        if (sub eq subNew) this
+        else {
+          val elemsNew = new Array[HashSet[A]](elems.length)
+          Array.copy(elems, 0, elemsNew, 0, elems.length)
+          elemsNew(offset) = subNew
+          new HashTrieSet(bitmap, elemsNew, size + (subNew.size - sub.size))
+        }
+      } else {
+        val elemsNew = new Array[HashSet[A]](elems.length + 1)
+        Array.copy(elems, 0, elemsNew, 0, offset)
+        elemsNew(offset) = new HashSet1(key, hash)
+        Array.copy(elems, offset, elemsNew, offset + 1, elems.length - offset)
+        val bitmapNew = bitmap | mask
+        new HashTrieSet(bitmapNew, elemsNew, size + 1)
+      }
+    }
+
+    protected def removed0(key: A, hash: Int, level: Int): HashSet[A] = {
+      val index = (hash >>> level) & 0x1f
+      val mask = (1 << index)
+      val offset = Integer.bitCount(bitmap & (mask-1))
+      if ((bitmap & mask) != 0) {
+        val sub = elems(offset)
+        val subNew = sub.removed0(key, hash, level + 5)
+        if (sub eq subNew) this
+        else if (subNew eq null) {
+          val bitmapNew = bitmap ^ mask
+          if (bitmapNew != 0) {
+            val elemsNew = new Array[HashSet[A]](elems.length - 1)
+            Array.copy(elems, 0, elemsNew, 0, offset)
+            Array.copy(elems, offset + 1, elemsNew, offset, elems.length - offset - 1)
+            val sizeNew = size - sub.size
+            // if we have only one child, which is not a HashTrieSet but a self-contained set like
+            // HashSet1 or HashSetCollision1, return the child instead
+            if (elemsNew.length == 1 && !elemsNew(0).isInstanceOf[HashTrieSet[_]])
+              elemsNew(0)
+            else
+              new HashTrieSet(bitmapNew, elemsNew, sizeNew)
+          } else
+            null
+        } else if(elems.length == 1 && !subNew.isInstanceOf[HashTrieSet[_]]) {
+          subNew
+        } else {
+          val elemsNew = new Array[HashSet[A]](elems.length)
+          Array.copy(elems, 0, elemsNew, 0, elems.length)
+          elemsNew(offset) = subNew
+          val sizeNew = size + (subNew.size - sub.size)
+          new HashTrieSet(bitmap, elemsNew, sizeNew)
+        }
+      } else {
+        this
+      }
+    }
+  }
+
+  // utility method to create a HashTrieSet from two leaf HashSets (HashSet1 or HashSetCollision1) with non-colliding hash code)
+  private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int) : HashTrieSet[A] = {
+    val index0 = (hash0 >>> level) & 0x1f
+    val index1 = (hash1 >>> level) & 0x1f
+    if(index0 != index1) {
+      val bitmap = (1 << index0) | (1 << index1)
+      val elems = new Array[HashSet[A]](2)
+      if(index0 < index1) {
+        elems(0) = elem0
+        elems(1) = elem1
+      } else {
+        elems(0) = elem1
+        elems(1) = elem0
+      }
+      new HashTrieSet[A](bitmap, elems, elem0.size + elem1.size)
+    } else {
+      val elems = new Array[HashSet[A]](1)
+      val bitmap = (1 << index0)
+      val child = makeHashTrieSet(hash0, elem0, hash1, elem1, level + 5)
+      elems(0) = child
+      new HashTrieSet[A](bitmap, elems, child.size)
+    }
+  }
+
+  /**
+    * In many internal operations the empty set is represented as null for performance reasons. This method converts
+    * null to the empty set for use in public methods
+    */
+  @inline private def nullToEmpty[A](s: HashSet[A]): HashSet[A] = if (s eq null) empty[A] else s
 
 }

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -37,11 +37,6 @@ sealed trait HashSet[A]
   // From SetLike
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
-  def ++ (that: collection.Set[A]): HashSet[A] =
-    // FIXME Same implementation as in ListSet. We might want to factor them out in immutable.SetMonoTransforms
-    if (that.isEmpty) this
-    else that.foldLeft(this)(_ + _)
-
   def + (elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 
   def - (elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -59,4 +59,6 @@ object LazyList extends IterableFactory[LazyList] {
 
   def newBuilder[A]: Builder[A, LazyList[A]] = ???
 
+  def empty[A <: Any]: LazyList[A] = new LazyList[A](None)
+
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -62,4 +62,6 @@ object List extends IterableFactory[List] {
 
   def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
+  def empty[A <: Any]: List[A] = Nil
+
 }

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -67,16 +67,13 @@ sealed class ListSet[A]
   def - (elem: A): ListSet[A] = this
 
   def iterator(): strawman.collection.Iterator[A] = {
-    def reverseList = {
-      var curr: ListSet[A] = this
-      var res: List[A] = Nil
-      while (!curr.isEmpty) {
-        res = curr.elem :: res
-        curr = curr.next
-      }
-      res
+    var curr: ListSet[A] = this
+    var res: List[A] = Nil
+    while (!curr.isEmpty) {
+      res = curr.elem :: res
+      curr = curr.next
     }
-    reverseList.iterator()
+    res.iterator()
   }
 
   protected def elem: A = throw new NoSuchElementException("elem of empty set")

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -28,6 +28,8 @@ object ListSet extends IterableFactory[ListSet] {
   private object EmptyListSet extends ListSet[Any]
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
+  def empty[A <: Any]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
+
 }
 
 /**
@@ -65,6 +67,8 @@ sealed class ListSet[A]
 
   def + (elem: A): ListSet[A] = new Node(elem)
   def - (elem: A): ListSet[A] = this
+
+  def empty: ListSet[A] = ListSet.empty
 
   def iterator(): strawman.collection.Iterator[A] = {
     var curr: ListSet[A] = this

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -66,11 +66,6 @@ sealed class ListSet[A]
   def + (elem: A): ListSet[A] = new Node(elem)
   def - (elem: A): ListSet[A] = this
 
-  def ++ (xs: collection.Set[A]): ListSet[A] =
-    if (xs.isEmpty) this
-    else xs.foldLeft(this)(_ + _)
-
-
   def iterator(): strawman.collection.Iterator[A] = {
     def reverseList = {
       var curr: ListSet[A] = this

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -1,0 +1,131 @@
+package strawman
+package collection.immutable
+
+import strawman.collection.mutable.{Builder, ImmutableSetBuilder}
+import strawman.collection.IterableFactory
+
+import scala.annotation.tailrec
+import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable}
+
+/**
+  * $factoryInfo
+  *
+  * Note that each element insertion takes O(n) time, which means that creating a list set with
+  * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
+  * elements.
+  *
+  * @since 1
+  * @define Coll ListSet
+  * @define coll list set
+  */
+object ListSet extends IterableFactory[ListSet] {
+
+  def newBuilder[A <: Any]: Builder[A, ListSet[A]] = new ImmutableSetBuilder[A, ListSet](empty[A])
+
+  def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] = newBuilder.++=(it).result
+
+  @SerialVersionUID(5010379588739277132L)
+  private object EmptyListSet extends ListSet[Any]
+  private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
+
+}
+
+/**
+  * This class implements immutable sets using a list-based data structure. List set iterators and
+  * traversal methods visit elements in the order whey were first inserted.
+  *
+  * Elements are stored internally in reversed insertion order, which means the newest element is at
+  * the head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and
+  * `init` are O(1). Other operations, such as inserting or removing entries, are also O(n), which
+  * makes this collection suitable only for a small number of elements.
+  *
+  * Instances of `ListSet` represent empty sets; they can be either created by calling the
+  * constructor directly, or by applying the function `ListSet.empty`.
+  *
+  * @tparam A the type of the elements contained in this list set
+  *
+  * @author Matthias Zenger
+  * @version 1.0, 09/07/2003
+  * @since 1
+  * @define Coll ListSet
+  * @define coll list set
+  * @define mayNotTerminateInf
+  * @define willNotTerminateInf
+  */
+@SerialVersionUID(-8417059026623606218L)
+sealed class ListSet[A]
+  extends Set[A]
+    with SetLike[A, ListSet]
+    with Serializable {
+
+  override def size: Int = 0
+  override def isEmpty: Boolean = true
+
+  def contains(elem: A): Boolean = false
+
+  def + (elem: A): ListSet[A] = new Node(elem)
+  def - (elem: A): ListSet[A] = this
+
+  def ++ (xs: collection.Set[A]): ListSet[A] =
+    if (xs.isEmpty) this
+    else xs.foldLeft(this)(_ + _)
+
+
+  def iterator(): strawman.collection.Iterator[A] = {
+    def reverseList = {
+      var curr: ListSet[A] = this
+      var res: List[A] = Nil
+      while (!curr.isEmpty) {
+        res = curr.elem :: res
+        curr = curr.next
+      }
+      res
+    }
+    reverseList.iterator()
+  }
+
+  protected def elem: A = throw new NoSuchElementException("elem of empty set")
+  protected def next: ListSet[A] = throw new NoSuchElementException("next of empty set")
+
+  def toSet[B >: A]: Set[B] = this.asInstanceOf[ListSet[B]]
+
+  def fromIterableWithSameElemType(coll: collection.Iterable[A]): ListSet[A] = ListSet.fromIterable(coll)
+
+  def fromIterable[B](coll: collection.Iterable[B]): ListSet[B] = ListSet.fromIterable(coll)
+
+  /**
+    * Represents an entry in the `ListSet`.
+    */
+  @SerialVersionUID(-787710309854855049L)
+  protected class Node(override protected val elem: A) extends ListSet[A] with Serializable {
+
+    override def size = sizeInternal(this, 0)
+
+    @tailrec private[this] def sizeInternal(n: ListSet[A], acc: Int): Int =
+      if (n.isEmpty) acc
+      else sizeInternal(n.next, acc + 1)
+
+    override def isEmpty: Boolean = false
+
+    override def contains(e: A) = containsInternal(this, e)
+
+    @tailrec private[this] def containsInternal(n: ListSet[A], e: A): Boolean =
+      !n.isEmpty && (n.elem == e || containsInternal(n.next, e))
+
+    override def + (e: A): ListSet[A] = if (contains(e)) this else new Node(e)
+
+    override def - (e: A): ListSet[A] = removeInternal(e, this, Nil)
+
+    @tailrec private[this] def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
+      if (cur.isEmpty) acc.last
+      else if (k == cur.elem) acc.foldLeft(cur.next) { case (t, h) => new t.Node(h.elem) }
+      else removeInternal(k, cur.next, cur :: acc)
+
+    override protected def next: ListSet[A] = ListSet.this
+
+    override def last: A = elem
+
+    // TODO Override init for performance
+    // override def init: ListSet[A] = next
+  }
+}

--- a/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
+++ b/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
@@ -1,0 +1,548 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2005-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+package strawman
+package collection.immutable
+
+import collection.Iterator
+
+import scala.annotation.tailrec
+import scala.annotation.meta.getter
+
+import scala.{Array, Boolean, inline, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit}
+import java.lang.{Integer, String}
+
+/** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
+  *
+  *  Implementation note: since efficiency is important for data structures this implementation
+  *  uses `null` to represent empty trees. This also means pattern matching cannot
+  *  easily be used. The API represented by the RedBlackTree object tries to hide these
+  *  optimizations behind a reasonably clean API.
+  *
+  *  @since 2.10
+  */
+private[collection] object RedBlackTree {
+
+  def isEmpty(tree: Tree[_, _]): Boolean = tree eq null
+
+  def contains[A: Ordering](tree: Tree[A, _], x: A): Boolean = lookup(tree, x) ne null
+  def get[A: Ordering, B](tree: Tree[A, B], x: A): Option[B] = lookup(tree, x) match {
+    case null => None
+    case tree => Some(tree.value)
+  }
+
+  @tailrec
+  def lookup[A, B](tree: Tree[A, B], x: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
+    val cmp = ordering.compare(x, tree.key)
+    if (cmp < 0) lookup(tree.left, x)
+    else if (cmp > 0) lookup(tree.right, x)
+    else tree
+  }
+
+  def count(tree: Tree[_, _]) = if (tree eq null) 0 else tree.count
+  /**
+    * Count all the nodes with keys greater than or equal to the lower bound and less than the upper bound.
+    * The two bounds are optional.
+    */
+  def countInRange[A](tree: Tree[A, _], from: Option[A], to:Option[A])(implicit ordering: Ordering[A]) : Int =
+    if (tree eq null) 0 else
+      (from, to) match {
+        // with no bounds use this node's count
+        case (None, None) => tree.count
+        // if node is less than the lower bound, try the tree on the right, it might be in range
+        case (Some(lb), _) if ordering.lt(tree.key, lb) => countInRange(tree.right, from, to)
+        // if node is greater than or equal to the upper bound, try the tree on the left, it might be in range
+        case (_, Some(ub)) if ordering.gteq(tree.key, ub) => countInRange(tree.left, from, to)
+        // node is in range so the tree on the left will all be less than the upper bound and the tree on the
+        // right will all be greater than or equal to the lower bound. So 1 for this node plus
+        // count the subtrees by stripping off the bounds that we don't need any more
+        case _ => 1 + countInRange(tree.left, from, None) + countInRange(tree.right, None, to)
+
+      }
+  def update[A: Ordering, B, B1 >: B](tree: Tree[A, B], k: A, v: B1, overwrite: Boolean): Tree[A, B1] = blacken(upd(tree, k, v, overwrite))
+  def delete[A: Ordering, B](tree: Tree[A, B], k: A): Tree[A, B] = blacken(del(tree, k))
+  def rangeImpl[A: Ordering, B](tree: Tree[A, B], from: Option[A], until: Option[A]): Tree[A, B] = (from, until) match {
+    case (Some(from), Some(until)) => this.range(tree, from, until)
+    case (Some(from), None)        => this.from(tree, from)
+    case (None,       Some(until)) => this.until(tree, until)
+    case (None,       None)        => tree
+  }
+  def range[A: Ordering, B](tree: Tree[A, B], from: A, until: A): Tree[A, B] = blacken(doRange(tree, from, until))
+  def from[A: Ordering, B](tree: Tree[A, B], from: A): Tree[A, B] = blacken(doFrom(tree, from))
+  def to[A: Ordering, B](tree: Tree[A, B], to: A): Tree[A, B] = blacken(doTo(tree, to))
+  def until[A: Ordering, B](tree: Tree[A, B], key: A): Tree[A, B] = blacken(doUntil(tree, key))
+
+  def drop[A: Ordering, B](tree: Tree[A, B], n: Int): Tree[A, B] = blacken(doDrop(tree, n))
+  def take[A: Ordering, B](tree: Tree[A, B], n: Int): Tree[A, B] = blacken(doTake(tree, n))
+  def slice[A: Ordering, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] = blacken(doSlice(tree, from, until))
+
+  def smallest[A, B](tree: Tree[A, B]): Tree[A, B] = {
+    if (tree eq null) throw new NoSuchElementException("empty map")
+    var result = tree
+    while (result.left ne null) result = result.left
+    result
+  }
+  def greatest[A, B](tree: Tree[A, B]): Tree[A, B] = {
+    if (tree eq null) throw new NoSuchElementException("empty map")
+    var result = tree
+    while (result.right ne null) result = result.right
+    result
+  }
+
+
+  def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
+
+  private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
+    if (tree.left ne null) _foreach(tree.left, f)
+    f((tree.key, tree.value))
+    if (tree.right ne null) _foreach(tree.right, f)
+  }
+
+  def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)
+
+  private[this] def _foreachKey[A, U](tree: Tree[A, _], f: A => U) {
+    if (tree.left ne null) _foreachKey(tree.left, f)
+    f((tree.key))
+    if (tree.right ne null) _foreachKey(tree.right, f)
+  }
+
+  def iterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[(A, B)] = new EntriesIterator(tree, start)
+  def keysIterator[A: Ordering](tree: Tree[A, _], start: Option[A] = None): Iterator[A] = new KeysIterator(tree, start)
+  def valuesIterator[A: Ordering, B](tree: Tree[A, B], start: Option[A] = None): Iterator[B] = new ValuesIterator(tree, start)
+
+  @tailrec
+  def nth[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
+    val count = this.count(tree.left)
+    if (n < count) nth(tree.left, n)
+    else if (n > count) nth(tree.right, n - count - 1)
+    else tree
+  }
+
+  def isBlack(tree: Tree[_, _]) = (tree eq null) || isBlackTree(tree)
+
+  private[this] def isRedTree(tree: Tree[_, _]) = tree.isInstanceOf[RedTree[_, _]]
+  private[this] def isBlackTree(tree: Tree[_, _]) = tree.isInstanceOf[BlackTree[_, _]]
+
+  private[this] def blacken[A, B](t: Tree[A, B]): Tree[A, B] = if (t eq null) null else t.black
+
+  private[this] def mkTree[A, B](isBlack: Boolean, k: A, v: B, l: Tree[A, B], r: Tree[A, B]) =
+    if (isBlack) BlackTree(k, v, l, r) else RedTree(k, v, l, r)
+
+  private[this] def balanceLeft[A, B, B1 >: B](isBlack: Boolean, z: A, zv: B, l: Tree[A, B1], d: Tree[A, B1]): Tree[A, B1] = {
+    if (isRedTree(l) && isRedTree(l.left))
+      RedTree(l.key, l.value, BlackTree(l.left.key, l.left.value, l.left.left, l.left.right), BlackTree(z, zv, l.right, d))
+    else if (isRedTree(l) && isRedTree(l.right))
+      RedTree(l.right.key, l.right.value, BlackTree(l.key, l.value, l.left, l.right.left), BlackTree(z, zv, l.right.right, d))
+    else
+      mkTree(isBlack, z, zv, l, d)
+  }
+  private[this] def balanceRight[A, B, B1 >: B](isBlack: Boolean, x: A, xv: B, a: Tree[A, B1], r: Tree[A, B1]): Tree[A, B1] = {
+    if (isRedTree(r) && isRedTree(r.left))
+      RedTree(r.left.key, r.left.value, BlackTree(x, xv, a, r.left.left), BlackTree(r.key, r.value, r.left.right, r.right))
+    else if (isRedTree(r) && isRedTree(r.right))
+      RedTree(r.key, r.value, BlackTree(x, xv, a, r.left), BlackTree(r.right.key, r.right.value, r.right.left, r.right.right))
+    else
+      mkTree(isBlack, x, xv, a, r)
+  }
+  private[this] def upd[A, B, B1 >: B](tree: Tree[A, B], k: A, v: B1, overwrite: Boolean)(implicit ordering: Ordering[A]): Tree[A, B1] = if (tree eq null) {
+    RedTree(k, v, null, null)
+  } else {
+    val cmp = ordering.compare(k, tree.key)
+    if (cmp < 0) balanceLeft(isBlackTree(tree), tree.key, tree.value, upd(tree.left, k, v, overwrite), tree.right)
+    else if (cmp > 0) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, upd(tree.right, k, v, overwrite))
+    else if (overwrite || k != tree.key) mkTree(isBlackTree(tree), k, v, tree.left, tree.right)
+    else tree
+  }
+  private[this] def updNth[A, B, B1 >: B](tree: Tree[A, B], idx: Int, k: A, v: B1, overwrite: Boolean): Tree[A, B1] = if (tree eq null) {
+    RedTree(k, v, null, null)
+  } else {
+    val rank = count(tree.left) + 1
+    if (idx < rank) balanceLeft(isBlackTree(tree), tree.key, tree.value, updNth(tree.left, idx, k, v, overwrite), tree.right)
+    else if (idx > rank) balanceRight(isBlackTree(tree), tree.key, tree.value, tree.left, updNth(tree.right, idx - rank, k, v, overwrite))
+    else if (overwrite) mkTree(isBlackTree(tree), k, v, tree.left, tree.right)
+    else tree
+  }
+
+  /* Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
+   * Constructing Red-Black Trees, Ralf Hinze: http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz
+   * Red-Black Trees in a Functional Setting, Chris Okasaki: https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf */
+  private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
+    def balance(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
+      if (isRedTree(tr)) {
+        RedTree(x, xv, tl.black, tr.black)
+      } else if (isRedTree(tl.left)) {
+        RedTree(tl.key, tl.value, tl.left.black, BlackTree(x, xv, tl.right, tr))
+      } else if (isRedTree(tl.right)) {
+        RedTree(tl.right.key, tl.right.value, BlackTree(tl.key, tl.value, tl.left, tl.right.left), BlackTree(x, xv, tl.right.right, tr))
+      } else {
+        BlackTree(x, xv, tl, tr)
+      }
+    } else if (isRedTree(tr)) {
+      if (isRedTree(tr.right)) {
+        RedTree(tr.key, tr.value, BlackTree(x, xv, tl, tr.left), tr.right.black)
+      } else if (isRedTree(tr.left)) {
+        RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), BlackTree(tr.key, tr.value, tr.left.right, tr.right))
+      } else {
+        BlackTree(x, xv, tl, tr)
+      }
+    } else {
+      BlackTree(x, xv, tl, tr)
+    }
+    def subl(t: Tree[A, B]) =
+      if (t.isInstanceOf[BlackTree[_, _]]) t.red
+      else sys.error("Defect: invariance violation; expected black, got "+t)
+
+    def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
+      RedTree(x, xv, tl.black, tr)
+    } else if (isBlackTree(tr)) {
+      balance(x, xv, tl, tr.red)
+    } else if (isRedTree(tr) && isBlackTree(tr.left)) {
+      RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
+    } else {
+      sys.error("Defect: invariance violation")
+    }
+    def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
+      RedTree(x, xv, tl, tr.black)
+    } else if (isBlackTree(tl)) {
+      balance(x, xv, tl.red, tr)
+    } else if (isRedTree(tl) && isBlackTree(tl.right)) {
+      RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
+    } else {
+      sys.error("Defect: invariance violation")
+    }
+    def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
+    def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
+    def append(tl: Tree[A, B], tr: Tree[A, B]): Tree[A, B] = if (tl eq null) {
+      tr
+    } else if (tr eq null) {
+      tl
+    } else if (isRedTree(tl) && isRedTree(tr)) {
+      val bc = append(tl.right, tr.left)
+      if (isRedTree(bc)) {
+        RedTree(bc.key, bc.value, RedTree(tl.key, tl.value, tl.left, bc.left), RedTree(tr.key, tr.value, bc.right, tr.right))
+      } else {
+        RedTree(tl.key, tl.value, tl.left, RedTree(tr.key, tr.value, bc, tr.right))
+      }
+    } else if (isBlackTree(tl) && isBlackTree(tr)) {
+      val bc = append(tl.right, tr.left)
+      if (isRedTree(bc)) {
+        RedTree(bc.key, bc.value, BlackTree(tl.key, tl.value, tl.left, bc.left), BlackTree(tr.key, tr.value, bc.right, tr.right))
+      } else {
+        balLeft(tl.key, tl.value, tl.left, BlackTree(tr.key, tr.value, bc, tr.right))
+      }
+    } else if (isRedTree(tr)) {
+      RedTree(tr.key, tr.value, append(tl, tr.left), tr.right)
+    } else if (isRedTree(tl)) {
+      RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
+    } else {
+      sys.error("unmatched tree on append: " + tl + ", " + tr)
+    }
+
+    val cmp = ordering.compare(k, tree.key)
+    if (cmp < 0) delLeft
+    else if (cmp > 0) delRight
+    else append(tree.left, tree.right)
+  }
+
+  private[this] def doFrom[A, B](tree: Tree[A, B], from: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
+    if (tree eq null) return null
+    if (ordering.lt(tree.key, from)) return doFrom(tree.right, from)
+    val newLeft = doFrom(tree.left, from)
+    if (newLeft eq tree.left) tree
+    else if (newLeft eq null) upd(tree.right, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, newLeft, tree.right)
+  }
+  private[this] def doTo[A, B](tree: Tree[A, B], to: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
+    if (tree eq null) return null
+    if (ordering.lt(to, tree.key)) return doTo(tree.left, to)
+    val newRight = doTo(tree.right, to)
+    if (newRight eq tree.right) tree
+    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, tree.left, newRight)
+  }
+  private[this] def doUntil[A, B](tree: Tree[A, B], until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
+    if (tree eq null) return null
+    if (ordering.lteq(until, tree.key)) return doUntil(tree.left, until)
+    val newRight = doUntil(tree.right, until)
+    if (newRight eq tree.right) tree
+    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, tree.left, newRight)
+  }
+  private[this] def doRange[A, B](tree: Tree[A, B], from: A, until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
+    if (tree eq null) return null
+    if (ordering.lt(tree.key, from)) return doRange(tree.right, from, until)
+    if (ordering.lteq(until, tree.key)) return doRange(tree.left, from, until)
+    val newLeft = doFrom(tree.left, from)
+    val newRight = doUntil(tree.right, until)
+    if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
+    else if (newLeft eq null) upd(newRight, tree.key, tree.value, overwrite = false)
+    else if (newRight eq null) upd(newLeft, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, newLeft, newRight)
+  }
+
+  private[this] def doDrop[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
+    if (n <= 0) return tree
+    if (n >= this.count(tree)) return null
+    val count = this.count(tree.left)
+    if (n > count) return doDrop(tree.right, n - count - 1)
+    val newLeft = doDrop(tree.left, n)
+    if (newLeft eq tree.left) tree
+    else if (newLeft eq null) updNth(tree.right, n - count - 1, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, newLeft, tree.right)
+  }
+  private[this] def doTake[A, B](tree: Tree[A, B], n: Int): Tree[A, B] = {
+    if (n <= 0) return null
+    if (n >= this.count(tree)) return tree
+    val count = this.count(tree.left)
+    if (n <= count) return doTake(tree.left, n)
+    val newRight = doTake(tree.right, n - count - 1)
+    if (newRight eq tree.right) tree
+    else if (newRight eq null) updNth(tree.left, n, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, tree.left, newRight)
+  }
+  private[this] def doSlice[A, B](tree: Tree[A, B], from: Int, until: Int): Tree[A, B] = {
+    if (tree eq null) return null
+    val count = this.count(tree.left)
+    if (from > count) return doSlice(tree.right, from - count - 1, until - count - 1)
+    if (until <= count) return doSlice(tree.left, from, until)
+    val newLeft = doDrop(tree.left, from)
+    val newRight = doTake(tree.right, until - count - 1)
+    if ((newLeft eq tree.left) && (newRight eq tree.right)) tree
+    else if (newLeft eq null) updNth(newRight, from - count - 1, tree.key, tree.value, overwrite = false)
+    else if (newRight eq null) updNth(newLeft, until, tree.key, tree.value, overwrite = false)
+    else rebalance(tree, newLeft, newRight)
+  }
+
+  // The zipper returned might have been traversed left-most (always the left child)
+  // or right-most (always the right child). Left trees are traversed right-most,
+  // and right trees are traversed leftmost.
+
+  // Returns the zipper for the side with deepest black nodes depth, a flag
+  // indicating whether the trees were unbalanced at all, and a flag indicating
+  // whether the zipper was traversed left-most or right-most.
+
+  // If the trees were balanced, returns an empty zipper
+  private[this] def compareDepth[A, B](left: Tree[A, B], right: Tree[A, B]): (NList[Tree[A, B]], Boolean, Boolean, Int) = {
+    import NList.cons
+    // Once a side is found to be deeper, unzip it to the bottom
+    def unzip(zipper: NList[Tree[A, B]], leftMost: Boolean): NList[Tree[A, B]] = {
+      val next = if (leftMost) zipper.head.left else zipper.head.right
+      if (next eq null) zipper
+      else unzip(cons(next, zipper), leftMost)
+    }
+
+    // Unzip left tree on the rightmost side and right tree on the leftmost side until one is
+    // found to be deeper, or the bottom is reached
+    def unzipBoth(left: Tree[A, B],
+      right: Tree[A, B],
+      leftZipper: NList[Tree[A, B]],
+      rightZipper: NList[Tree[A, B]],
+      smallerDepth: Int): (NList[Tree[A, B]], Boolean, Boolean, Int) = {
+      if (isBlackTree(left) && isBlackTree(right)) {
+        unzipBoth(left.right, right.left, cons(left, leftZipper), cons(right, rightZipper), smallerDepth + 1)
+      } else if (isRedTree(left) && isRedTree(right)) {
+        unzipBoth(left.right, right.left, cons(left, leftZipper), cons(right, rightZipper), smallerDepth)
+      } else if (isRedTree(right)) {
+        unzipBoth(left, right.left, leftZipper, cons(right, rightZipper), smallerDepth)
+      } else if (isRedTree(left)) {
+        unzipBoth(left.right, right, cons(left, leftZipper), rightZipper, smallerDepth)
+      } else if ((left eq null) && (right eq null)) {
+        (null, true, false, smallerDepth)
+      } else if ((left eq null) && isBlackTree(right)) {
+        val leftMost = true
+        (unzip(cons(right, rightZipper), leftMost), false, leftMost, smallerDepth)
+      } else if (isBlackTree(left) && (right eq null)) {
+        val leftMost = false
+        (unzip(cons(left, leftZipper), leftMost), false, leftMost, smallerDepth)
+      } else {
+        sys.error("unmatched trees in unzip: " + left + ", " + right)
+      }
+    }
+    unzipBoth(left, right, null, null, 0)
+  }
+
+  private[this] def rebalance[A, B](tree: Tree[A, B], newLeft: Tree[A, B], newRight: Tree[A, B]) = {
+    // This is like drop(n-1), but only counting black nodes
+    @tailrec
+    def  findDepth(zipper: NList[Tree[A, B]], depth: Int): NList[Tree[A, B]] =
+    if (zipper eq null) {
+      sys.error("Defect: unexpected empty zipper while computing range")
+    } else if (isBlackTree(zipper.head)) {
+      if (depth == 1) zipper else findDepth(zipper.tail, depth - 1)
+    } else {
+      findDepth(zipper.tail, depth)
+    }
+
+    // Blackening the smaller tree avoids balancing problems on union;
+    // this can't be done later, though, or it would change the result of compareDepth
+    val blkNewLeft = blacken(newLeft)
+    val blkNewRight = blacken(newRight)
+    val (zipper, levelled, leftMost, smallerDepth) = compareDepth(blkNewLeft, blkNewRight)
+
+    if (levelled) {
+      BlackTree(tree.key, tree.value, blkNewLeft, blkNewRight)
+    } else {
+      val zipFrom = findDepth(zipper, smallerDepth)
+      val union = if (leftMost) {
+        RedTree(tree.key, tree.value, blkNewLeft, zipFrom.head)
+      } else {
+        RedTree(tree.key, tree.value, zipFrom.head, blkNewRight)
+      }
+      val zippedTree = NList.foldLeft(zipFrom.tail, union: Tree[A, B]) { (tree, node) =>
+        if (leftMost)
+          balanceLeft(isBlackTree(node), node.key, node.value, tree, node.right)
+        else
+          balanceRight(isBlackTree(node), node.key, node.value, node.left, tree)
+      }
+      zippedTree
+    }
+  }
+
+  // Null optimized list implementation for tree rebalancing. null presents Nil.
+  private[this] final class NList[A](val head: A, val tail: NList[A])
+
+  private[this] final object NList {
+
+    def cons[B](x: B, xs: NList[B]): NList[B] = new NList(x, xs)
+
+    def foldLeft[A, B](xs: NList[A], z: B)(op: (B, A) => B): B = {
+      var acc = z
+      var these = xs
+      while (these ne null) {
+        acc = op(acc, these.head)
+        these = these.tail
+      }
+      acc
+    }
+
+  }
+
+  /*
+   * Forcing direct fields access using the @inline annotation helps speed up
+   * various operations (especially smallest/greatest and update/delete).
+   *
+   * Unfortunately the direct field access is not guaranteed to work (but
+   * works on the current implementation of the Scala compiler).
+   *
+   * An alternative is to implement the these classes using plain old Java code...
+   */
+  sealed abstract class Tree[A, +B](
+    @(inline @getter) final val key: A,
+    @(inline @getter) final val value: B,
+    @(inline @getter) final val left: Tree[A, B],
+    @(inline @getter) final val right: Tree[A, B])
+    extends Serializable {
+    @(inline @getter) final val count: Int = 1 + RedBlackTree.count(left) + RedBlackTree.count(right)
+    def black: Tree[A, B]
+    def red: Tree[A, B]
+  }
+  final class RedTree[A, +B](key: A,
+    value: B,
+    left: Tree[A, B],
+    right: Tree[A, B]) extends Tree[A, B](key, value, left, right) {
+    override def black: Tree[A, B] = BlackTree(key, value, left, right)
+    override def red: Tree[A, B] = this
+    override def toString: String = "RedTree(" + key + ", " + value + ", " + left + ", " + right + ")"
+  }
+  final class BlackTree[A, +B](key: A,
+    value: B,
+    left: Tree[A, B],
+    right: Tree[A, B]) extends Tree[A, B](key, value, left, right) {
+    override def black: Tree[A, B] = this
+    override def red: Tree[A, B] = RedTree(key, value, left, right)
+    override def toString: String = "BlackTree(" + key + ", " + value + ", " + left + ", " + right + ")"
+  }
+
+  object RedTree {
+    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
+    def unapply[A, B](t: RedTree[A, B]) = Some((t.key, t.value, t.left, t.right))
+  }
+  object BlackTree {
+    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
+    def unapply[A, B](t: BlackTree[A, B]) = Some((t.key, t.value, t.left, t.right))
+  }
+
+  private[this] abstract class TreeIterator[A, B, R](root: Tree[A, B], start: Option[A])(implicit ordering: Ordering[A]) extends Iterator[R] {
+    protected[this] def nextResult(tree: Tree[A, B]): R
+
+    override def hasNext: Boolean = lookahead ne null
+
+    override def next: R = lookahead match {
+      case null =>
+        throw new NoSuchElementException("next on empty iterator")
+      case tree =>
+        lookahead = findLeftMostOrPopOnEmpty(goRight(tree))
+        nextResult(tree)
+    }
+
+    @tailrec
+    private[this] def findLeftMostOrPopOnEmpty(tree: Tree[A, B]): Tree[A, B] =
+      if (tree eq null) popNext()
+      else if (tree.left eq null) tree
+      else findLeftMostOrPopOnEmpty(goLeft(tree))
+
+    private[this] def pushNext(tree: Tree[A, B]) {
+      stackOfNexts(index) = tree
+      index += 1
+    }
+    private[this] def popNext(): Tree[A, B] = if (index == 0) null else {
+      index -= 1
+      stackOfNexts(index)
+    }
+
+    private[this] var stackOfNexts = if (root eq null) null else {
+      /*
+       * According to "Ralf Hinze. Constructing red-black trees" [http://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+       * the maximum height of a red-black tree is 2*log_2(n + 2) - 2.
+       *
+       * According to {@see Integer#numberOfLeadingZeros} ceil(log_2(n)) = (32 - Integer.numberOfLeadingZeros(n - 1))
+       *
+       * Although we don't store the deepest nodes in the path during iteration,
+       * we potentially do so in `startFrom`.
+       */
+      val maximumHeight = 2 * (32 - Integer.numberOfLeadingZeros(root.count + 2 - 1)) - 2
+      new Array[Tree[A, B]](maximumHeight)
+    }
+    private[this] var index = 0
+    private[this] var lookahead: Tree[A, B] = start map startFrom getOrElse findLeftMostOrPopOnEmpty(root)
+
+    /**
+      * Find the leftmost subtree whose key is equal to the given key, or if no such thing,
+      * the leftmost subtree with the key that would be "next" after it according
+      * to the ordering. Along the way build up the iterator's path stack so that "next"
+      * functionality works.
+      */
+    private[this] def startFrom(key: A) : Tree[A,B] = if (root eq null) null else {
+      @tailrec def find(tree: Tree[A, B]): Tree[A, B] =
+        if (tree eq null) popNext()
+        else find(
+          if (ordering.lteq(key, tree.key)) goLeft(tree)
+          else goRight(tree)
+        )
+      find(root)
+    }
+
+    private[this] def goLeft(tree: Tree[A, B]) = {
+      pushNext(tree)
+      tree.left
+    }
+
+    private[this] def goRight(tree: Tree[A, B]) = tree.right
+  }
+
+  private[this] class EntriesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, (A, B)](tree, focus) {
+    override def nextResult(tree: Tree[A, B]) = (tree.key, tree.value)
+  }
+
+  private[this] class KeysIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, A](tree, focus) {
+    override def nextResult(tree: Tree[A, B]) = tree.key
+  }
+
+  private[this] class ValuesIterator[A: Ordering, B](tree: Tree[A, B], focus: Option[A]) extends TreeIterator[A, B, B](tree, focus) {
+    override def nextResult(tree: Tree[A, B]) = tree.value
+  }
+}

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -8,9 +8,10 @@ trait Set[A]
     with SetLike[A, Set]
 
 /** Base trait for immutable set operations */
-trait SetLike[A, +C[X] <: Set[X]]
+trait SetLike[A, +C[X] <: Set[X] with SetLike[X, C]]
   extends collection.SetLike[A, C]
     with SetMonoTransforms[A, C[A]]
+    with SetPolyTransforms[A, C]
 
 /** Transformation operations returning a Set containing the same kind of
   * elements
@@ -21,5 +22,16 @@ trait SetMonoTransforms[A, +Repr]
   def + (elem: A): Repr
 
   def - (elem: A): Repr
+
+}
+
+trait SetPolyTransforms[A, +C[X] <: Set[X] with SetLike[X, C]]
+  extends collection.SetPolyTransforms[A, C] {
+
+  protected def coll: C[A]
+
+  def ++ (that: collection.Set[A]): C[A] =
+    if (that.isEmpty) coll
+    else that.foldLeft[C[A]](coll)(_ + _)
 
 }

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -1,6 +1,11 @@
 package strawman
 package collection.immutable
 
+import strawman.collection.mutable.Builder
+import strawman.collection.IterableFactory
+
+import scala.Any
+
 /** Base trait for immutable set collections */
 trait Set[A]
   extends collection.Set[A]
@@ -37,4 +42,10 @@ trait SetPolyTransforms[A, +C[X] <: Set[X] with SetLike[X, C]]
     result
   }
 
+}
+
+object Set extends IterableFactory[Set] {
+  def empty[A <: Any]: Set[A] = HashSet.empty
+  def newBuilder[A <: Any]: Builder[A, Set[A]] = HashSet.newBuilder
+  def fromIterable[E](it: strawman.collection.Iterable[E]): Set[E] = HashSet.fromIterable(it)
 }

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -30,8 +30,11 @@ trait SetPolyTransforms[A, +C[X] <: Set[X] with SetLike[X, C]]
 
   protected def coll: C[A]
 
-  def ++ (that: collection.Set[A]): C[A] =
-    if (that.isEmpty) coll
-    else that.foldLeft[C[A]](coll)(_ + _)
+  def ++ (that: collection.Set[A]): C[A] = {
+    var result: C[A] = coll
+    val it = that.iterator()
+    while (it.hasNext) result = result + it.next()
+    result
+  }
 
 }

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -16,7 +16,13 @@ trait SortedMapLike[K, +V, +C[X, +Y] <: SortedMap[X, Y]]
   extends SortedLike[K, C[K, V]]
     with SortedMapPolyTransforms[K, V, C]
     with MapLike[K, V, Map] // Inherited Map operations can only return a `Map` because they don’t take an evidence `Ordering`
-    with MapMonoTransforms[K, V, C[K, V]] // Operations that return the same collection type can return a `SortedMap`, though
+    with MapMonoTransforms[K, V, C[K, V]] { // Operations that return the same collection type can return a `SortedMap`, though
+
+  def firstKey: K = head._1
+
+  def lastKey: K = last._1
+
+}
 
 /** Polymorphic transformation methods for sorted Maps */
 trait SortedMapPolyTransforms[K, +V, +C[X, Y] <: Sorted[X]]

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -44,4 +44,6 @@ object TreeMap extends ConstrainedMapFactory[TreeMap, Ordering] {
 
   def constrainedNewBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] = ???
 
+  def empty[K: Ordering, V]: TreeMap[K, V] = ???
+
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -1,52 +1,118 @@
-package strawman.collection.immutable
+package strawman
+package collection.immutable
 
-import strawman.collection.mutable.Builder
-import strawman.collection.{ConstrainedIterableFactory, ConstrainedPolyBuildable, Iterator}
+import collection.mutable.{Builder, ImmutableSetBuilder}
+import collection.{ConstrainedIterableFactory, ConstrainedPolyBuildable, Iterator}
+import collection.immutable.{RedBlackTree => RB}
 
-import scala.{Boolean, Ordering}
-import scala.Predef.???
+import scala.{Boolean, Int, NullPointerException, Ordering, Unit}
 
-/** Immutable sorted set backed by a tree */
-final class TreeSet[A]()(implicit val ordering: Ordering[A])
+/** This class implements immutable sorted sets using a tree.
+  *
+  *  @tparam A         the type of the elements contained in this tree set
+  *  @param ordering   the implicit ordering used to compare objects of type `A`
+  *
+  *  @author  Martin Odersky
+  *  @version 2.0, 02/01/2007
+  *  @since   1
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#redblack_trees "Scala's Collection Library overview"]]
+  *  section on `Red-Black Trees` for more information.
+  *
+  *  @define Coll `immutable.TreeSet`
+  *  @define coll immutable tree set
+  *  @define orderDependent
+  *  @define orderDependentFold
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetLike[A, TreeSet]
     with ConstrainedPolyBuildable[A, TreeSet, Ordering] {
 
-  // From IterableOnce
-  def iterator(): Iterator[A] = ???
+  if (ordering eq null) throw new NullPointerException("ordering must not be null")
 
-  // From FromIterable
-  def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = ???
+  def this()(implicit ordering: Ordering[A]) = this(null)(ordering)
 
-  // From IterableMonoTransforms
+  private def newSet(t: RB.Tree[A, Unit]) = new TreeSet[A](t)
+
+  override def size: Int = RB.count(tree)
+
+  override def head: A = RB.smallest(tree).key
+
+  override def last: A = RB.greatest(tree).key
+
+  override def tail: TreeSet[A] = new TreeSet(RB.delete(tree, firstKey))
+
+  override def drop(n: Int): TreeSet[A] = {
+    if (n <= 0) this
+    else if (n >= size) empty
+    else newSet(RB.drop(tree, n))
+  }
+
+  override def take(n: Int): TreeSet[A] = {
+    if (n <= 0) empty
+    else if (n >= size) this
+    else newSet(RB.take(tree, n))
+  }
+
+  override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
+
+  def iterator(): Iterator[A] = RB.keysIterator(tree)
+
+  def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
+
   protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.constrainedNewBuilder[A].++=(coll).result
+    TreeSet.constrainedFromIterable(coll)
 
-  // From ConstrainedFromIterable
   def constrainedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.constrainedNewBuilder[B].++=(coll).result
+    TreeSet.constrainedFromIterable(coll)
+
   def unconstrained: Set[A] = this
 
-  // From ConstrainedPolyBuildable
-  def newConstrainedBuilder[E : Ordering] = TreeSet.constrainedNewBuilder
+  /** Checks if this set contains element `elem`.
+    *
+    *  @param  elem    the element to check for membership.
+    *  @return true, iff `elem` is contained in this set.
+    */
+  def contains(elem: A): Boolean = RB.contains(tree, elem)
 
-  // From PolyBuildable
-  def newBuilder[E]: Builder[E, Set[E]] = ???
+  /** A factory to create empty sets of the same type of keys.
+    */
+  def empty: TreeSet[A] = TreeSet.empty
 
-  // From SetLike
-  def contains(elem: A): Boolean = ???
+  def range(from: A, until: A): TreeSet[A] = newSet(RB.range(tree, from, until))
 
-  // From immutable.SetMonoTransforms
-  def +(elem: A): TreeSet[A] = ???
-  def -(elem: A): TreeSet[A] = ???
+  /** Creates a new `TreeSet` with the entry added.
+    *
+    *  @param elem    a new element to add.
+    *  @return        a new $coll containing `elem` and all the elements of this $coll.
+    */
+  def + (elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
 
-  // From SortedLike
-  def range(from: A, until: A): TreeSet[A] = ???
+  /** Creates a new `TreeSet` with the entry removed.
+    *
+    *  @param elem    a new element to add.
+    *  @return        a new $coll containing all the elements of this $coll except `elem`.
+    */
+  def - (elem: A): TreeSet[A] =
+    if (!RB.contains(tree, elem)) this
+    else newSet(RB.delete(tree, elem))
+
+  def newConstrainedBuilder[E: Ordering]: Builder[E, TreeSet[E]] = TreeSet.constrainedNewBuilder[E]
+
 }
 
 object TreeSet extends ConstrainedIterableFactory[TreeSet, Ordering] {
 
-  def constrainedFromIterable[E : Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] = ???
+  def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
-  def constrainedNewBuilder[A : Ordering]: Builder[A, TreeSet[A]] = ???
+  def constrainedNewBuilder[A : Ordering]: Builder[A, TreeSet[A]] = new ImmutableSetBuilder[A, TreeSet](empty[A])
+
+  def constrainedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
+    it match {
+      case ts: TreeSet[E] => ts
+      case _ => constrainedNewBuilder[E].++=(it).result
+    }
+
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -36,9 +36,6 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
   // From SetLike
   def contains(elem: A): Boolean = ???
 
-  // From SetMonoTransforms
-  def ++ (that: strawman.collection.Set[A]): TreeSet[A] = ???
-
   // From immutable.SetMonoTransforms
   def +(elem: A): TreeSet[A] = ???
   def -(elem: A): TreeSet[A] = ???

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -35,10 +35,8 @@ final class TreeSet[A]()(implicit val ordering: Ordering[A])
 
   // From SetLike
   def contains(elem: A): Boolean = ???
-  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
 
   // From SetMonoTransforms
-  def & (that: strawman.collection.Set[A]): TreeSet[A] = ???
   def ++ (that: strawman.collection.Set[A]): TreeSet[A] = ???
 
   // From immutable.SetMonoTransforms

--- a/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -1,0 +1,216 @@
+package strawman
+
+package collection.immutable
+
+//import HashMap.{ HashTrieMap, HashMapCollision1, HashMap1 }
+import HashSet.{HashSet1, HashSetCollision1, HashTrieSet}
+import collection.Iterator
+import strawman.collection.mutable.ArrayBuffer
+
+import scala.annotation.unchecked.{uncheckedVariance => uV}
+import scala.annotation.tailrec
+import scala.{AnyRef, Array, Boolean, Int}
+import scala.Predef.intWrapper
+
+/** Abandons any pretense of type safety for speed.  You can't say I
+ *  didn't try: see r23934.
+ */
+private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) extends collection.Iterator[T] {
+  outer =>
+
+  private[immutable] def getElem(x: AnyRef): T
+
+  def initDepth                                     = 0
+  def initArrayStack: Array[Array[Iterable[T @uV]]] = new Array[Array[Iterable[T]]](6)
+  def initPosStack                                  = new Array[Int](6)
+  def initArrayD: Array[Iterable[T @uV]]            = elems
+  def initPosD                                      = 0
+  def initSubIter: Iterator[T]                      = null // to traverse collision nodes
+
+  private[this] var depth                                     = initDepth
+  private[this] var arrayStack: Array[Array[Iterable[T @uV]]] = initArrayStack
+  private[this] var posStack                                  = initPosStack
+  private[this] var arrayD: Array[Iterable[T @uV]]            = initArrayD
+  private[this] var posD                                      = initPosD
+  private[this] var subIter                                   = initSubIter
+
+  private[this] def getElems(x: Iterable[T]): Array[Iterable[T]] = (x match {
+//    case x: HashTrieMap[_, _] => x.elems
+    case x: HashTrieSet[_]    => x.elems
+  }).asInstanceOf[Array[Iterable[T]]]
+
+  private[this] def collisionToArray(x: Iterable[T]): Array[Iterable[T]] = (x match {
+//    case x: HashMapCollision1[_, _] => x.kvs.map(x => HashMap(x)).toArray
+    case x: HashSetCollision1[_]    => x.ks.map(x => HashSet(x)).toArray
+  }).asInstanceOf[Array[Iterable[T]]]
+
+  private[this] type SplitIterators = ((Iterator[T], Int), Iterator[T])
+
+  private def isTrie(x: AnyRef) = x match {
+//    case _: HashTrieMap[_,_] | _: HashTrieSet[_] => true
+    case _                                       => false
+  }
+  private def isContainer(x: AnyRef) = x match {
+//    case _: HashMap1[_, _] | _: HashSet1[_] => true
+    case _                                  => false
+  }
+
+  final class DupIterator(xs: Array[Iterable[T]]) extends {
+    override val initDepth                                     = outer.depth
+    override val initArrayStack: Array[Array[Iterable[T @uV]]] = outer.arrayStack
+    override val initPosStack                                  = outer.posStack
+    override val initArrayD: Array[Iterable[T @uV]]            = outer.arrayD
+    override val initPosD                                      = outer.posD
+    override val initSubIter                                   = outer.subIter
+  } with TrieIterator[T](xs) {
+    final override def getElem(x: AnyRef): T = outer.getElem(x)
+  }
+
+  def dupIterator: TrieIterator[T] = new DupIterator(elems)
+
+  private[this] def newIterator(xs: Array[Iterable[T]]) = new TrieIterator(xs) {
+    final override def getElem(x: AnyRef): T = outer.getElem(x)
+  }
+
+  private[this] def iteratorWithSize(arr: Array[Iterable[T]]): (Iterator[T], Int) =
+    (newIterator(arr), (arr.map(_.size): strawman.collection.IterableOps[Int]).sum)
+
+  private[this] def arrayToIterators(arr: Array[Iterable[T]]): SplitIterators = {
+    val (fst, snd) = arr.splitAt(arr.length / 2)
+
+    (iteratorWithSize(snd), newIterator(fst))
+  }
+  private[this] def splitArray(ad: Array[Iterable[T]]): SplitIterators =
+    if (ad.length > 1) arrayToIterators(ad)
+    else ad(0) match {
+      case /*_: HashMapCollision1[_, _] |*/ _: HashSetCollision1[_] =>
+        arrayToIterators(collisionToArray(ad(0)))
+      case _ =>
+        splitArray(getElems(ad(0)))
+    }
+
+  def hasNext = (subIter ne null) || depth >= 0
+  def next(): T = {
+    if (subIter ne null) {
+      val el = subIter.next()
+      if (!subIter.hasNext)
+        subIter = null
+      el
+    } else
+      next0(arrayD, posD)
+  }
+
+  @tailrec private[this] def next0(elems: Array[Iterable[T]], i: Int): T = {
+    if (i == elems.length-1) { // reached end of level, pop stack
+      depth -= 1
+      if (depth >= 0) {
+        arrayD = arrayStack(depth)
+        posD = posStack(depth)
+        arrayStack(depth) = null
+      } else {
+        arrayD = null
+        posD = 0
+      }
+    } else
+      posD += 1
+
+    val m = elems(i)
+
+    // Note: this block is over twice as fast written this way as it is
+    // as a pattern match.  Haven't started looking into why that is, but
+    // it's pretty sad the pattern matcher is that much slower.
+    if (isContainer(m))
+      getElem(m) // push current pos onto stack and descend
+    else if (isTrie(m)) {
+      if (depth >= 0) {
+        arrayStack(depth) = arrayD
+        posStack(depth) = posD
+      }
+      depth += 1
+      arrayD = getElems(m)
+      posD = 0
+      next0(getElems(m), 0)
+    }
+    else {
+      subIter = m.iterator
+      next()
+    }
+    // The much slower version:
+    //
+    // m match {
+    //   case _: HashMap1[_, _] | _: HashSet1[_] =>
+    //     getElem(m) // push current pos onto stack and descend
+    //   case _: HashTrieMap[_,_] | _: HashTrieSet[_] =>
+    //     if (depth >= 0) {
+    //       arrayStack(depth) = arrayD
+    //       posStack(depth) = posD
+    //     }
+    //     depth += 1
+    //     arrayD = getElems(m)
+    //     posD = 0
+    //     next0(getElems(m), 0)
+    //   case _ =>
+    //     subIter = m.iterator
+    //     next
+    // }
+  }
+
+  // assumption: contains 2 or more elements
+  // splits this iterator into 2 iterators
+  // returns the 1st iterator, its number of elements, and the second iterator
+  def split: SplitIterators = {
+    // 0) simple case: no elements have been iterated - simply divide arrayD
+    if (arrayD != null && depth == 0 && posD == 0)
+      return splitArray(arrayD)
+
+    // otherwise, some elements have been iterated over
+    // 1) collision case: if we have a subIter, we return subIter and elements after it
+    if (subIter ne null) {
+      val buff = ArrayBuffer.empty.++=(subIter)
+      subIter = null
+      ((buff.iterator(), buff.length), this)
+    }
+    else {
+      // otherwise find the topmost array stack element
+      if (depth > 0) {
+        // 2) topmost comes before (is not) arrayD
+        //    steal a portion of top to create a new iterator
+        if (posStack(0) == arrayStack(0).length - 1) {
+          // 2a) only a single entry left on top
+          // this means we have to modify this iterator - pop topmost
+          val snd = Array[Iterable[T]](arrayStack(0).last)
+          val szsnd = snd(0).size
+          // modify this - pop
+          depth -= 1
+          1 until arrayStack.length foreach (i => arrayStack(i - 1) = arrayStack(i))
+          arrayStack(arrayStack.length - 1) = Array[Iterable[T]](null)
+          posStack = strawman.collection.arrayToArrayOps(strawman.collection.arrayToArrayOps(posStack).tail) ++ Array[Int](0)
+          // we know that `this` is not empty, since it had something on the arrayStack and arrayStack elements are always non-empty
+          ((newIterator(snd), szsnd), this)
+        } else {
+          // 2b) more than a single entry left on top
+          val (fst, snd) = arrayStack(0).splitAt(arrayStack(0).length - (arrayStack(0).length - posStack(0) + 1) / 2)
+          arrayStack(0) = fst
+          (iteratorWithSize(snd), this)
+        }
+      } else {
+        // 3) no topmost element (arrayD is at the top)
+        //    steal a portion of it and update this iterator
+        if (posD == arrayD.length - 1) {
+          // 3a) positioned at the last element of arrayD
+          val m = arrayD(posD)
+          arrayToIterators(
+            if (isTrie(m)) getElems(m)
+            else collisionToArray(m)
+          )
+        }
+        else {
+          // 3b) arrayD has more free elements
+          val (fst, snd) = arrayD.splitAt(arrayD.length - (arrayD.length - posD + 1) / 2)
+          arrayD = fst
+          (iteratorWithSize(snd), this)
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -140,6 +140,8 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
+  def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
+
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -17,4 +17,7 @@ object BitSet extends BoundedIterableFactory[Int] {
   def fromIterable[E <: Int](it: strawman.collection.Iterable[E]): BitSet = ???
 
   def newBuilder[E <: Int]: Builder[E, BitSet] = ???
+
+  def empty[A <: Int]: BitSet = ???
+
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -28,9 +28,7 @@ final class HashSet[A]
 
   def contains(elem: A): Boolean = ???
   def get(elem: A): Option[A] = ???
-  def subsetOf(that: strawman.collection.Set[A]): Boolean = ???
 
-  def & (that: strawman.collection.Set[A]): HashSet[A] = ???
   def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
 
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -27,6 +27,7 @@ final class HashSet[A]
   def clear(): Unit = ???
 
   def contains(elem: A): Boolean = ???
+  def empty: HashSet[A] = HashSet.empty
   def get(elem: A): Option[A] = ???
 
   def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
@@ -44,5 +45,7 @@ object HashSet extends IterableFactory[HashSet] {
   }
 
   def newBuilder[A]: Builder[A, HashSet[A]] = new HashSet[A]
+
+  def empty[A <: Any]: HashSet[A] = new HashSet[A]
 
 }

--- a/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
@@ -1,0 +1,24 @@
+package strawman
+package collection.mutable
+
+import scala.Unit
+
+/** The canonical builder for immutable Sets.
+  *
+  *  @tparam A      The type of the elements that will be contained in this set.
+  *  @tparam C      The type of the actual collection this set builds.
+  *  @param empty   The empty element of the collection.
+  *  @since 2.13
+  */
+class ImmutableSetBuilder[
+  A,
+  C[X] <: strawman.collection.immutable.Set[X] with strawman.collection.immutable.SetLike[X, C]
+](empty: C[A])
+  extends ReusableBuilder[A, C[A]] {
+
+  type Coll = C[A]
+  protected var elems: Coll = empty
+  def +=(x: A): this.type = { elems = elems + x; this }
+  def clear(): Unit = { elems = empty }
+  def result(): Coll = elems
+}

--- a/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
@@ -12,7 +12,7 @@ import scala.Unit
   */
 class ImmutableSetBuilder[
   A,
-  C[X] <: strawman.collection.immutable.Set[X] with strawman.collection.immutable.SetLike[X, C]
+  C[X] <: strawman.collection.immutable.Set[X] with strawman.collection.immutable.SetMonoTransforms[X, C[X]]
 ](empty: C[A])
   extends ReusableBuilder[A, C[A]] {
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -18,7 +18,7 @@ class ListBuffer[A]
     with Builder[A, ListBuffer[A]] {
 
   private var first: List[A] = Nil
-  private var last: ::[A] = null
+  private var last0: ::[A] = null
   private var aliased = false
   private var len = 0
 
@@ -39,7 +39,7 @@ class ListBuffer[A]
   private def copyElems(): Unit = {
     val buf = ListBuffer.fromIterable(result)
     first = buf.first
-    last = buf.last
+    last0 = buf.last0
     aliased = false
   }
 
@@ -58,15 +58,15 @@ class ListBuffer[A]
   def +=(elem: A) = {
     ensureUnaliased()
     val last1 = (elem :: Nil).asInstanceOf[::[A]]
-    if (len == 0) first = last1 else last.next = last1
-    last = last1
+    if (len == 0) first = last1 else last0.next = last1
+    last0 = last1
     len += 1
     this
   }
 
   private def locate(i: Int): Predecessor[A] =
     if (i == 0) null
-    else if (i == len) last
+    else if (i == len) last0
     else {
       var j = i - 1
       var p = first
@@ -152,7 +152,7 @@ class ListBuffer[A]
     val buf = new ListBuffer[A]
     for (elem <- this) buf += f(elem)
     first = buf.first
-    last = buf.last
+    last0 = buf.last0
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -205,4 +205,6 @@ object ListBuffer extends IterableFactory[ListBuffer] {
 
   def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
 
+  def empty[A <: Any]: ListBuffer[A] = new ListBuffer[A]
+
 }

--- a/src/main/scala/strawman/collection/mutable/ReusableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ReusableBuilder.scala
@@ -1,0 +1,41 @@
+package strawman
+package collection.mutable
+
+import scala.Unit
+
+/** `ReusableBuilder` is a marker trait that indicates that a `Builder`
+  *  can be reused to build more than one instance of a collection.  In
+  *  particular, calling `result` followed by `clear` will produce a
+  *  collection and reset the builder to begin building a new collection
+  *  of the same type.
+  *
+  *  It is up to subclasses to implement this behavior, and to document any
+  *  other behavior that varies from standard `ReusableBuilder` usage
+  *  (e.g. operations being well-defined after a call to `result`, or allowing
+  *  multiple calls to result to obtain different snapshots of a collection under
+  *  construction).
+  *
+  *  @tparam  Elem  the type of elements that get added to the builder.
+  *  @tparam  To    the type of collection that it produced.
+  *
+  *  @since 2.12
+  */
+trait ReusableBuilder[-Elem, +To] extends Builder[Elem, To] {
+  /** Clears the contents of this builder.
+    *  After execution of this method, the builder will contain no elements.
+    *
+    *  If executed immediately after a call to `result`, this allows a new
+    *  instance of the same type of collection to be built.
+    */
+  override def clear(): Unit    // Note: overriding for Scaladoc only!
+
+  /** Produces a collection from the added elements.
+    *
+    *  After a call to `result`, the behavior of all other methods is undefined
+    *  save for `clear`.  If `clear` is called, then the builder is reset and
+    *  may be used to build another instance.
+    *
+    *  @return a collection containing the elements added to this builder.
+    */
+  override def result(): To    // Note: overriding for Scaladoc only!
+}

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -40,7 +40,7 @@ class TraverseTest {
       case (_             ,  Left(a)) => Left(a)
     }.map(_.result)
 
-  //  @Test
+  @Test
   def optionSequence1Test: Unit = {
     val xs1 = immutable.List(Some(1), None, Some(2))
     val o1 = optionSequence1(xs1)
@@ -66,6 +66,7 @@ class TraverseTest {
     val o4t: Option[immutable.TreeMap[Int, String]] = o4
   }
 
+  @Test
   def eitherSequenceTest: Unit = {
     val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
     val e1 = eitherSequence(xs3)


### PR DESCRIPTION
In a process of getting something usable by users as quickly as possible, I’m starting by replacing triple question marks by actual implementations.

This PR adds immutable `HashSet`, `ListSet` and `TreeSet`. I mostly copy-pasted the current implementation from 2.12.