### PR TITLE
Provide alphanumeric methods with descriptive names as alternatives to symbolic operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 - [x] `empty`
 - [x] `filter` / `filterNot`
 - [ ] `groupBy`
+- [x] `intersect`
 - [x] `partition`
 - [x] `range`
 - [x] `splitAt`
@@ -111,7 +112,7 @@ libraryDependencies += "ch.epfl.scala" %% "collection-strawman" % "0.2.0-SNAPSHO
 
 ### Transformations to collections that can have a different element type
 
-- [x] `++` / `concat`
+- [x] `++` / `concat` / `union`
 - [x] `flatMap`
 - [x] `map`
 - [x] `merged`

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,7 +3,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, Int, Numeric, StringContext, Unit}
+import scala.{Any, Array, Boolean, inline, Int, Numeric, StringContext, Unit}
 import java.lang.{String, UnsupportedOperationException}
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}
@@ -243,8 +243,19 @@ trait IterablePolyTransforms[+A, +C[_]] extends Any {
   /** Flatmap */
   def flatMap[B](f: A => IterableOnce[B]): C[B] = fromIterable(View.FlatMap(coll, f))
 
-  /** Concatenation */
-  def ++[B >: A](xs: IterableOnce[B]): C[B] = fromIterable(View.Concat(coll, xs))
+  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
+    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+    *  the element types of the two operands.
+    *
+    *  @param xs   the traversable to append.
+    *  @tparam B   the element type of the returned collection.
+    *  @return     a new collection of type `C[B]` which contains all elements
+    *              of this $coll followed by all elements of `xs`.
+    */
+  def concat[B >: A](xs: IterableOnce[B]): C[B] = fromIterable(View.Concat(coll, xs))
+
+  /** Alias for `concat` */
+  @inline final def ++ [B >: A](xs: IterableOnce[B]): C[B] = concat(xs)
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: IterableOnce[B]): C[(A @uncheckedVariance, B)] = fromIterable(View.Zip(coll, xs))
@@ -270,8 +281,19 @@ trait ConstrainedIterablePolyTransforms[+A, +C[_], +CC[X] <: C[X]] extends Any w
   /** Flatmap */
   def flatMap[B : Ev](f: A => IterableOnce[B]): CC[B] = constrainedFromIterable(View.FlatMap(coll, f))
 
-  /** Concatenation */
-  def ++[B >: A : Ev](xs: IterableOnce[B]): CC[B] = constrainedFromIterable(View.Concat(coll, xs))
+  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
+    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+    *  the element types of the two operands.
+    *
+    *  @param xs   the traversable to append.
+    *  @tparam B   the element type of the returned collection.
+    *  @return     a new collection of type `CC[B]` which contains all elements
+    *              of this $coll followed by all elements of `xs`.
+    */
+  def concat[B >: A : Ev](xs: IterableOnce[B]): CC[B] = constrainedFromIterable(View.Concat(coll, xs))
+
+  /** Alias for `concat` */
+  @inline final def ++ [B >: A : Ev](xs: IterableOnce[B]): CC[B] = concat(xs)
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: IterableOnce[B])(implicit ev: Ev[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = constrainedFromIterable(View.Zip(coll, xs))

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -3,7 +3,7 @@ package collection
 
 import collection.mutable.Builder
 
-import scala.{Any, Boolean, None, NoSuchElementException, Nothing, Option, PartialFunction, Some}
+import scala.{Any, Boolean, inline, None, NoSuchElementException, Nothing, Option, PartialFunction, Some}
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Base Map type */
@@ -92,10 +92,17 @@ trait MapPolyTransforms[K, +V, +C[X, Y]]
 /** Operations that return a Map collection with different types values (e.g. `concat`) */
 trait MapValuePolyTransforms[K, +V, +C[X, Y]] {
 
+  /** Adds all key/value pairs in a traversable collection to this map, returning
+    * a new map.
+    *
+    *  @param    xs  the collection containing the added key/value pairs
+    *  @tparam   V2  the type of the added values
+    *  @return   a new map with the given bindings added to this map
+    */
   def concat [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2]
 
   /** Alias for `concat` */
-  final def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2] = concat(xs)
+  @inline final def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2] = concat(xs)
 
 }
 

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -58,7 +58,16 @@ trait SetLike[A, +C[X] <: Set[X]]
 trait SetMonoTransforms[A, +Repr]
   extends IterableMonoTransforms[A, Repr] {
 
-  def & (that: Set[A]): Repr = this.filter(that)
+  /** Computes the intersection between this set and another set.
+    *
+    *  @param   that  the set to intersect with.
+    *  @return  a new set consisting of all elements that are both in this
+    *  set and in the given set `that`.
+    */
+  def intersect(that: Set[A]): Repr = this.filter(that)
+
+  /** Alias for `intersect` */
+  @inline final def & (that: Set[A]): Repr = intersect(that)
 
   /** The empty set of the same type as this set
     * @return  an empty set of type `Repr`.
@@ -69,7 +78,34 @@ trait SetMonoTransforms[A, +Repr]
 
 trait SetPolyTransforms[A, +C[X]] extends IterablePolyTransforms[A, C] {
 
-  def ++ (that: Set[A]): C[A]
+  /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
+    *
+    * This method takes a collection of elements and adds all elements, omitting duplicates, into $coll.
+    *
+    * Example:
+    *  {{{
+    *    scala> val a = Set(1, 2) concat Set(2, 3)
+    *    a: scala.collection.immutable.Set[Int] = Set(1, 2, 3)
+    *  }}}
+    *
+    *  @param that     the collection containing the elements to add.
+    *  @return a new $coll with the given elements added, omitting duplicates.
+    */
+  def concat(that: Set[A]): C[A]
+
+  /** Alias for `concat` */
+  @inline final def ++ (that: Set[A]): C[A] = concat(that)
+
+  /** Computes the union between of set and another set.
+    *
+    *  @param   that  the set to form the union with.
+    *  @return  a new set consisting of all elements that are in this
+    *  set or in the given set `that`.
+    */
+  @inline final def union(that: Set[A]): C[A] = concat(that)
+
+  /** Alias for `union` */
+  @inline final def | (that: Set[A]): C[A] = concat(that)
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -43,7 +43,7 @@ sealed trait HashMap[K, +V]
   protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] =
     HashMap.fromIterable(it)
 
-  def - (key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
+  def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
   def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] =
     updated0(key, computeHash(key), 0, value, null, null)

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -36,9 +36,9 @@ sealed trait HashSet[A]
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
-  def + (elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
+  def add(elem: A): HashSet[A] = updated0(elem, computeHash(elem), 0)
 
-  def - (elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
+  def remove(elem: A): HashSet[A] = nullToEmpty(removed0(elem, computeHash(elem), 0))
 
   override def empty: HashSet[A] = HashSet.empty
 

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -30,9 +30,9 @@ sealed trait List[+A]
     else prefix.head :: prefix.tail ++: this
 
   /** When concatenating with another list `xs`, avoid copying `xs` */
-  override def ++[B >: A](xs: IterableOnce[B]): List[B] = xs match {
+  override def concat[B >: A](xs: IterableOnce[B]): List[B] = xs match {
     case xs: List[B] => this ++: xs
-    case _ => super.++(xs)
+    case _ => super.concat(xs)
   }
 
   override def className = "List"

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -90,7 +90,7 @@ sealed class ListMap[K, +V]
 
   def updated[B1 >: V](key: K, value: B1): ListMap[K, B1] = new Node[B1](key, value)
 
-  def - (key: K): ListMap[K, V] = this
+  def remove(key: K): ListMap[K, V] = this
 
   def iterator(): Iterator[(K, V)] = {
     var curr: ListMap[K, V] = this
@@ -149,7 +149,7 @@ sealed class ListMap[K, +V]
       new m.Node[V2](k, v)
     }
 
-    override def - (k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
+    override def remove(k: K): ListMap[K, V1] = removeInternal(k, this, Nil)
 
     @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
       if (cur.isEmpty) acc.last

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -65,8 +65,8 @@ sealed class ListSet[A]
 
   def contains(elem: A): Boolean = false
 
-  def + (elem: A): ListSet[A] = new Node(elem)
-  def - (elem: A): ListSet[A] = this
+  def add(elem: A): ListSet[A] = new Node(elem)
+  def remove(elem: A): ListSet[A] = this
 
   def empty: ListSet[A] = ListSet.empty
 
@@ -108,9 +108,9 @@ sealed class ListSet[A]
     @tailrec private[this] def containsInternal(n: ListSet[A], e: A): Boolean =
       !n.isEmpty && (n.elem == e || containsInternal(n.next, e))
 
-    override def + (e: A): ListSet[A] = if (contains(e)) this else new Node(e)
+    override def add(e: A): ListSet[A] = if (contains(e)) this else new Node(e)
 
-    override def - (e: A): ListSet[A] = removeInternal(e, this, Nil)
+    override def remove(e: A): ListSet[A] = removeInternal(e, this, Nil)
 
     @tailrec private[this] def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
       if (cur.isEmpty) acc.last

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -4,6 +4,8 @@ package collection.immutable
 import strawman.collection.MapFactory
 import strawman.collection.mutable.Builder
 
+import scala.inline
+
 /** Base type of immutable Maps */
 trait Map[K, +V]
   extends collection.Map[K, V]
@@ -32,7 +34,9 @@ trait MapMonoTransforms[K, +V, +Repr <: Map[K, V]]
     * @param key the key to be removed
     * @return a new map without a binding for ''key''
     */
-  def - (key: K): Repr
+  def remove(key: K): Repr
+  /** Alias for `remove` */
+  @inline final def - (key: K): Repr = remove(key)
 
   /** The empty map of the same type as this map
     * @return   an empty map of type `Repr`.

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -4,7 +4,7 @@ package collection.immutable
 import strawman.collection.mutable.Builder
 import strawman.collection.IterableFactory
 
-import scala.Any
+import scala.{Any, inline}
 
 /** Base trait for immutable set collections */
 trait Set[A]
@@ -24,9 +24,26 @@ trait SetLike[A, +C[X] <: Set[X] with SetLike[X, C]]
 trait SetMonoTransforms[A, +Repr]
   extends collection.SetMonoTransforms[A, Repr] {
 
-  def + (elem: A): Repr
+  /** Creates a new set with an additional element, unless the element is
+    *  already present.
+    *
+    *  @param elem the element to be added
+    *  @return a new set that contains all elements of this set and that also
+    *          contains `elem`.
+    */
+  def add(elem: A): Repr
+  /** Alias for `add` */
+  @inline final def + (elem: A): Repr = add(elem)
 
-  def - (elem: A): Repr
+  /** Creates a new set with a given element removed from this set.
+    *
+    *  @param elem the element to be removed
+    *  @return a new set that contains all elements of this set but that does not
+    *          contain `elem`.
+    */
+  def remove(elem: A): Repr
+  /** Alias for `remove` */
+  @inline final def - (elem: A): Repr = remove(elem)
 
 }
 
@@ -35,7 +52,7 @@ trait SetPolyTransforms[A, +C[X] <: Set[X] with SetLike[X, C]]
 
   protected def coll: C[A]
 
-  def ++ (that: collection.Set[A]): C[A] = {
+  def concat (that: collection.Set[A]): C[A] = {
     var result: C[A] = coll
     val it = that.iterator()
     while (it.hasNext) result = result + it.next()

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -48,7 +48,7 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def get(key: K): Option[V] = RB.get(tree, key)
 
-  def - (key: K): TreeMap[K,V] =
+  def remove(key: K): TreeMap[K,V] =
     if (!RB.contains(tree, key)) this
     else new TreeMap(RB.delete(tree, key))
 

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -88,14 +88,14 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     *  @param elem    a new element to add.
     *  @return        a new $coll containing `elem` and all the elements of this $coll.
     */
-  def + (elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
+  def add(elem: A): TreeSet[A] = newSet(RB.update(tree, elem, (), overwrite = false))
 
   /** Creates a new `TreeSet` with the entry removed.
     *
     *  @param elem    a new element to add.
     *  @return        a new $coll containing all the elements of this $coll except `elem`.
     */
-  def - (elem: A): TreeSet[A] =
+  def remove(elem: A): TreeSet[A] =
     if (!RB.contains(tree, elem)) this
     else newSet(RB.delete(tree, elem))
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -56,7 +56,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def clear() =
     end = 0
 
-  def +=(elem: A): this.type = {
+  def addInPlace(elem: A): this.type = {
     ensureSize(end + 1)
     this(end) = elem
     end += 1
@@ -64,13 +64,13 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   }
 
   /** Overridden to use array copying for efficiency where possible. */
-  override def ++=(elems: IterableOnce[A]): this.type = {
+  override def addAllInPlace(elems: IterableOnce[A]): this.type = {
     elems match {
       case elems: ArrayBuffer[_] =>
         ensureSize(length + elems.length)
         Array.copy(elems.array, 0, array, length, elems.length)
         end = length + elems.length
-      case _ => super.++=(elems)
+      case _ => super.addAllInPlace(elems)
     }
     this
   }

--- a/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -7,9 +7,6 @@ import strawman.collection.{IterableMonoTransforms, IterableOnce}
 /** Base trait for collection builders */
 trait Builder[-A, +To] extends Growable[A] { self =>
 
-  /** Append an element */
-  def +=(x: A): this.type
-
   /** Clears the contents of this builder.
    *  After execution of this method the builder will contain no elements.
    */
@@ -20,9 +17,9 @@ trait Builder[-A, +To] extends Growable[A] { self =>
 
   /** A builder resulting from this builder my mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo) = new Builder[A, NewTo] {
-    def +=(x: A): this.type = { self += x; this }
+    def addInPlace(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()
-    override def ++=(xs: IterableOnce[A]): this.type = { self ++= xs; this }
+    override def addAllInPlace(xs: IterableOnce[A]): this.type = { self ++= xs; this }
     def result: NewTo = f(self.result)
   }
 }
@@ -30,12 +27,15 @@ trait Builder[-A, +To] extends Growable[A] { self =>
 class StringBuilder extends Builder[Char, String] {
   private val sb = new java.lang.StringBuilder
 
-  def += (x: Char) = { sb.append(x); this }
+  def addInPlace(x: Char) = { sb.append(x); this }
 
   def clear() = sb.setLength(0)
 
-  /** Overloaded version of `++=` that takes a string */
-  def ++= (s: String) = { sb.append(s); this }
+  /** Overloaded version of `addAllInPlace` that takes a string */
+  def addAllInPlace(s: String): this.type = { sb.append(s); this }
+
+  /** Alias for `addAllInPlace` */
+  def ++= (s: String): this.type = addAllInPlace(s)
 
   def result = sb.toString
 

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -1,7 +1,7 @@
 package strawman.collection.mutable
 
 import strawman.collection.IterableOnce
-import scala.Unit
+import scala.{inline, Unit}
 import scala.annotation.tailrec
 import strawman.collection.{toOldSeq, toNewSeq}
 
@@ -16,7 +16,10 @@ trait Growable[-A] {
    *  @param elem  the element to $add.
    *  @return the $coll itself
    */
-  def +=(elem: A): this.type
+  def addInPlace(elem: A): this.type
+
+  /** Alias for `addInPlace` */
+  @inline final def += (elem: A): this.type = addInPlace(elem)
 
   /** ${Add}s two or more elements to this $coll.
    *
@@ -25,14 +28,14 @@ trait Growable[-A] {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
-  def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems.toStrawman: IterableOnce[A])
+  @inline final def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems.toStrawman: IterableOnce[A])
 
   /** ${Add}s all elements produced by a TraversableOnce to this $coll.
    *
    *  @param xs   the TraversableOnce producing the elements to $add.
    *  @return  the $coll itself.
    */
-  def ++=(xs: IterableOnce[A]): this.type = {
+  def addAllInPlace(xs: IterableOnce[A]): this.type = {
     @tailrec def loop(xs: scala.collection.LinearSeq[A]): Unit = {
       if (xs.nonEmpty) {
         this += xs.head
@@ -47,6 +50,9 @@ trait Growable[-A] {
     // for List. Maybe we should just simplify the code by deferring to iterator foreach?
     this
   }
+
+  /** Alias for `addAllInPlace` */
+  @inline final def ++= (xs: IterableOnce[A]): this.type = addAllInPlace(xs)
 
   /** Clears the $coll's contents. After this operation, the
    *  $coll is empty.

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -18,11 +18,11 @@ final class HashMap[K, V]
   def get(key: K): Option[V] = ???
 
   // From Growable
-  def +=(elem: (K, V)): this.type = ???
+  def addInPlace(elem: (K, V)): this.type = ???
   def clear(): Unit = ???
 
   // From mutable.MapLike
-  def -=(elem: (K, V)): this.type = ???
+  def removeInPlace(elem: (K, V)): this.type = ???
   def put(key: K, value: V): Option[V] = ???
 
   // From IterablePolyTransforms

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -22,15 +22,15 @@ final class HashSet[A]
   def newBuilder[E]: Builder[E, HashSet[E]] = new HashSet[E]
   def result: HashSet[A] = this
 
-  def +=(elem: A): this.type = ???
-  def -=(elem: A): this.type = ???
+  def addInPlace(elem: A): this.type = ???
+  def removeInPlace(elem: A): this.type = ???
   def clear(): Unit = ???
 
   def contains(elem: A): Boolean = ???
   def empty: HashSet[A] = HashSet.empty
   def get(elem: A): Option[A] = ???
 
-  def ++ (that: strawman.collection.Set[A]): HashSet[A] = ???
+  def concat(that: strawman.collection.Set[A]): HashSet[A] = ???
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/ImmutableMapBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableMapBuilder.scala
@@ -7,6 +7,6 @@ class ImmutableMapBuilder[
 ](empty: C[K, V])
   extends ImmutableBuilder[(K, V), C[K, V]](empty) {
 
-  def += (kv: (K, V)): this.type = { elems = elems + kv; this }
+  def addInPlace(kv: (K, V)): this.type = { elems = elems + kv; this }
 
 }

--- a/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableSetBuilder.scala
@@ -14,5 +14,6 @@ class ImmutableSetBuilder[
 ](empty: C[A])
   extends ImmutableBuilder[A, C[A]](empty) {
 
-  def +=(x: A): this.type = { elems = elems + x; this }
+  def addInPlace(x: A): this.type = { elems = elems + x; this }
+
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -55,7 +55,7 @@ class ListBuffer[A]
     first = Nil
   }
 
-  def +=(elem: A) = {
+  def addInPlace(elem: A) = {
     ensureUnaliased()
     val last1 = (elem :: Nil).asInstanceOf[::[A]]
     if (len == 0) first = last1 else last0.next = last1

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import strawman.collection.IterableMonoTransforms
 
-import scala.Option
+import scala.{inline, Option}
 
 /** Base type of mutable Maps */
 trait Map[K, V]
@@ -15,7 +15,14 @@ trait MapLike[K, V, +C[X, Y] <: Map[X, Y]]
     with Iterable[(K, V)]
     with Growable[(K, V)] {
 
-  def -= (elem: (K, V)): this.type
+  /** Removes a single element from this $coll.
+    *
+    *  @param elem  the element to remove.
+    *  @return the $coll itself
+    */
+  def removeInPlace(elem: (K, V)): this.type
+  /** Alias for `removeInPlace` */
+  @inline final def -= (elem: (K, V)): this.type = removeInPlace(elem)
 
   def put(key: K, value: V): Option[V]
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import strawman.collection
 import strawman.collection.IterableOnce
-import scala.{Int, Boolean, Unit, Option, Some, None}
+import scala.{inline, Int, Boolean, Unit, Option, Some, None}
 import scala.Predef.???
 
 /** Base trait for mutable sets */
@@ -11,8 +11,15 @@ trait Set[A]
     with SetLike[A, Set]
     with Growable[A] {
 
-  def +=(elem: A): this.type
-  def -=(elem: A): this.type
+  def addInPlace(elem: A): this.type
+  /** Removes a single element from this $coll.
+    *
+    *  @param elem  the element to remove.
+    *  @return the $coll itself
+    */
+  def removeInPlace(elem: A): this.type
+  /** Alias for `removeInPlace` */
+  @inline final def -= (elem: A): this.type = removeInPlace(elem)
 
   def contains(elem: A): Boolean
   def get(elem: A): Option[A]


### PR DESCRIPTION
Fixes #46.

I systematically added methods with alphanumeric names for all operations and defined symbolic operators as aliases.

I suffixed operations on mutable collections with `InPlace`, since that’s the new convention.