### PR TITLE
Compile under dotty

### DIFF
--- a/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/src/main/scala/strawman/collection/BuildFrom.scala
@@ -33,7 +33,7 @@ object BuildFrom {
   }
 
   /** Build the source collection type from a ConstrainedPolyBuildable */
-  implicit def buildFromConstrainedPolyBuildable[Ev[_], Impl[_], CC[_], A, E : Ev]: BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] { type To = CC[E] } = new BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] {
+  implicit def buildFromConstrainedPolyBuildable[Ev[_], CC[_], A, E : Ev]: BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] { type To = CC[E] } = new BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] {
     //TODO: Reuse a prototype instance
     type To = CC[E]
     def newBuilder(from: ConstrainedPolyBuildable[A, CC, Ev]): Builder[E, To] = from.newConstrainedBuilder[E]

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, Equals, inline, Int}
+import scala.{Any, Boolean, Equals, `inline`, Int}
 import scala.util.hashing.MurmurHash3
 
 /** Base trait for set collections.
@@ -34,7 +34,7 @@ trait SetLike[A, +C[X] <: Set[X]]
     *  @param elem the element to test for membership.
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
-  @inline final def apply(elem: A): Boolean = this.contains(elem)
+  @`inline` final def apply(elem: A): Boolean = this.contains(elem)
 
   def subsetOf(that: Set[A]): Boolean = this.forall(that)
 

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -5,7 +5,7 @@ package collection.immutable
 import strawman.collection.{IterableFactory, Iterator}
 import strawman.collection.mutable.{Builder, ImmutableSetBuilder}
 
-import scala.{Any, AnyRef, Array, Boolean, inline, Int, NoSuchElementException, Serializable, SerialVersionUID, sys, Unit}
+import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, NoSuchElementException, Serializable, SerialVersionUID, sys, Unit}
 import scala.Predef.assert
 import java.lang.Integer
 
@@ -166,7 +166,7 @@ object HashSet extends IterableFactory[HashSet] {
         }
       } else this
 
-    private def writeObject(out: java.io.ObjectOutputStream) {
+    private def writeObject(out: java.io.ObjectOutputStream): Unit = {
       // this cannot work - reading things in might produce different
       // hash codes and remove the collision. however this is never called
       // because no references to this class are ever handed out to client code
@@ -175,7 +175,7 @@ object HashSet extends IterableFactory[HashSet] {
       //out.writeObject(kvs)
     }
 
-    private def readObject(in: java.io.ObjectInputStream) {
+    private def readObject(in: java.io.ObjectInputStream): Unit = {
       sys.error("cannot deserialize an immutable.HashSet where all items have the same 32-bit hash code")
       //kvs = in.readObject().asInstanceOf[ListSet[A]]
       //hash = computeHash(kvs.)
@@ -342,6 +342,6 @@ object HashSet extends IterableFactory[HashSet] {
     * In many internal operations the empty set is represented as null for performance reasons. This method converts
     * null to the empty set for use in public methods
     */
-  @inline private def nullToEmpty[A](s: HashSet[A]): HashSet[A] = if (s eq null) empty[A] else s
+  @`inline` private def nullToEmpty[A](s: HashSet[A]): HashSet[A] = if (s eq null) empty[A] else s
 
 }

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -114,7 +114,7 @@ sealed class ListSet[A]
 
     @tailrec private[this] def removeInternal(k: A, cur: ListSet[A], acc: List[ListSet[A]]): ListSet[A] =
       if (cur.isEmpty) acc.last
-      else if (k == cur.elem) acc.foldLeft(cur.next) { case (t, h) => new t.Node(h.elem) }
+      else if (k == cur.elem) acc.foldLeft(cur.next)((t, h) => new t.Node(h.elem)) 
       else removeInternal(k, cur.next, cur :: acc)
 
     override protected def next: ListSet[A] = ListSet.this

--- a/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
+++ b/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
@@ -13,7 +13,7 @@ import collection.Iterator
 import scala.annotation.tailrec
 import scala.annotation.meta.getter
 
-import scala.{Array, Boolean, inline, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit}
+import scala.{Array, Boolean, `inline`, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit}
 import java.lang.{Integer, String}
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
@@ -96,7 +96,7 @@ private[collection] object RedBlackTree {
 
   def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
 
-  private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
+  private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U): Unit = {
     if (tree.left ne null) _foreach(tree.left, f)
     f((tree.key, tree.value))
     if (tree.right ne null) _foreach(tree.right, f)
@@ -104,7 +104,7 @@ private[collection] object RedBlackTree {
 
   def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)
 
-  private[this] def _foreachKey[A, U](tree: Tree[A, _], f: A => U) {
+  private[this] def _foreachKey[A, U](tree: Tree[A, _], f: A => U): Unit = {
     if (tree.left ne null) _foreachKey(tree.left, f)
     f((tree.key))
     if (tree.right ne null) _foreachKey(tree.right, f)
@@ -422,7 +422,7 @@ private[collection] object RedBlackTree {
   }
 
   /*
-   * Forcing direct fields access using the @inline annotation helps speed up
+   * Forcing direct fields access using the @`inline` annotation helps speed up
    * various operations (especially smallest/greatest and update/delete).
    *
    * Unfortunately the direct field access is not guaranteed to work (but
@@ -431,12 +431,12 @@ private[collection] object RedBlackTree {
    * An alternative is to implement the these classes using plain old Java code...
    */
   sealed abstract class Tree[A, +B](
-    @(inline @getter) final val key: A,
-    @(inline @getter) final val value: B,
-    @(inline @getter) final val left: Tree[A, B],
-    @(inline @getter) final val right: Tree[A, B])
+    @(`inline` @getter) final val key: A,
+    @(`inline` @getter) final val value: B,
+    @(`inline` @getter) final val left: Tree[A, B],
+    @(`inline` @getter) final val right: Tree[A, B])
     extends Serializable {
-    @(inline @getter) final val count: Int = 1 + RedBlackTree.count(left) + RedBlackTree.count(right)
+    @(`inline` @getter) final val count: Int = 1 + RedBlackTree.count(left) + RedBlackTree.count(right)
     def black: Tree[A, B]
     def red: Tree[A, B]
   }
@@ -458,11 +458,11 @@ private[collection] object RedBlackTree {
   }
 
   object RedTree {
-    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
+    @`inline` def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new RedTree(key, value, left, right)
     def unapply[A, B](t: RedTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
   object BlackTree {
-    @inline def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
+    @`inline` def apply[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new BlackTree(key, value, left, right)
     def unapply[A, B](t: BlackTree[A, B]) = Some((t.key, t.value, t.left, t.right))
   }
 
@@ -485,7 +485,7 @@ private[collection] object RedBlackTree {
       else if (tree.left eq null) tree
       else findLeftMostOrPopOnEmpty(goLeft(tree))
 
-    private[this] def pushNext(tree: Tree[A, B]) {
+    private[this] def pushNext(tree: Tree[A, B]): Unit = {
       stackOfNexts(index) = tree
       index += 1
     }

--- a/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -55,7 +55,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
     case _                                  => false
   }
 
-  final class DupIterator(xs: Array[Iterable[T]]) extends TrieIterator[T](xs) {
+  final class DupIterator(xs: Array[Iterable[T]] @uV) extends TrieIterator[T](xs) {
     override def initDepth                                     = outer.depth
     override def initArrayStack: Array[Array[Iterable[T @uV]]] = outer.arrayStack
     override def initPosStack                                  = outer.posStack

--- a/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -55,14 +55,14 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
     case _                                  => false
   }
 
-  final class DupIterator(xs: Array[Iterable[T]]) extends {
-    override val initDepth                                     = outer.depth
-    override val initArrayStack: Array[Array[Iterable[T @uV]]] = outer.arrayStack
-    override val initPosStack                                  = outer.posStack
-    override val initArrayD: Array[Iterable[T @uV]]            = outer.arrayD
-    override val initPosD                                      = outer.posD
-    override val initSubIter                                   = outer.subIter
-  } with TrieIterator[T](xs) {
+  final class DupIterator(xs: Array[Iterable[T]]) extends TrieIterator[T](xs) {
+    override def initDepth                                     = outer.depth
+    override def initArrayStack: Array[Array[Iterable[T @uV]]] = outer.arrayStack
+    override def initPosStack                                  = outer.posStack
+    override def initArrayD: Array[Iterable[T @uV]]            = outer.arrayD
+    override def initPosD                                      = outer.posD
+    override def initSubIter                                   = outer.subIter
+
     final override def getElem(x: AnyRef): T = outer.getElem(x)
   }
 

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -57,7 +57,8 @@ class TraverseTest {
     val o1t: Option[immutable.List[Int]] = o1
 
     val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-    val o2 = optionSequence(xs2)
+    val o2 = optionSequence(xs2)(
+     BuildFrom.buildFromConstrainedPolyBuildable[math.Ordering, immutable.TreeSet, Option[String], String])
     val o2t: Option[immutable.TreeSet[String]] = o2
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -69,9 +69,8 @@ class TraverseTest {
 
   @Test
   def eitherSequenceTest: Unit = {
-    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
+    val xs3: mutable.ListBuffer[Either[Int, String]] = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
     val e1 = eitherSequence(xs3)
     val e1t: Either[Int, mutable.ListBuffer[String]] = e1
   }
-
 }

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -9,6 +9,7 @@ import strawman.collection._
 
 import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
 import scala.Predef.ArrowAssoc
+import scala.math.Ordering
 import java.lang.String
 
 class TraverseTest {
@@ -58,7 +59,7 @@ class TraverseTest {
 
     val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
     val o2 = optionSequence(xs2)(
-     BuildFrom.buildFromConstrainedPolyBuildable[math.Ordering, immutable.TreeSet, Option[String], String])
+     BuildFrom.buildFromConstrainedPolyBuildable[Ordering, immutable.TreeSet, Option[String], String])
     val o2t: Option[immutable.TreeSet[String]] = o2
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:


### PR DESCRIPTION
This is a set of changes needed to compile the strawman under dotty. The first 4 commits are simple rewrites or only concern some details. The next two commits are more problematic.

fc09109 shows a failure to infer the right type instance of `buildFromConstrainedPolyBuildable`

It's signature is the epic

    implicit def buildFromConstrainedPolyBuildable[Ev[_], CC[_], Impl[_], A, E : Ev]: BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] { type To = CC[E] }

Btw, `Impl[_]` is unused - why are we adding a 5th type parameter here? 

I have no idea why dotty fails to find in the implicit, and in fact have no idea how an implicit os supposed to be found in the first place. Can someone explain the intended sequence of instantiations here?

a475189 shows a failure of type inference due to union types. See the commit comment. The worrying thing here is that we see `ListBuffer.To` in the error message, which IMO should not happen.
