### PR TITLE
Add ArrayView benchmarks (and baseline)

### DIFF
--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -41,9 +41,9 @@ object MemoryFootprint extends App {
       "List"          -> benchmark(List.fill(_)(obj)),
       "LazyList"      -> benchmark(LazyList.fill(_)(obj)),
       "scala.HashSet" -> benchmark(n => scala.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
-      "HashSet"       -> benchmark(n => collection.immutable.HashSet((1 to n).map(_.toString): _*)),
+      "HashSet"       -> benchmark(n => strawman.collection.immutable.HashSet((1 to n).map(_.toString): _*)),
       "scala.TreeSet" -> benchmark(n => scala.collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
-      "TreeSet"       -> benchmark(n => collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
+      "TreeSet"       -> benchmark(n => strawman.collection.immutable.TreeSet((1 to n).map(_.toString): _*)),
       "ArrayBuffer"   -> benchmark(ArrayBuffer.fill(_)(obj)),
       "ListBuffer"    -> benchmark(ListBuffer.fill(_)(obj))
     )

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
@@ -79,25 +79,6 @@ class ArrayBaselineBenchmark {
   }
 
   @Benchmark
-  def filters(bh: Blackhole) = {
-    var i=0
-    var ret=0L
-    while (i < v.length) {
-      if ((v(i) & 0xD) != 0xCAFED00D &&
-          (v(i) & 0xE) == 0xD15EA5E &&
-          (v(i) & 0xA) != 0xDABBAD00 &&
-          (v(i) & 0xD) == 0xDEADBAAD &&
-          (v(i) & 0xB) != 0xDEADDEAD &&
-          (v(i) & 0xE) == 0xDEADFA11 &&
-          (v(i) & 0xE) != 0xFFBADD11 &&
-          (v(i) & 0xF) == 0x4B1D)
-        ret += v(i)
-      i += 1
-    }
-    bh.consume(ret)
-  }
-
-  @Benchmark
   def maps(bh: Blackhole)= {
     var i=0
     var ret=0L
@@ -105,12 +86,21 @@ class ArrayBaselineBenchmark {
       ret += v(i) +
         (v(i) & 0xD) + 0xCAFED00D +
         (v(i) & 0xE) + 0xD15EA5E +
-        (v(i) & 0xA) + 0xDABBAD00 +
-        (v(i) & 0xD) + 0xDEADBAAD +
-        (v(i) & 0xB) + 0xDEADDEAD +
-        (v(i) & 0xE) + 0xDEADFA11 +
-        (v(i) & 0xE) + 0xFFBADD11 +
-        (v(i) & 0xF) + 0x4B1D
+        (v(i) & 0xA) + 0xDABBAD00
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def filters(bh: Blackhole) = {
+    var i=0
+    var ret=0L
+    while (i < v.length) {
+      if ((v(i) & 0x13) != 0x11 &&
+          (v(i) & 0x12) == 0x12 &&
+          (v(i) & 0x11) != 0x10)
+        ret += v(i)
       i += 1
     }
     bh.consume(ret)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
@@ -1,0 +1,143 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import strawman.collection.{ArrayView, View}
+import scala.{Any, AnyRef, Int, Long, Unit, Array}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class ArrayBaselineBenchmark {
+
+  @Param(scala.Array("282", "73121", "7312102"))
+  var size: Int = _
+
+  @Param(scala.Array("39"))
+  var vLoSize: Int = _
+
+  var shortRangingFactor : Int = (size * 0.2).toInt
+
+  var v: Array[Long] = _
+  var vLo: Array[Long] = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+
+    def fillArray(range: Int) = {
+      val array = new Array[Long](range)
+      var i = 0
+      while (i < range) {
+        array(i) = i.toLong
+        i += 1
+      }
+      array
+    }
+
+    v = fillArray(size)
+    vLo = fillArray(vLoSize)
+  }
+
+  @Benchmark
+  def sum(bh: Blackhole) = {
+    var i = 0
+    var ret = 0L
+    while (i < v.length) {
+      ret += v(i)
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def sumOfSquares(bh: Blackhole) = {
+    var i = 0
+    var ret = 0L
+    while (i < v.length) {
+      ret += v(i) * v(i)
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def sumOfSquaresEven(bh: Blackhole) = {
+    var i = 0
+    var ret = 0L
+    while (i < v.length) {
+      if (v(i) % 2L == 0L)
+        ret += v(i) * v(i)
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def filters(bh: Blackhole) = {
+    var i=0
+    var ret=0L
+    while (i < v.length) {
+      if (v(i) > 1 && v(i) > 2 && v(i) > 3 && v(i) > 4 && v(i) > 5 && v(i) > 6 && v(i) > 7)
+        ret += v(i)
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def maps(bh: Blackhole)= {
+    var i=0
+    var ret=0L
+    while (i < v.length) {
+      ret += v(i) * 1*2*3*4*5*6*7
+      i += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def cart(bh: Blackhole)= {
+    var d, dp = 0
+    var ret = 0L
+    while (d < v.length) {
+      dp = 0
+      while (dp < vLo.length) {
+        ret += v(d) * vLo(dp)
+        dp += 1
+      }
+      d += 1
+    }
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def flatMap_take(bh: Blackhole) = {
+    var counter1 = 0
+    var counter2 = 0
+    var ret = 0L
+    var n = 0
+    var flag = true
+    val size1 = v.length
+    val size2 = vLo.length
+    while (counter1 < size1 && flag) {
+      val item1 = v(counter1)
+      while (counter2 < size2 && flag) {
+        val item2 = vLo(counter2)
+        ret = ret + item1 * item2
+        counter2 += 1
+        n += 1
+        if (n == 20000000)
+          flag = false
+      }
+      counter2 = 0
+      counter1 += 1
+    }
+    bh.consume(ret)
+  }
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayBaselineBenchmark.scala
@@ -10,13 +10,13 @@ import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Fork(15)
+@Warmup(iterations = 30)
+@Measurement(iterations = 15)
 @State(Scope.Benchmark)
 class ArrayBaselineBenchmark {
 
-  @Param(scala.Array("282", "73121", "7312102"))
+  @Param(scala.Array("39", "282", "73121", "7312102"))
   var size: Int = _
 
   @Param(scala.Array("39"))
@@ -34,7 +34,7 @@ class ArrayBaselineBenchmark {
       val array = new Array[Long](range)
       var i = 0
       while (i < range) {
-        array(i) = i.toLong
+        array(i) = scala.util.Random.nextInt(size).toLong
         i += 1
       }
       array
@@ -83,7 +83,14 @@ class ArrayBaselineBenchmark {
     var i=0
     var ret=0L
     while (i < v.length) {
-      if (v(i) > 1 && v(i) > 2 && v(i) > 3 && v(i) > 4 && v(i) > 5 && v(i) > 6 && v(i) > 7)
+      if ((v(i) & 0xD) != 0xCAFED00D &&
+          (v(i) & 0xE) == 0xD15EA5E &&
+          (v(i) & 0xA) != 0xDABBAD00 &&
+          (v(i) & 0xD) == 0xDEADBAAD &&
+          (v(i) & 0xB) != 0xDEADDEAD &&
+          (v(i) & 0xE) == 0xDEADFA11 &&
+          (v(i) & 0xE) != 0xFFBADD11 &&
+          (v(i) & 0xF) == 0x4B1D)
         ret += v(i)
       i += 1
     }
@@ -95,7 +102,15 @@ class ArrayBaselineBenchmark {
     var i=0
     var ret=0L
     while (i < v.length) {
-      ret += v(i) * 1*2*3*4*5*6*7
+      ret += v(i) +
+        (v(i) & 0xD) + 0xCAFED00D +
+        (v(i) & 0xE) + 0xD15EA5E +
+        (v(i) & 0xA) + 0xDABBAD00 +
+        (v(i) & 0xD) + 0xDEADBAAD +
+        (v(i) & 0xB) + 0xDEADDEAD +
+        (v(i) & 0xE) + 0xDEADFA11 +
+        (v(i) & 0xE) + 0xFFBADD11 +
+        (v(i) & 0xF) + 0x4B1D
       i += 1
     }
     bh.consume(ret)
@@ -132,7 +147,7 @@ class ArrayBaselineBenchmark {
         ret = ret + item1 * item2
         counter2 += 1
         n += 1
-        if (n == 20000000)
+        if (n == shortRangingFactor)
           flag = false
       }
       counter2 = 0

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
@@ -1,0 +1,131 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import strawman.collection.{ArrayView, View}
+import scala.{Any, AnyRef, Int, Long, Unit, Array}
+import scala.Predef.intWrapper
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 12)
+@Measurement(iterations = 12)
+@State(Scope.Benchmark)
+class ArrayViewBenchmark {
+
+  @Param(scala.Array("282", "73121", "7312102"))
+  var size: Int = _
+
+  @Param(scala.Array("39"))
+  var vLoSize: Int = _
+
+  var shortRangingFactor : Int = (size * 0.2).toInt
+
+  var v: View[Long] = _
+  var vLo: View[Long] = _
+
+  @Setup(Level.Trial)
+  def initData(): Unit = {
+
+    def fillArray(range: Int) = {
+      val array = new Array[Long](range)
+      var i = 0
+      while (i < range) {
+        array(i) = i.toLong
+        i += 1
+      }
+      array
+    }
+
+    v = ArrayView(fillArray(size))
+    vLo = ArrayView(fillArray(vLoSize))
+  }
+
+  @Benchmark
+  def sum (bh: Blackhole) = {
+    val ret : Long = v
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def sumOfSquares (bh: Blackhole) = {
+    val ret : Long = v
+      .map(d => d * d)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def sumOfSquaresEven (bh: Blackhole) = {
+    val ret : Long = v
+      .filter(x  => x % 2L == 0L)
+      .map(x => x * x)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def mapsMegamorphic (bh: Blackhole) = {
+    val ret : Long = v
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .map(x => x + 1)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def filtersMegamorphic (bh: Blackhole) = {
+    val ret : Long = v
+      .filter(x => x > 1)
+      .filter(x => x > 2)
+      .filter(x => x > 3)
+      .filter(x => x > 4)
+      .filter(x => x > 5)
+      .filter(x => x > 6)
+      .filter(x => x > 7)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def maps (bh: Blackhole) = {
+    val function = (x : Long) => { x + 1 }
+    val ret : Long = v
+      .map(function)
+      .map(function)
+      .map(function)
+      .map(function)
+      .map(function)
+      .map(function)
+      .map(function)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def cart (bh: Blackhole) = {
+    val ret : Long = v
+      .flatMap(d => vLo.view.map (dp => dp * d))
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def flatMap_take (bh: Blackhole) = {
+    val ret = v
+      .flatMap((x) => vLo
+        .map((dP) => dP * x))
+      .take(shortRangingFactor)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
@@ -10,13 +10,13 @@ import scala.Predef.intWrapper
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Fork(15)
+@Warmup(iterations = 30)
+@Measurement(iterations = 15)
 @State(Scope.Benchmark)
 class ArrayViewBenchmark {
 
-  @Param(scala.Array("282", "73121", "7312102"))
+  @Param(scala.Array("39", "282", "73121", "7312102"))
   var size: Int = _
 
   @Param(scala.Array("39"))
@@ -34,7 +34,7 @@ class ArrayViewBenchmark {
       val array = new Array[Long](range)
       var i = 0
       while (i < range) {
-        array(i) = i.toLong
+        array(i) = scala.util.Random.nextInt(size).toLong
         i += 1
       }
       array
@@ -46,8 +46,7 @@ class ArrayViewBenchmark {
 
   @Benchmark
   def sum (bh: Blackhole) = {
-    val ret : Long = v
-      .foldLeft(0L)(_+_)
+    val ret : Long = v.foldLeft(0L)(_+_)
     bh.consume(ret)
   }
 
@@ -69,44 +68,31 @@ class ArrayViewBenchmark {
   }
 
   @Benchmark
-  def mapsMegamorphic (bh: Blackhole) = {
-    val ret : Long = v
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .map(x => x + 1)
-      .foldLeft(0L)(_+_)
-    bh.consume(ret)
-  }
-
-  @Benchmark
-  def filtersMegamorphic (bh: Blackhole) = {
-    val ret : Long = v
-      .filter(x => x > 1)
-      .filter(x => x > 2)
-      .filter(x => x > 3)
-      .filter(x => x > 4)
-      .filter(x => x > 5)
-      .filter(x => x > 6)
-      .filter(x => x > 7)
-      .foldLeft(0L)(_+_)
-    bh.consume(ret)
-  }
-
-  @Benchmark
   def maps (bh: Blackhole) = {
-    val function = (x : Long) => { x + 1 }
     val ret : Long = v
-      .map(function)
-      .map(function)
-      .map(function)
-      .map(function)
-      .map(function)
-      .map(function)
-      .map(function)
+      .map(x => x + (x & 0xD) + 0xCAFED00D)
+      .map(x => x + (x & 0xE) + 0xD15EA5E)
+      .map(x => x + (x & 0xA) + 0xDABBAD00)
+      .map(x => x + (x & 0xD) + 0xDEADBAAD)
+      .map(x => x + (x & 0xB) + 0xDEADDEAD)
+      .map(x => x + (x & 0xE) + 0xDEADFA11)
+      .map(x => x + (x & 0xE) + 0xFFBADD11)
+      .map(x => x + (x & 0xF) + 0x4B1D)
+      .foldLeft(0L)(_+_)
+    bh.consume(ret)
+  }
+
+  @Benchmark
+  def filters (bh: Blackhole) = {
+    val ret : Long = v
+      .filter(x => (x & 0xD) != 0xCAFED00D)
+      .filter(x => (x & 0xE) == 0xD15EA5E)
+      .filter(x => (x & 0xA) != 0xDABBAD00)
+      .filter(x => (x & 0xD) == 0xDEADBAAD)
+      .filter(x => (x & 0xB) != 0xDEADDEAD)
+      .filter(x => (x & 0xE) == 0xDEADFA11)
+      .filter(x => (x & 0xE) != 0xFFBADD11)
+      .filter(x => (x & 0xF) == 0x4B1D)
       .foldLeft(0L)(_+_)
     bh.consume(ret)
   }
@@ -114,7 +100,7 @@ class ArrayViewBenchmark {
   @Benchmark
   def cart (bh: Blackhole) = {
     val ret : Long = v
-      .flatMap(d => vLo.view.map (dp => dp * d))
+      .flatMap(d => vLo.map (dp => dp * d))
       .foldLeft(0L)(_+_)
     bh.consume(ret)
   }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
@@ -27,18 +27,18 @@ class ArrayViewBenchmark {
   var v: View[Long] = _
   var vLo: View[Long] = _
 
+  def fillArray(range: Int) = {
+    val array = new Array[Long](range)
+    var i = 0
+    while (i < range) {
+      array(i) = scala.util.Random.nextInt(size).toLong
+      i += 1
+    }
+    array
+  }
+
   @Setup(Level.Trial)
   def initData(): Unit = {
-
-    def fillArray(range: Int) = {
-      val array = new Array[Long](range)
-      var i = 0
-      while (i < range) {
-        array(i) = scala.util.Random.nextInt(size).toLong
-        i += 1
-      }
-      array
-    }
 
     v = ArrayView(fillArray(size))
     vLo = ArrayView(fillArray(vLoSize))
@@ -85,14 +85,14 @@ class ArrayViewBenchmark {
   @Benchmark
   def filters (bh: Blackhole) = {
     val ret : Long = v
-      .filter(x => (x & 0xD) != 0xCAFED00D)
-      .filter(x => (x & 0xE) == 0xD15EA5E)
-      .filter(x => (x & 0xA) != 0xDABBAD00)
-      .filter(x => (x & 0xD) == 0xDEADBAAD)
-      .filter(x => (x & 0xB) != 0xDEADDEAD)
-      .filter(x => (x & 0xE) == 0xDEADFA11)
-      .filter(x => (x & 0xE) != 0xFFBADD11)
-      .filter(x => (x & 0xF) == 0x4B1D)
+      .filter(x => (x & 0x15) != 0x11)
+      .filter(x => (x & 0x10) == 0x10)
+      .filter(x => (x & 0x30) != 0x10)
+      .filter(x => (x & 0x10) == 0x10)
+      .filter(x => (x & 0x15) != 0x10)
+      .filter(x => (x & 0x10) == 0x10)
+      .filter(x => (x & 0x30) != 0x10)
+      .filter(x => (x & 0x15) == 0x10)
       .foldLeft(0L)(_+_)
     bh.consume(ret)
   }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ArrayViewBenchmark.scala
@@ -73,11 +73,6 @@ class ArrayViewBenchmark {
       .map(x => x + (x & 0xD) + 0xCAFED00D)
       .map(x => x + (x & 0xE) + 0xD15EA5E)
       .map(x => x + (x & 0xA) + 0xDABBAD00)
-      .map(x => x + (x & 0xD) + 0xDEADBAAD)
-      .map(x => x + (x & 0xB) + 0xDEADDEAD)
-      .map(x => x + (x & 0xE) + 0xDEADFA11)
-      .map(x => x + (x & 0xE) + 0xFFBADD11)
-      .map(x => x + (x & 0xF) + 0x4B1D)
       .foldLeft(0L)(_+_)
     bh.consume(ret)
   }
@@ -85,14 +80,9 @@ class ArrayViewBenchmark {
   @Benchmark
   def filters (bh: Blackhole) = {
     val ret : Long = v
-      .filter(x => (x & 0x15) != 0x11)
-      .filter(x => (x & 0x10) == 0x10)
-      .filter(x => (x & 0x30) != 0x10)
-      .filter(x => (x & 0x10) == 0x10)
-      .filter(x => (x & 0x15) != 0x10)
-      .filter(x => (x & 0x10) == 0x10)
-      .filter(x => (x & 0x30) != 0x10)
-      .filter(x => (x & 0x15) == 0x10)
+      .filter(x => (x & 0x13) != 0x11)
+      .filter(x => (x & 0x12) == 0x12)
+      .filter(x => (x & 0x11) != 0x10)
       .foldLeft(0L)(_+_)
     bh.consume(ret)
   }

--- a/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
+++ b/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
@@ -1,0 +1,204 @@
+package streams;
+
+import java.util.stream.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(15)
+@Warmup(iterations = 30)
+@Measurement(iterations = 15)
+@State(Scope.Benchmark)
+public class Java8Streams {
+
+    @Param({"39", "282", "73121", "7312102"})
+    public int size;
+
+    @Param({"39"})
+    public int vLoSize;
+
+    public int shortRangingFactor = (int)(size * 0.2);
+
+    public Long[] v_B, vLo_B;
+
+    public long[] v_P, vLo_P;
+
+    public Long[] fillArray_B(int range){
+        Random r = new Random();
+        Long[] array = new Long[range];
+        for (int i = 0; i < range; i++) {
+            array[i] = (new Long(r.nextInt(size)));
+        }
+        return array;
+    }
+
+    public long[] fillArray_P(int range){
+        Random r = new Random();
+        long[] array = new long[range];
+        for (int i = 0; i < range; i++) {
+            array[i] = ((long) r.nextInt(size));
+        }
+        return array;
+    }
+
+    @Setup(Level.Trial)
+    public void initData() {
+        v_B  = fillArray_B(size);
+        vLo_B = fillArray_B(vLoSize);
+
+        v_P = fillArray_P(size);
+        vLo_P = fillArray_P(vLoSize);
+    }
+
+    @Benchmark
+    public void sum_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .reduce(0, (a, b) -> a + b);
+
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void sumOfSquares_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .map(d -> d * d)
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void sumOfSquaresEven_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .filter(x -> x % 2 == 0)
+                .map(x -> x * x)
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void cart_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .flatMap(d -> LongStream.of(vLo_P)
+                    .map(dP -> dP * d))
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void maps_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .map(x -> x + (x & 0xD) + 0xCAFED00D)
+                .map(x -> x + (x & 0xE) + 0xD15EA5E)
+                .map(x -> x + (x & 0xA) + 0xDABBAD00)
+                .map(x -> x + (x & 0xD) + 0xDEADBAAD)
+                .map(x -> x + (x & 0xB) + 0xDEADDEAD)
+                .map(x -> x + (x & 0xE) + 0xDEADFA11)
+                .map(x -> x + (x & 0xE) + 0xFFBADD11)
+                .map(x -> x + (x & 0xF) + 0x4B1D)
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void filters_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .filter(x -> (x & 0x15) != 0x11)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x30) != 0x10)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x15) != 0x10)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x30) != 0x10)
+                .filter(x -> (x & 0x15) == 0x10)
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void flatMap_take_primitive(Blackhole bh) {
+        long ret = LongStream.of(v_P)
+                .flatMap(x -> LongStream.of(vLo_P)
+                        .map(dP -> dP * x))
+                .limit(shortRangingFactor)
+                .reduce(0, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void sum_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .reduce(0L, (a, b) -> a + b);
+
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void sumOfSquares_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .map(d -> d * d)
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void sumOfSquaresEven_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .filter(x -> x % 2 == 0)
+                .map(x -> x * x)
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void cart_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .flatMap(d -> Stream.of(vLo_B)
+                        .map(dP -> dP * d))
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void maps_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .map(x -> x + (x & 0xD) + 0xCAFED00D)
+                .map(x -> x + (x & 0xE) + 0xD15EA5E)
+                .map(x -> x + (x & 0xA) + 0xDABBAD00)
+                .map(x -> x + (x & 0xD) + 0xDEADBAAD)
+                .map(x -> x + (x & 0xB) + 0xDEADDEAD)
+                .map(x -> x + (x & 0xE) + 0xDEADFA11)
+                .map(x -> x + (x & 0xE) + 0xFFBADD11)
+                .map(x -> x + (x & 0xF) + 0x4B1D)
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void filters_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .filter(x -> (x & 0x15) != 0x11)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x30) != 0x10)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x15) != 0x10)
+                .filter(x -> (x & 0x10) == 0x10)
+                .filter(x -> (x & 0x30) != 0x10)
+                .filter(x -> (x & 0x15) == 0x10)
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+
+    @Benchmark
+    public void flatMap_take_boxed(Blackhole bh) {
+        Long ret = Stream.of(v_B)
+                .flatMap(x -> Stream.of(vLo_B)
+                        .map(dP -> dP * x))
+                .limit(shortRangingFactor)
+                .reduce(0L, (a, b) -> a + b);
+        bh.consume(ret);
+    }
+}

--- a/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
+++ b/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
@@ -158,11 +158,6 @@ public class Java8Streams {
                 .map(x -> x + (x & 0xD) + 0xCAFED00D)
                 .map(x -> x + (x & 0xE) + 0xD15EA5E)
                 .map(x -> x + (x & 0xA) + 0xDABBAD00)
-                .map(x -> x + (x & 0xD) + 0xDEADBAAD)
-                .map(x -> x + (x & 0xB) + 0xDEADDEAD)
-                .map(x -> x + (x & 0xE) + 0xDEADFA11)
-                .map(x -> x + (x & 0xE) + 0xFFBADD11)
-                .map(x -> x + (x & 0xF) + 0x4B1D)
                 .reduce(0L, (a, b) -> a + b);
         bh.consume(ret);
     }
@@ -170,14 +165,9 @@ public class Java8Streams {
     @Benchmark
     public void filters_boxed(Blackhole bh) {
         Long ret = Stream.of(v_B)
-                .filter(x -> (x & 0x15) != 0x11)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x30) != 0x10)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x15) != 0x10)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x30) != 0x10)
-                .filter(x -> (x & 0x15) == 0x10)
+                .filter(x -> (x & 0x13) != 0x11)
+                .filter(x -> (x & 0x12) == 0x12)
+                .filter(x -> (x & 0x11) != 0x10)
                 .reduce(0L, (a, b) -> a + b);
         bh.consume(ret);
     }

--- a/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
+++ b/benchmarks/timeJava8/src/main/java/streams/Java8Streams.java
@@ -94,11 +94,6 @@ public class Java8Streams {
                 .map(x -> x + (x & 0xD) + 0xCAFED00D)
                 .map(x -> x + (x & 0xE) + 0xD15EA5E)
                 .map(x -> x + (x & 0xA) + 0xDABBAD00)
-                .map(x -> x + (x & 0xD) + 0xDEADBAAD)
-                .map(x -> x + (x & 0xB) + 0xDEADDEAD)
-                .map(x -> x + (x & 0xE) + 0xDEADFA11)
-                .map(x -> x + (x & 0xE) + 0xFFBADD11)
-                .map(x -> x + (x & 0xF) + 0x4B1D)
                 .reduce(0, (a, b) -> a + b);
         bh.consume(ret);
     }
@@ -106,14 +101,9 @@ public class Java8Streams {
     @Benchmark
     public void filters_primitive(Blackhole bh) {
         long ret = LongStream.of(v_P)
-                .filter(x -> (x & 0x15) != 0x11)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x30) != 0x10)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x15) != 0x10)
-                .filter(x -> (x & 0x10) == 0x10)
-                .filter(x -> (x & 0x30) != 0x10)
-                .filter(x -> (x & 0x15) == 0x10)
+                .filter(x -> (x & 0x13) != 0x11)
+                .filter(x -> (x & 0x12) == 0x12)
+                .filter(x -> (x & 0x11) != 0x10)
                 .reduce(0, (a, b) -> a + b);
         bh.consume(ret);
     }

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,25 @@ val timeBenchmark =
       }.evaluated
     )
 
+
+val timeJava8Benchmark =
+  project.in(file("benchmarks/timeJava8"))
+    .enablePlugins(JmhPlugin)
+    .settings(commonSettings: _*)
+    .settings(
+      charts := Def.inputTaskDyn {
+        val benchmarks = Def.spaceDelimited().parsed
+        val targetDir = crossTarget.value
+        val jmhReport = targetDir / "jmh-result.json"
+        val runTask = run in Jmh
+        Def.inputTask {
+          val _ = runTask.evaluated
+          strawman.collection.Bencharts(jmhReport, "Execution time (lower is better)", targetDir)
+          targetDir
+        }.toTask(s" -rf json -rff ${jmhReport.absolutePath} ${benchmarks.mkString(" ")}")
+      }.evaluated
+    )
+
 val memoryBenchmark =
   project.in(file("benchmarks/memory"))
     .dependsOn(collections)


### PR DESCRIPTION
This set could be useful for examining, through experimentation, to see whether the finally executed code was fused, and by comparing it with the baseline set, to check whether inline+specialization gave interesting results. This would be also interesting for quickly testing auto specialization in dotty compared with the baseline or even Java 8 streams.

I have ported some of these stream benchmarks (or Views in Scala parlance) from our Stream Fusion, to Completeness paper ([pdf](https://arxiv.org/pdf/1612.06668.pdf)).

WDYT?