### PR TITLE
Compile under dotty, V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target/
 .DS_Store
 /tmp/
 /bin/
+/.cache-main
+/.cache-tests

--- a/src/main/scala/strawman/collection/BitSet.scala
+++ b/src/main/scala/strawman/collection/BitSet.scala
@@ -3,7 +3,7 @@ package collection
 
 import strawman.collection.BitSetLike.{LogWL, WordLength}
 
-import scala.{Array, Boolean, inline, Int, Long, Option, Ordering, Unit}
+import scala.{Array, Boolean, `inline`, Int, Long, Option, Ordering, Unit}
 import scala.Predef.{assert, intWrapper}
 
 /** Base type of bitsets */
@@ -141,7 +141,7 @@ trait BitSetMonoTransforms[+C <: BitSet with BitSetLike[C]]
     coll.fromBitMaskNoCopy(words)
   }
 
-  @inline final def ^ (other: BitSet): C = xor(other)
+  @`inline` final def ^ (other: BitSet): C = xor(other)
 
   /**
     * Builds a new bitset by applying a function to all elements of this bitset

--- a/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/src/main/scala/strawman/collection/BuildFrom.scala
@@ -32,12 +32,12 @@ object BuildFrom {
     def fromIterable(from: C[A])(it: Iterable[E]): To = from.fromIterable(it)
   }
 
-  /** Build the source collection type from a ConstrainedPolyBuildable */
-  implicit def buildFromConstrainedPolyBuildable[Ev[_], CC[_], A, E : Ev]: BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] { type To = CC[E] } = new BuildFrom[ConstrainedPolyBuildable[A, CC, Ev], E] {
+  /** Build the source collection type from a OrderedPolyBuildable */
+  implicit def buildFromOrderedPolyBuildable[CC[_], A, E : Ordering]: BuildFrom[OrderedPolyBuildable[A, CC], E] { type To = CC[E] } = new BuildFrom[OrderedPolyBuildable[A, CC], E] {
     //TODO: Reuse a prototype instance
     type To = CC[E]
-    def newBuilder(from: ConstrainedPolyBuildable[A, CC, Ev]): Builder[E, To] = from.newConstrainedBuilder[E]
-    def fromIterable(from: ConstrainedPolyBuildable[A, CC, Ev])(it: Iterable[E]): To = from.constrainedFromIterable(it)
+    def newBuilder(from: OrderedPolyBuildable[A, CC]): Builder[E, To] = from.newOrderedBuilder[E]
+    def fromIterable(from: OrderedPolyBuildable[A, CC])(it: Iterable[E]): To = from.orderedFromIterable(it)
   }
 
   /** Convert an IterableFactory to a BuildFrom */
@@ -47,11 +47,11 @@ object BuildFrom {
     def fromIterable(from: Any)(it: Iterable[E]): To = fact.fromIterable(it)
   }
 
-  /** Convert a ConstrainedIterableFactory to a BuildFrom */
-  implicit def buildConstrainedIterableFactory[CC[_], Ev[_], E : Ev](fact: ConstrainedIterableFactory[CC, Ev]): BuildFrom[Any, E] { type To = CC[E] } = new BuildFrom[Any, E] {
+  /** Convert an OrderedIterableFactory to a BuildFrom */
+  implicit def buildOrderedIterableFactory[CC[_], E : Ordering](fact: OrderedIterableFactory[CC]): BuildFrom[Any, E] { type To = CC[E] } = new BuildFrom[Any, E] {
     type To = CC[E]
-    def newBuilder(from: Any): Builder[E, To] = fact.constrainedNewBuilder
-    def fromIterable(from: Any)(it: Iterable[E]): To = fact.constrainedFromIterable(it)
+    def newBuilder(from: Any): Builder[E, To] = fact.orderedNewBuilder
+    def fromIterable(from: Any)(it: Iterable[E]): To = fact.orderedFromIterable(it)
   }
 
   /** Convert a MapFactory to a BuildFrom */
@@ -61,10 +61,10 @@ object BuildFrom {
     def fromIterable(from: Any)(it: Iterable[(K, V)]): To = fact.fromIterable(it)
   }
 
-  /** Convert a ConstrainedMapFactory to a BuildFrom */
-  implicit def buildConstrainedMapFactory[CC[_, _], Ev[_], K : Ev, V](fact: ConstrainedMapFactory[CC, Ev]): BuildFrom[Any, (K, V)] { type To = CC[K, V] } = new BuildFrom[Any, (K, V)] {
+  /** Convert a OrderedMapFactory to a BuildFrom */
+  implicit def buildOrderedMapFactory[CC[_, _], K : Ordering, V](fact: OrderedMapFactory[CC]): BuildFrom[Any, (K, V)] { type To = CC[K, V] } = new BuildFrom[Any, (K, V)] {
     type To = CC[K, V]
-    def newBuilder(from: Any): Builder[(K, V), To] = fact.constrainedNewBuilder
-    def fromIterable(from: Any)(it: Iterable[(K, V)]): To = fact.constrainedFromIterable(it)
+    def newBuilder(from: Any): Builder[(K, V), To] = fact.orderedNewBuilder
+    def fromIterable(from: Any)(it: Iterable[(K, V)]): To = fact.orderedFromIterable(it)
   }
 }

--- a/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/src/main/scala/strawman/collection/BuildFrom.scala
@@ -2,7 +2,7 @@ package strawman.collection
 
 import scala.language.implicitConversions
 
-import scala.Any
+import scala.{Any, Ordering}
 import scala.annotation.implicitNotFound
 import mutable.Builder
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,7 +3,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, `inline`, Int, Numeric, StringContext, Unit}
+import scala.{Any, Array, Boolean, `inline`, Int, Numeric, Ordering, StringContext, Unit}
 import java.lang.{String, UnsupportedOperationException}
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,7 +3,7 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, inline, Int, Numeric, StringContext, Unit}
+import scala.{Any, Array, Boolean, `inline`, Int, Numeric, StringContext, Unit}
 import java.lang.{String, UnsupportedOperationException}
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}
@@ -249,7 +249,7 @@ trait IterablePolyTransforms[+A, +C[_]] extends Any {
   def concat[B >: A](xs: IterableOnce[B]): C[B] = fromIterable(View.Concat(coll, xs))
 
   /** Alias for `concat` */
-  @inline final def ++ [B >: A](xs: IterableOnce[B]): C[B] = concat(xs)
+  @`inline` final def ++ [B >: A](xs: IterableOnce[B]): C[B] = concat(xs)
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: IterableOnce[B]): C[(A @uncheckedVariance, B)] = fromIterable(View.Zip(coll, xs))
@@ -257,7 +257,7 @@ trait IterablePolyTransforms[+A, +C[_]] extends Any {
 }
 
 /** Transforms over iterables that can return collections of different element types for which an implicit
-  * evidence is required. Every constrained collection type `CC` extends an unconstrained collection type `C`
+  * evidence is required. Every ordered collection type `CC` extends an unordered collection type `C`
   * (e.g. `SortedSet[X] extends Set[X]`) so it inherits methods from `IterablePolyTransforms` that do not require
   * the implicit evidence. These methods can only build a default representation of `C` (e.g. a `HashSet` in the
   * case of `Set`). The methods in this trait are the same as the ones in `IterablePolyTransforms` but they do
@@ -283,10 +283,10 @@ trait OrderedIterablePolyTransforms[+A, +C[_], +CC[X] <: C[X]] extends Any with 
     *  @return     a new collection of type `CC[B]` which contains all elements
     *              of this $coll followed by all elements of `xs`.
     */
-  def concat[B >: A : Ordering](xs: IterableOnce[B]): CC[B] = constrainedFromIterable(View.Concat(coll, xs))
+  def concat[B >: A : Ordering](xs: IterableOnce[B]): CC[B] = orderedFromIterable(View.Concat(coll, xs))
 
   /** Alias for `concat` */
-  @inline final def ++ [B >: A : Ordering](xs: IterableOnce[B]): CC[B] = concat(xs)
+  @`inline` final def ++ [B >: A : Ordering](xs: IterableOnce[B]): CC[B] = concat(xs)
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: IterableOnce[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = orderedFromIterable(View.Zip(coll, xs))

--- a/src/main/scala/strawman/collection/IterableFactories.scala
+++ b/src/main/scala/strawman/collection/IterableFactories.scala
@@ -13,8 +13,8 @@ trait FromIterable[+C[_]] extends Any {
 
 /** Base trait for instances that can construct a collection from an iterable by using an implicit evidence
   * for the element type. */
-trait ConstrainedFromIterable[+CC[_], Ev[_]] extends Any {
-  def constrainedFromIterable[E : Ev](it: Iterable[E]): CC[E]
+trait OrderedFromIterable[+CC[_]] extends Any {
+  def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E]
 }
 
 /** Base trait for companion objects of collection types that may require an upper bound but no implicit evidence */
@@ -40,13 +40,13 @@ trait IterableFactory[+C[_]] extends BoundedIterableFactory[Any] with FromIterab
 }
 
 /** Base trait for companion objects of collections that require an implicit evidence */
-trait ConstrainedIterableFactory[+CC[X], Ev[_]] extends ConstrainedFromIterable[CC, Ev] {
+trait OrderedIterableFactory[+CC[X]] extends OrderedFromIterable[CC] {
 
-  def empty[A : Ev]: CC[A]
+  def empty[A : Ordering]: CC[A]
 
-  def apply[A : Ev](xs: A*): CC[A] = constrainedFromIterable(View.Elems(xs: _*))
+  def apply[A : Ordering](xs: A*): CC[A] = orderedFromIterable(View.Elems(xs: _*))
 
-  def fill[A : Ev](n: Int)(elem: => A): CC[A] = constrainedFromIterable(View.Fill(n)(elem))
+  def fill[A : Ordering](n: Int)(elem: => A): CC[A] = orderedFromIterable(View.Fill(n)(elem))
 
-  def constrainedNewBuilder[A : Ev]: Builder[A, CC[A]]
+  def orderedNewBuilder[A : Ordering]: Builder[A, CC[A]]
 }

--- a/src/main/scala/strawman/collection/IterableFactories.scala
+++ b/src/main/scala/strawman/collection/IterableFactories.scala
@@ -3,7 +3,7 @@ package collection
 
 import strawman.collection.mutable.Builder
 
-import scala.{Any, Int, Nothing}
+import scala.{Any, Int, Ordering, Nothing}
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Base trait for instances that can construct an unconstrained collection from an iterable */

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -3,7 +3,7 @@ package collection
 
 import collection.mutable.Builder
 
-import scala.{Any, Boolean, inline, None, NoSuchElementException, Nothing, Option, PartialFunction, Some}
+import scala.{Any, Boolean, `inline`, None, NoSuchElementException, Nothing, Option, PartialFunction, Some}
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Base Map type */
@@ -102,7 +102,7 @@ trait MapValuePolyTransforms[K, +V, +C[X, Y]] {
   def concat [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2]
 
   /** Alias for `concat` */
-  @inline final def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2] = concat(xs)
+  @`inline` final def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): C[K, V2] = concat(xs)
 
 }
 

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -3,7 +3,7 @@ package collection
 
 import collection.mutable.Builder
 
-import scala.{Any, Boolean, `inline`, None, NoSuchElementException, Nothing, Option, PartialFunction, Some}
+import scala.{Any, Boolean, `inline`, None, NoSuchElementException, Nothing, Option, Ordering, PartialFunction, Some}
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Base Map type */

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -120,15 +120,15 @@ trait MapFactory[+C[_, _]] { self =>
 }
 
 /** Factory methods for collections of kind `* −> * -> *` which require an implicit evidence value for the key type */
-trait ConstrainedMapFactory[+C[_, _], Ev[_]] { self =>
+trait OrderedMapFactory[+C[_, _]] { self =>
 
-  def constrainedNewBuilder[K : Ev, V]: Builder[(K, V), C[K, V]]
+  def orderedNewBuilder[K : Ordering, V]: Builder[(K, V), C[K, V]]
 
-  def constrainedFromIterable[K : Ev, V](it: Iterable[(K, V)]): C[K, V] =
-    constrainedNewBuilder[K, V].++=(it).result
+  def orderedFromIterable[K : Ordering, V](it: Iterable[(K, V)]): C[K, V] =
+    orderedNewBuilder[K, V].++=(it).result
 
-  def empty[K : Ev, V]: C[K, V]
+  def empty[K : Ordering, V]: C[K, V]
 
-  def apply[K : Ev, V](elems: (K, V)*): C[K, V] =
-    constrainedNewBuilder[K, V].++=(elems.toStrawman).result
+  def apply[K : Ordering, V](elems: (K, V)*): C[K, V] =
+    orderedNewBuilder[K, V].++=(elems.toStrawman).result
 }

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -12,7 +12,7 @@ trait SortedSet[A]
 
 trait SortedSetLike[A, +C[X] <: SortedSet[X]]
   extends SortedLike[A, C[A]]
-    with ConstrainedIterablePolyTransforms[A, Set, C]
+    with OrderedIterablePolyTransforms[A, Set, C]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetMonoTransforms[A, C[A]] { // Override the return type of Set ops to return C[A]
 

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -24,8 +24,8 @@ trait SortedSetLike[A, +C[X] <: SortedSet[X]]
 
 }
 
-object SortedSet extends ConstrainedIterableFactory[SortedSet, Ordering] {
+object SortedSet extends OrderedIterableFactory[SortedSet] {
   def empty[A : Ordering]: SortedSet[A] = immutable.SortedSet.empty
-  def constrainedNewBuilder[A : Ordering]: Builder[A, SortedSet[A]] = immutable.SortedSet.constrainedNewBuilder
-  def constrainedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.constrainedFromIterable(it)
+  def orderedNewBuilder[A : Ordering]: Builder[A, SortedSet[A]] = immutable.SortedSet.orderedNewBuilder
+  def orderedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.orderedFromIterable(it)
 }

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -28,8 +28,8 @@ sealed abstract class BitSet
 
   // From IterableMonoTransforms
   protected def fromIterableWithSameElemType(coll: collection.Iterable[Int]): BitSet = BitSet.fromIterable(coll)
-  // From ConstrainedIterablePolyTransforms
-  protected def constrainedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.constrainedFromIterable(it)
+  // From OrderedIterablePolyTransforms
+  protected def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.orderedFromIterable(it)
   // From IterablePolyTransforms
   def fromIterable[B](coll: collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
 
@@ -52,7 +52,7 @@ sealed abstract class BitSet
     } else this
   }
 
-  def unconstrained: Set[Int] = this
+  def unordered: Set[Int] = this
 
   /** Update word at index `idx`; enlarge set if `idx` outside range of set.
     */

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -5,7 +5,7 @@ import collection.{Hashing, Iterator, MapFactory}
 import collection.mutable.{Builder, ImmutableMapBuilder}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.{Any, AnyRef, Array, Boolean, inline, Int, math, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, math, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, sys}
 import java.lang.{Integer, String, System}
 
 /** This class implements immutable maps using a hash trie.
@@ -155,13 +155,13 @@ object HashMap extends MapFactory[HashMap] {
     * @param size the maximum size of the collection to be generated
     * @return the maximum buffer size
     */
-  @inline private def bufferSize(size: Int): Int = math.min(size + 6, 32 * 7)
+  @`inline` private def bufferSize(size: Int): Int = math.min(size + 6, 32 * 7)
 
   /**
     * In many internal operations the empty map is represented as null for performance reasons. This method converts
     * null to the empty map for use in public methods
     */
-  @inline private def nullToEmpty[A, B](m: HashMap[A, B]): HashMap[A, B] = if (m eq null) empty[A, B] else m
+  @`inline` private def nullToEmpty[A, B](m: HashMap[A, B]): HashMap[A, B] = if (m eq null) empty[A, B] else m
 
   private object EmptyHashMap extends HashMap[Any, Nothing] {
 

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -153,7 +153,7 @@ sealed class ListMap[K, +V]
 
     @tailrec private[this] def removeInternal(k: K, cur: ListMap[K, V1], acc: List[ListMap[K, V1]]): ListMap[K, V1] =
       if (cur.isEmpty) acc.last
-      else if (k == cur.key) acc.foldLeft(cur.next) { case (t, h) => new t.Node(h.key, h.value) }
+      else if (k == cur.key) acc.foldLeft(cur.next) { (t, h) => new t.Node(h.key, h.value) }
       else removeInternal(k, cur.next, cur :: acc)
 
     override protected def next: ListMap[K, V1] = ListMap.this

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -4,7 +4,7 @@ package collection.immutable
 import strawman.collection.MapFactory
 import strawman.collection.mutable.Builder
 
-import scala.inline
+import scala.`inline`
 
 /** Base type of immutable Maps */
 trait Map[K, +V]
@@ -36,7 +36,7 @@ trait MapMonoTransforms[K, +V, +Repr <: Map[K, V]]
     */
   def remove(key: K): Repr
   /** Alias for `remove` */
-  @inline final def - (key: K): Repr = remove(key)
+  @`inline` final def - (key: K): Repr = remove(key)
 
   /** The empty map of the same type as this map
     * @return   an empty map of type `Repr`.

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -4,7 +4,7 @@ package collection.immutable
 import strawman.collection.mutable.Builder
 import strawman.collection.IterableFactory
 
-import scala.{Any, inline}
+import scala.{Any, `inline`}
 
 /** Base trait for immutable set collections */
 trait Set[A]
@@ -33,7 +33,7 @@ trait SetMonoTransforms[A, +Repr]
     */
   def add(elem: A): Repr
   /** Alias for `add` */
-  @inline final def + (elem: A): Repr = add(elem)
+  @`inline` final def + (elem: A): Repr = add(elem)
 
   /** Creates a new set with a given element removed from this set.
     *
@@ -43,7 +43,7 @@ trait SetMonoTransforms[A, +Repr]
     */
   def remove(elem: A): Repr
   /** Alias for `remove` */
-  @inline final def - (elem: A): Repr = remove(elem)
+  @`inline` final def - (elem: A): Repr = remove(elem)
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -40,10 +40,9 @@ trait SortedMapPolyTransforms[K, +V, +C[X, +Y] <: SortedMap[X, Y] with SortedMap
 
   protected def coll: C[K, V]
 
-  def constrainedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): C[K2, V2]
+  def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): C[K2, V2]
 
   // And finally, we add new overloads taking an ordering
   def map[K2, V2](f: (K, V) => (K2, V2))(implicit ordering: Ordering[K2]): C[K2, V2] =
-    constrainedMapFromIterable(View.Map(coll, f.tupled))
-
+    orderedMapFromIterable(View.Map(coll, f.tupled))
 }

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -3,7 +3,6 @@ package collection.immutable
 
 import strawman.collection.mutable.Builder
 import strawman.collection.ConstrainedIterableFactory
-
 import scala.Ordering
 
 /** Base trait for sorted sets */

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -2,7 +2,7 @@ package strawman
 package collection.immutable
 
 import strawman.collection.mutable.Builder
-import strawman.collection.ConstrainedIterableFactory
+import strawman.collection.OrderedIterableFactory
 import scala.Ordering
 
 /** Base trait for sorted sets */
@@ -16,8 +16,8 @@ trait SortedSetLike[A, +C[X] <: SortedSet[X]]
     with SetLike[A, Set] // Inherited Set operations return a `Set`
     with SetMonoTransforms[A, C[A]] // Override the return type of Set ops to return C[A]
 
-object SortedSet extends ConstrainedIterableFactory[SortedSet, Ordering] {
+object SortedSet extends OrderedIterableFactory[SortedSet] {
   def empty[A : Ordering]: SortedSet[A] = TreeSet.empty
-  def constrainedNewBuilder[A : Ordering]: Builder[A, SortedSet[A]] = TreeSet.constrainedNewBuilder
-  def constrainedFromIterable[E : Ordering](it: collection.Iterable[E]): SortedSet[E] = TreeSet.constrainedFromIterable(it)
+  def orderedNewBuilder[A : Ordering]: Builder[A, SortedSet[A]] = TreeSet.orderedNewBuilder
+  def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): SortedSet[E] = TreeSet.orderedFromIterable(it)
 }

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -38,15 +38,15 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   protected[this] def fromIterableWithSameElemType(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
     coll match {
       case tm: TreeMap[K, V] => tm
-      case _ => TreeMap.constrainedNewBuilder[K, V].++=(coll).result
+      case _ => TreeMap.orderedNewBuilder[K, V].++=(coll).result
     }
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
   def keysIteratorFrom(start: K): collection.Iterator[K] = RB.keysIterator(tree, Some(start))
 
-  def constrainedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
-    TreeMap.constrainedNewBuilder[K2, V2].++=(it).result
+  def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
+    TreeMap.orderedNewBuilder[K2, V2].++=(it).result
 
   def get(key: K): Option[V] = RB.get(tree, key)
 

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.immutable
 
-import strawman.collection.ConstrainedMapFactory
+import strawman.collection.OrderedMapFactory
 import strawman.collection.immutable.{RedBlackTree => RB}
 import strawman.collection.mutable.{Builder, ImmutableMapBuilder}
 
@@ -100,11 +100,10 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   *  @define Coll immutable.TreeMap
   *  @define coll immutable tree map
   */
-object TreeMap extends ConstrainedMapFactory[TreeMap, Ordering] {
+object TreeMap extends OrderedMapFactory[TreeMap] {
 
-  def constrainedNewBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] =
+  def orderedNewBuilder[K : Ordering, V]: Builder[(K, V), TreeMap[K, V]] =
     new ImmutableMapBuilder[K, V, TreeMap](empty[K, V])
 
   def empty[K: Ordering, V]: TreeMap[K, V] = new TreeMap()
-
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -2,7 +2,7 @@ package strawman
 package collection.immutable
 
 import collection.mutable.{Builder, ImmutableSetBuilder}
-import collection.{ConstrainedIterableFactory, ConstrainedPolyBuildable, Iterator}
+import collection.{OrderedIterableFactory, OrderedPolyBuildable, Iterator}
 import collection.immutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, NullPointerException, Option, Ordering, Some, Unit}
@@ -28,7 +28,7 @@ import scala.{Boolean, Int, NullPointerException, Option, Ordering, Some, Unit}
 final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetLike[A, TreeSet]
-    with ConstrainedPolyBuildable[A, TreeSet, Ordering] {
+    with OrderedPolyBuildable[A, TreeSet] {
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")
 
@@ -65,12 +65,12 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
   def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
 
   protected[this] def fromIterableWithSameElemType(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.constrainedFromIterable(coll)
+    TreeSet.orderedFromIterable(coll)
 
-  def constrainedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.constrainedFromIterable(coll)
+  def orderedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
+    TreeSet.orderedFromIterable(coll)
 
-  def unconstrained: Set[A] = this
+  def unordered: Set[A] = this
 
   /** Checks if this set contains element `elem`.
     *
@@ -103,20 +103,20 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     if (!RB.contains(tree, elem)) this
     else newSet(RB.delete(tree, elem))
 
-  def newConstrainedBuilder[E: Ordering]: Builder[E, TreeSet[E]] = TreeSet.constrainedNewBuilder[E]
+  def newOrderedBuilder[E: Ordering]: Builder[E, TreeSet[E]] = TreeSet.orderedNewBuilder[E]
 
 }
 
-object TreeSet extends ConstrainedIterableFactory[TreeSet, Ordering] {
+object TreeSet extends OrderedIterableFactory[TreeSet] {
 
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
-  def constrainedNewBuilder[A : Ordering]: Builder[A, TreeSet[A]] = new ImmutableSetBuilder[A, TreeSet](empty[A])
+  def orderedNewBuilder[A : Ordering]: Builder[A, TreeSet[A]] = new ImmutableSetBuilder[A, TreeSet](empty[A])
 
-  def constrainedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
+  def orderedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
     it match {
       case ts: TreeSet[E] => ts
-      case _ => constrainedNewBuilder[E].++=(it).result
+      case _ => orderedNewBuilder[E].++=(it).result
     }
 
 }

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -1,7 +1,7 @@
 package strawman.collection.mutable
 
 import strawman.collection.IterableOnce
-import scala.{inline, Unit}
+import scala.{`inline`, Unit}
 import scala.annotation.tailrec
 import strawman.collection.{toOldSeq, toNewSeq}
 
@@ -19,7 +19,7 @@ trait Growable[-A] {
   def addInPlace(elem: A): this.type
 
   /** Alias for `addInPlace` */
-  @inline final def += (elem: A): this.type = addInPlace(elem)
+  @`inline` final def += (elem: A): this.type = addInPlace(elem)
 
   /** ${Add}s two or more elements to this $coll.
    *
@@ -28,7 +28,7 @@ trait Growable[-A] {
    *  @param elems the remaining elements to $add.
    *  @return the $coll itself
    */
-  @inline final def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems.toStrawman: IterableOnce[A])
+  @`inline` final def +=(elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems.toStrawman: IterableOnce[A])
 
   /** ${Add}s all elements produced by a TraversableOnce to this $coll.
    *
@@ -52,7 +52,7 @@ trait Growable[-A] {
   }
 
   /** Alias for `addAllInPlace` */
-  @inline final def ++= (xs: IterableOnce[A]): this.type = addAllInPlace(xs)
+  @`inline` final def ++= (xs: IterableOnce[A]): this.type = addAllInPlace(xs)
 
   /** Clears the $coll's contents. After this operation, the
    *  $coll is empty.

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import strawman.collection.IterableMonoTransforms
 
-import scala.{inline, Option}
+import scala.{`inline`, Option}
 
 /** Base type of mutable Maps */
 trait Map[K, V]
@@ -22,7 +22,7 @@ trait MapLike[K, V, +C[X, Y] <: Map[X, Y]]
     */
   def removeInPlace(elem: (K, V)): this.type
   /** Alias for `removeInPlace` */
-  @inline final def -= (elem: (K, V)): this.type = removeInPlace(elem)
+  @`inline` final def -= (elem: (K, V)): this.type = removeInPlace(elem)
 
   def put(key: K, value: V): Option[V]
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -2,7 +2,7 @@ package strawman.collection.mutable
 
 import strawman.collection
 import strawman.collection.IterableOnce
-import scala.{inline, Int, Boolean, Unit, Option, Some, None}
+import scala.{`inline`, Int, Boolean, Unit, Option, Some, None}
 import scala.Predef.???
 
 /** Base trait for mutable sets */
@@ -19,7 +19,7 @@ trait Set[A]
     */
   def removeInPlace(elem: A): this.type
   /** Alias for `removeInPlace` */
-  @inline final def -= (elem: A): this.type = removeInPlace(elem)
+  @`inline` final def -= (elem: A): this.type = removeInPlace(elem)
 
   def contains(elem: A): Boolean
   def get(elem: A): Option[A]

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -3,8 +3,6 @@ package collection.mutable
 
 import scala.Ordering
 
-import strawman.collection.ConstrainedIterablePolyTransforms
-
 trait SortedSet[A]
   extends collection.SortedSet[A]
     with Set[A]

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -327,9 +327,9 @@ class StrawmanTest {
     val x1 = xs.get("foo")
     val x2: Option[Int] = x1
     val xs1 = xs + ("foo", 1)
-    val xs2: immutable.SortedMap[String, Int] = xs1
+    //val xs2: immutable.SortedMap[String, Int] = xs1  // FIXME: does not work under dotty!
     val xs3 = xs.map(kv => kv._1)
-    val xs4: immutable.Iterable[String] = xs3
+    //val xs4: immutable.Iterable[String] = xs3    // FIXME: does not work under dotty.
     val xs5 = xs.map((k: String, v: Int) => (v, k)) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
     val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -314,6 +314,7 @@ class StrawmanTest {
 
   def mapOps(xs: Map[Int, String]): Unit = {
     val xs1 = xs.map((k, v) => (v, k))
+    val xs1Bis = xs.map { case (k, v) => (v, k) }
     val xs2: strawman.collection.Map[String, Int] = xs1
     val xs3 = xs.map(kv => (kv._2, kv._1))
     val xs4: strawman.collection.Iterable[(String, Int)] = xs3
@@ -327,9 +328,9 @@ class StrawmanTest {
     val x1 = xs.get("foo")
     val x2: Option[Int] = x1
     val xs1 = xs + ("foo", 1)
-    //val xs2: immutable.SortedMap[String, Int] = xs1  // FIXME: does not work under dotty!
+    val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
-    //val xs4: immutable.Iterable[String] = xs3    // FIXME: does not work under dotty.
+    // val xs4: immutable.Iterable[String] = xs3  // FIXME: does not work under dotty, we get a collection.Iterable
     val xs5 = xs.map((k: String, v: Int) => (v, k)) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
     val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo
@@ -346,12 +347,12 @@ class StrawmanTest {
     val xs3 = xs ^ ys
     val xs4: immutable.BitSet = xs3
     val b = xs.subsetOf(zs)
-    val xs5 = xs.map((x: Int) => x + 1) // TODO Remove type annotation when SI-5708 is fixed
+    val xs5 = xs.map(x => x + 1)
     val xs6: immutable.BitSet = xs5
     val xs7 = (xs: immutable.SortedSet[Int]).map((x: Int) => x.toString)
     val xs8: immutable.SortedSet[String] = xs7
     val xs9 = (xs: immutable.Set[Int]).map(x => Left(x): Either[Int, Nothing])
-    val xs10: immutable.Set[Either[Int, Nothing]] = xs9
+    //val xs10: immutable.Set[Either[Int, Nothing]] = xs9
     val xs11 = xs + 42
     val xs12: immutable.BitSet = xs11
     val l = List(1, 2, 3)

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -314,7 +314,6 @@ class StrawmanTest {
 
   def mapOps(xs: Map[Int, String]): Unit = {
     val xs1 = xs.map((k, v) => (v, k))
-    val xs1Bis = xs.map { case (k, v) => (v, k) }
     val xs2: strawman.collection.Map[String, Int] = xs1
     val xs3 = xs.map(kv => (kv._2, kv._1))
     val xs4: strawman.collection.Iterable[(String, Int)] = xs3

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -14,15 +14,15 @@ import java.lang.String
 
 class TraverseTest {
 
-  // You can either overload methods for PolyBuildable and ConstrainedPolyBuildable (if you want to support constrained collection types)
+  // You can either overload methods for PolyBuildable and OrderedPolyBuildable (if you want to support ordered collection types)
   def optionSequence1[C[X] <: Iterable[X] with PolyBuildable[X, C], A](xs: C[Option[A]]): Option[C[A]] =
     xs.foldLeft[Option[Builder[A, C[A]]]](Some(xs.newBuilder)) {
       case (Some(builder), Some(a)) => Some(builder += a)
       case _ => None
     }.map(_.result)
 
-  def optionSequence1[Ev[_], CC[_], A](xs: ConstrainedPolyBuildable[Option[A], CC, Ev] with Iterable[Option[A]])(implicit ev: Ev[A]): Option[CC[A]] =
-    xs.foldLeft[Option[Builder[A, CC[A]]]](Some(xs.newConstrainedBuilder)) {
+  def optionSequence1[CC[_], A](xs: OrderedPolyBuildable[Option[A], CC] with Iterable[Option[A]])(implicit ev: Ordering[A]): Option[CC[A]] =
+    xs.foldLeft[Option[Builder[A, CC[A]]]](Some(xs.newOrderedBuilder)) {
       case (Some(builder), Some(a)) => Some(builder += a)
       case _ => None
     }.map(_.result)
@@ -58,8 +58,7 @@ class TraverseTest {
     val o1t: Option[immutable.List[Int]] = o1
 
     val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-    val o2 = optionSequence(xs2)(
-     BuildFrom.buildFromConstrainedPolyBuildable[Ordering, immutable.TreeSet, Option[String], String])
+    val o2 = optionSequence(xs2)
     val o2t: Option[immutable.TreeSet[String]] = o2
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:
@@ -70,7 +69,8 @@ class TraverseTest {
 
   @Test
   def eitherSequenceTest: Unit = {
-    val xs3: mutable.ListBuffer[Either[Int, String]] = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
+    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
+    val xs3t: mutable.ListBuffer[Either[Int, String]] = xs3
     val e1 = eitherSequence(xs3)
     val e1t: Either[Int, mutable.ListBuffer[String]] = e1
   }


### PR DESCRIPTION
Changes to compile latest master under dotty.

This compiles with the dotty compiler in https://github.com/lampepfl/dotty/pull/2240.

There's a known problem in parameter forwarding, so for the moment you need to compile with

 -Ysuppress-param-forwarding.

Also for the moment you need to compile with a 2.12 version of Either that starts as follows:

    sealed abstract class Either[+A, +B] extends Product1[A | B] with Serializable { ...

If you don't do that, type inference will yield the wrong type in TraverseTest.eitherSequence. We should check whether there's something we can do in the library design about this.



