### PR TITLE
Use delegation over inheritance

### DIFF
--- a/src/main/scala/strawman/collection/Hashing.scala
+++ b/src/main/scala/strawman/collection/Hashing.scala
@@ -1,20 +1,20 @@
 package strawman
 package collection
 
-import scala.Int
+import scala.{Any, Int}
 
-trait Hashing[A] {
+protected[collection] object Hashing {
 
-  protected final def elemHashCode(key: A): Int = key.##
+  def elemHashCode(key: Any): Int = key.##
 
-  protected final def improve(hcode: Int): Int = {
+  def improve(hcode: Int): Int = {
     var h: Int = hcode + ~(hcode << 9)
     h = h ^ (h >>> 14)
     h = h + (h << 4)
     h ^ (h >>> 10)
   }
 
-  protected final def computeHash(key: A): Int =
+  def computeHash(key: Any): Int =
     improve(elemHashCode(key))
 
   /**
@@ -29,7 +29,7 @@ trait Hashing[A] {
     * @param keep a bitmask containing which bits to keep
     * @return the original bitmap with all bits where keep is not 1 set to 0
     */
-  protected def keepBits(bitmap: Int, keep: Int): Int = {
+  def keepBits(bitmap: Int, keep: Int): Int = {
     var result = 0
     var current = bitmap
     var kept = keep

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -1,7 +1,8 @@
 package strawman
 package collection.immutable
 
-import collection.{Hashing, Iterator, MapFactory}
+import collection.{Iterator, MapFactory}
+import collection.Hashing.{computeHash, keepBits}
 import collection.mutable.{Builder, ImmutableMapBuilder}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
@@ -29,7 +30,6 @@ import java.lang.{Integer, String, System}
 sealed trait HashMap[K, +V]
   extends Map[K, V]
     with MapLike[K, V, HashMap]
-    with Hashing[K]
     with Serializable {
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -1,9 +1,9 @@
 package strawman
-
 package collection.immutable
 
-import strawman.collection.{Hashing, IterableFactory, Iterator}
-import strawman.collection.mutable.{Builder, ImmutableSetBuilder}
+import collection.{IterableFactory, Iterator}
+import collection.Hashing.computeHash
+import collection.mutable.{Builder, ImmutableSetBuilder}
 
 import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, sys}
 import scala.Predef.assert
@@ -26,7 +26,6 @@ import java.lang.Integer
 sealed trait HashSet[A]
   extends Set[A]
     with SetLike[A, HashSet]
-    with Hashing[A]
     with Serializable {
 
   import HashSet.nullToEmpty


### PR DESCRIPTION
In order to simplify the inheritance graph, I moved the code shared by `HashSet` and `HashMap` into an object rather than an inherited trait.