### PR TITLE
Introduce a CanBuild typeclass witnessing the ability to produce a Builder

### DIFF
--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,7 +1,9 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, Equals, `inline`, Int}
+import strawman.collection.mutable.Builder
+
+import scala.{Any, Boolean, Equals, Int, `inline`}
 import scala.util.hashing.MurmurHash3
 
 /** Base trait for set collections.
@@ -98,5 +100,7 @@ object Set extends IterableFactory[Set] {
     h = MurmurHash3.mixLast(h, c)
     MurmurHash3.finalizeHash(h, n)
   }
+
+  def newBuilder[A](): Builder[A, Set[A]] = immutable.Set.newBuilder[A]()
 
 }

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -8,11 +8,11 @@ import scala.Ordering
 /** Base type of sorted sets */
 trait SortedMap[K, +V] extends Map[K, V] with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
+trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
   extends MapOps[K, V, Map, C]
      with SortedOps[K, C] {
 
-  protected def coll: CC[K, V]
+  protected def coll: SortedMap[K, V]
 
   protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2]
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -30,8 +30,8 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
     orderedMapFromIterable(View.Concat(coll, xs))
 }
 
-object SortedMap extends OrderedSetFactory[SortedSet] {
-  def empty[A : Ordering]: SortedSet[A] = immutable.SortedSet.empty
-  def orderedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.orderedFromIterable(it)
+object SortedMap extends OrderedMapFactory[SortedMap] {
+  def empty[K: Ordering, V]: SortedMap[K, V] = immutable.TreeMap.empty[K, V]
+  def newBuilder[K: Ordering, V](): Builder[(K, V), SortedMap[K, V]] = immutable.TreeMap.newBuilder[K, V]()
 }
 

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -46,8 +46,9 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X] with SortedSetOps[X, CC, _], +C <: 
   )
 }
 
-object SortedSet extends OrderedSetFactory[SortedSet] {
+object SortedSet extends OrderedIterableFactory[SortedSet] {
   def empty[A : Ordering]: SortedSet[A] = immutable.SortedSet.empty
   def orderedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.orderedFromIterable(it)
+  def newBuilder[A: Ordering](): Builder[A, SortedSet[A]] = immutable.SortedSet.newBuilder[A]()
 }
 

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -3,7 +3,7 @@ package collection
 package immutable
 
 import BitSetOps.{LogWL, updateArray}
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 
 import scala.{Array, Boolean, Int, Long, Ordering, SerialVersionUID, Serializable, Unit}
 import scala.Predef.require
@@ -92,6 +92,11 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 
   def empty: BitSet = new BitSet1(0L)
+
+  def newBuilder(): Builder[Int, BitSet] =
+    new ImmutableBuilder[Int, BitSet](empty) {
+      def add(elem: Int): this.type = { elems = elems + elem; this }
+    }
 
   @SerialVersionUID(2260107458435649300L)
   class BitSet1(val elems: Long) extends BitSet {

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -5,8 +5,10 @@ import collection.{Iterator, MapFactory}
 import collection.Hashing.{computeHash, keepBits}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, math, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, `inline`, math, sys}
 import java.lang.{Integer, String, System}
+
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 /** This class implements immutable maps using a hash trie.
   *
@@ -103,6 +105,11 @@ sealed trait HashMap[K, +V]
 object HashMap extends MapFactory[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = EmptyHashMap.asInstanceOf[HashMap[K, V]]
+
+  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] =
+    new ImmutableBuilder[(K, V), HashMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+    }
 
   private[collection] abstract class Merger[A, B] {
     def apply(kv1: (A, B), kv2: (A, B)): (A, B)

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -2,10 +2,10 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 import Hashing.computeHash
 
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, `inline`, sys}
 import scala.Predef.assert
 import java.lang.Integer
 
@@ -60,6 +60,11 @@ object HashSet extends IterableFactory[HashSet] {
     }
 
   def empty[A <: Any]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+
+  def newBuilder[A](): Builder[A, HashSet[A]] =
+    new ImmutableBuilder[A, HashSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -2,10 +2,10 @@ package strawman
 package collection
 package immutable
 
-import scala.{None, Nothing, Option, Some, StringContext, Any, Int}
+import scala.{Any, Int, None, Nothing, Option, Some, StringContext}
 import scala.Predef.???
 import scala.annotation.tailrec
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 
 class LazyList[+A](expr: => LazyList.Evaluated[A])
   extends Seq[A]
@@ -64,7 +64,7 @@ object LazyList extends IterableFactory[LazyList] {
   def fromIterator[A](it: Iterator[A]): LazyList[A] =
     new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
 
-  def newBuilder[A]: Builder[A, LazyList[A]] = ???
+  def newBuilder[A](): Builder[A, LazyList[A]] = List.newBuilder[A]().mapResult(fromIterable)
 
   def empty[A <: Any]: LazyList[A] = new LazyList[A](None)
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -62,8 +62,8 @@ object List extends IterableFactory[List] {
     case _ => ListBuffer.fromIterable(coll).toList
   }
 
-  def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
+  def newBuilder[A](): Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
-  def empty[A <: Any]: List[A] = Nil
+  def empty[A]: List[A] = Nil
 
 }

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -16,7 +16,7 @@ import scala.annotation.tailrec
 import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, sys}
 import java.lang.Integer
 
-import strawman.collection.mutable.Builder
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 /**
   * This class implements immutable maps using a list-based data structure. List map iterators and
@@ -157,6 +157,11 @@ sealed class ListMap[K, +V]
 object ListMap extends MapFactory[ListMap] {
 
   def empty[K, V]: ListMap[K, V] = EmptyListMap.asInstanceOf[ListMap[K, V]]
+
+  def newBuilder[K, V](): Builder[(K, V), ListMap[K, V]] =
+    new ImmutableBuilder[(K, V), ListMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+    }
 
   @SerialVersionUID(-8256686706655863282L)
   private object EmptyListMap extends ListMap[Any, Nothing]

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -2,7 +2,8 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
+
 import scala.annotation.tailrec
 import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable}
 
@@ -114,11 +115,16 @@ object ListSet extends IterableFactory[ListSet] {
 
   def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] = empty ++ it
 
+  def newBuilder[A](): Builder[A, ListSet[A]] =
+    new ImmutableBuilder[A, ListSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
+
   @SerialVersionUID(5010379588739277132L)
   private object EmptyListSet extends ListSet[Any]
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
-  def empty[A <: Any]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
+  def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -65,5 +65,6 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, _], +C <: Map[
 
 // TODO Special case small maps
 object Map extends MapFactory[Map] {
-  def empty[K, V]: Map[K, V] = ListMap.empty[K, V]
+  def empty[K, V]: Map[K, V] = HashMap.empty[K, V]
+  def newBuilder[K, V](): Builder[(K, V), Map[K, V]] = HashMap.newBuilder[K, V]()
 }

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -14,7 +14,7 @@ trait Seq[+A] extends Iterable[A]
 trait SeqOps[+A, +CC[A] <: Seq[A], +C] extends collection.SeqOps[A, CC, C]
 
 object Seq extends IterableFactory[Seq] {
-  def empty[A <: Any]: Seq[A] = List.empty[A]
-  def newBuilder[A <: Any]: Builder[A, Seq[A]] = List.newBuilder[A]
+  def empty[A]: Seq[A] = List.empty[A]
+  def newBuilder[A](): Builder[A, Seq[A]] = List.newBuilder[A]()
   def fromIterable[E](it: collection.Iterable[E]): Seq[E] = List.fromIterable(it)
 }

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -48,6 +48,7 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
 }
 
 object Set extends IterableFactory[Set] {
-  def empty[A <: Any]: Set[A] = ListSet.empty
-  def fromIterable[E](it: strawman.collection.Iterable[E]): Set[E] = ListSet.fromIterable(it)
+  def empty[A]: Set[A] = HashSet.empty
+  def fromIterable[E](it: strawman.collection.Iterable[E]): Set[E] = HashSet.fromIterable(it)
+  def newBuilder[A](): Builder[A, Set[A]] = HashSet.newBuilder[A]()
 }

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -9,9 +9,11 @@ trait SortedMap[K, +V]
      with collection.SortedMap[K, V]
      with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
+trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
   extends MapOps[K, V, Map, C]
      with collection.SortedMapOps[K, V, CC, C] {
+
+  protected def coll: SortedMap[K, V]
 
   override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -17,7 +17,8 @@ trait SortedSetOps[A,
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 
-object SortedSet extends OrderedSetFactory[SortedSet] {
+object SortedSet extends OrderedIterableFactory[SortedSet] {
   def empty[A : Ordering]: SortedSet[A] = TreeSet.empty
   def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): SortedSet[E] = TreeSet.orderedFromIterable(it)
+  def newBuilder[A: Ordering](): Builder[A, SortedSet[A]] = TreeSet.newBuilder[A]()
 }

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.OrderedMapFactory
 import strawman.collection.immutable.{RedBlackTree => RB}
-import strawman.collection.mutable.Builder
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 
@@ -108,4 +108,8 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   */
 object TreeMap extends OrderedMapFactory[TreeMap] {
   def empty[K: Ordering, V]: TreeMap[K, V] = new TreeMap()
+  def newBuilder[K: Ordering, V](): Builder[(K, V), TreeMap[K, V]] =
+    new ImmutableBuilder[(K, V), TreeMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+    }
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -2,7 +2,7 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 import immutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, NullPointerException, Option, Ordering, Some, Unit}
@@ -103,7 +103,7 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     else newSet(RB.delete(tree, elem))
 }
 
-object TreeSet extends OrderedSetFactory[TreeSet] {
+object TreeSet extends OrderedIterableFactory[TreeSet] {
 
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
@@ -113,4 +113,8 @@ object TreeSet extends OrderedSetFactory[TreeSet] {
       case _ => empty ++ it
     }
 
+  def newBuilder[A: Ordering](): Builder[A, TreeSet[A]] =
+    new ImmutableBuilder[A, TreeSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -137,9 +137,9 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
     }
     else new ArrayBuffer[B] ++= coll
 
-  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
+  def newBuilder[A](): Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
-  def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
+  def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -18,4 +18,5 @@ trait BitSet
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
   def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = ???
   def empty: BitSet = ???
+  def newBuilder(): Builder[Int, BitSet] = ???
 }

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -30,7 +30,7 @@ final class HashMap[K, V] extends Map[K, V] with MapOps[K, V, HashMap, HashMap[K
 
 object HashMap extends MapFactory[HashMap] {
 
-  def newBuilder[K, V]: Builder[(K, V), HashMap[K, V]] = ???
+  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] = ???
 
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -46,8 +46,8 @@ object HashSet extends IterableFactory[HashSet] {
     result
   }
 
-  def newBuilder[A]: Builder[A, HashSet[A]] = new HashSet[A]
+  def newBuilder[A](): Builder[A, HashSet[A]] = new HashSet[A]
 
-  def empty[A <: Any]: HashSet[A] = new HashSet[A]
+  def empty[A]: HashSet[A] = new HashSet[A]
 
 }

--- a/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
@@ -1,0 +1,19 @@
+package strawman
+package collection
+package mutable
+
+import scala.Unit
+
+/**
+  * Reusable builder for immutable collections
+  */
+abstract class ImmutableBuilder[-Elem, Coll](empty: Coll)
+  extends ReusableBuilder[Elem, Coll] {
+
+  protected var elems: Coll = empty
+
+  def clear(): Unit = { elems = empty }
+
+  def result(): Coll = elems
+
+}

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -202,7 +202,7 @@ class ListBuffer[A]
 object ListBuffer extends IterableFactory[ListBuffer] {
 
   def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
-  def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
-  def empty[A <: Any]: ListBuffer[A] = new ListBuffer[A]
+  def newBuilder[A](): Builder[A, ListBuffer[A]] = new ListBuffer[A]
+  def empty[A]: ListBuffer[A] = new ListBuffer[A]
 
 }

--- a/src/test/scala/strawman/collection/test/GenericTest.scala
+++ b/src/test/scala/strawman/collection/test/GenericTest.scala
@@ -1,0 +1,61 @@
+package strawman
+package collection
+package test
+
+import mutable.Builder
+
+import scala.util.Try
+import scala.{Any, Int, None, Nothing, Option, Ordering, Some, Unit}
+import scala.Predef.{augmentString, implicitly, wrapRefArray, assert}
+import java.lang.String
+
+import org.junit.Test
+
+trait Parse[A] {
+  def parse(s: String): Option[A]
+}
+
+object Parse {
+
+  implicit def parseInt: Parse[Int] = (s: String) => Try(s.toInt).toOption
+
+  implicit def parseTuple[A, B](implicit
+    parseA: Parse[A],
+    parseB: Parse[B]
+  ): Parse[(A, B)] = { (s: String) =>
+    val parts = s.split("-")
+    (parseA.parse(parts(0)), parseB.parse(parts(1))) match {
+      case (Some(a), Some(b)) => Some((a, b))
+      case _ => None
+    }
+  }
+
+  implicit def parseCollection[A, C](implicit
+    cb: CanBuild[A, C],
+    parseA: Parse[A]
+  ): Parse[C] = { (s: String) =>
+    val parts = s.split("\\|")
+    parts.foldLeft[Option[Builder[A, C]]](Some(cb.newBuilder())) { (maybeBuilder, s) =>
+      (maybeBuilder, parseA.parse(s)) match {
+        case (Some(builder), Some(a)) =>
+          scala.Predef.println(a)
+          scala.Predef.println(builder.result)
+          Some(builder += a)
+        case _ => None
+      }
+    }.map(_.result)
+  }
+
+}
+
+class GenericTest {
+
+  @Test
+  def genericTest: Unit = {
+    assert(implicitly[Parse[immutable.List[Int]]].parse("1|2|3").contains(1 :: 2 :: 3 :: immutable.Nil))
+
+    // TODO wrap with assert when HashMap’s equality is correctly implemented
+    implicitly[Parse[immutable.HashMap[Int, Int]]].parse("1-2|3-4").contains(immutable.HashMap((1, 2), (3, 4)))
+  }
+
+}

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -1,77 +1,139 @@
-//package strawman
-//
-//package collection.test
-//
-//import org.junit.Test
-//import strawman.collection.Iterable
-//import strawman.collection.mutable.Builder
-//import strawman.collection._
-//
-//import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
-//import scala.Predef.ArrowAssoc
-//import scala.math.Ordering
-//import java.lang.String
-//
-//class TraverseTest {
-//
-//  // You can either overload methods for PolyBuildable and OrderedPolyBuildable (if you want to support ordered collection types)
-//  def optionSequence1[C[X] <: Iterable[X] with PolyBuildable[X, C], A](xs: C[Option[A]]): Option[C[A]] =
-//    xs.foldLeft[Option[Builder[A, C[A]]]](Some(xs.newBuilder)) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
-//  def optionSequence1[CC[_], A](xs: OrderedPolyBuildable[Option[A], CC] with Iterable[Option[A]])(implicit ev: Ordering[A]): Option[CC[A]] =
-//    xs.foldLeft[Option[Builder[A, CC[A]]]](Some(xs.newOrderedBuilder)) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
-//  // ...or use BuildFrom to abstract over both and also allow building arbitrary collection types
-//  def optionSequence[CC[X] <: Iterable[X], A](xs: CC[Option[A]])(implicit bf: BuildFrom[CC[Option[A]], A]): Option[bf.To] =
-//    xs.foldLeft[Option[Builder[A, bf.To]]](Some(bf.newBuilder(xs))) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
-//  def eitherSequence[C[X] <: Iterable[X], A, B](xs: C[Either[A, B]])(implicit bf: BuildFrom[xs.type, B]): Either[A, bf.To] =
-//    xs.foldLeft[Either[A, Builder[B, bf.To]]](Right(bf.newBuilder(xs))) {
-//      case (Right(builder), Right(b)) => Right(builder += b)
-//      case (Left(a)       ,        _) => Left(a)
-//      case (_             ,  Left(a)) => Left(a)
-//    }.right.map(_.result)
-//
+package strawman
+
+package collection.test
+
+import org.junit.Test
+import strawman.collection.Iterable
+import strawman.collection.mutable.Builder
+import strawman.collection._
+
+import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
+import scala.Predef.{ArrowAssoc, implicitly}
+import scala.math.Ordering
+import java.lang.String
+
+/**
+  * Auxiliary type allowing us to define which collection type to build according to the type of an existing collection.
+  * @tparam From Existing collection type that will drives the collection type to build
+  * @tparam A Element type
+  */
+trait BuildFrom[-From, -A] {
+
+  /** Collection type to build */
+  type To
+
+  def newBuilder(): Builder[A, To]
+
+}
+
+trait BuildFromLowPriority {
+
+  /**
+    * Extracts the binary type constructor of `From` and applies it to `A` and `B`
+    * to build the `To` type.
+    */
+  implicit def binaryTC[CC[_, _], A, B](implicit
+    cb: CanBuild[(A, B), CC[A, B]]
+  ): BuildFrom.Aux[CC[_, _], (A, B), CC[A, B]] =
+    new BuildFrom[CC[_, _], (A, B)] {
+      type To = CC[A, B]
+      def newBuilder(): Builder[(A, B), CC[A, B]] = cb.newBuilder()
+    }
+
+}
+
+object BuildFrom extends BuildFromLowPriority {
+
+  type Aux[From, A, To0] = BuildFrom[From, A] { type To = To0 }
+
+  /**
+    * Extracts the unary type constructor of `From` and applies it to `A`
+    * to build the `To` type.
+    */
+  implicit def unaryTC[CC[_], A](implicit
+    cb: CanBuild[A, CC[A]]
+  ): BuildFrom.Aux[CC[_], A, CC[A]] =
+    new BuildFrom[CC[_], A] {
+      type To = CC[A]
+      def newBuilder(): Builder[A, CC[A]] = cb.newBuilder()
+    }
+
+  // Explicit BuildFrom instances allowing breakOut-like style (see below in tests for usage examples)
+  // We have to define four variants to support all the combinations of factories (unary vs binary type
+  // constructor, ordered vs unordered)
+
+  def factory[CC[_], A](iterableFactory: IterableFactory[CC]): BuildFrom.Aux[Any, A, CC[A]] =
+    new BuildFrom[Any, A] {
+      type To = CC[A]
+      def newBuilder(): Builder[A, CC[A]] = iterableFactory.newBuilder[A]
+    }
+
+  def factory[CC[_], A](orderedIterableFactory: OrderedIterableFactory[CC])(implicit ordering: Ordering[A]): BuildFrom.Aux[Any, A, CC[A]] =
+    new BuildFrom[Any, A] {
+      type To = CC[A]
+      def newBuilder(): Builder[A, CC[A]] = orderedIterableFactory.newBuilder[A]
+    }
+
+  def factory[CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _], K, V](
+    mapFactory: MapFactory[CC]
+  ): BuildFrom.Aux[Any, (K, V), CC[K, V]] =
+    new BuildFrom[Any, (K, V)] {
+      type To = CC[K, V]
+      def newBuilder(): Builder[(K, V), CC[K, V]] = mapFactory.newBuilder[K, V]
+    }
+
+  def factory[CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], K, V](
+    orderedMapFactory: OrderedMapFactory[CC]
+  )(implicit
+    ordering: Ordering[K]
+  ): BuildFrom.Aux[Any, (K, V), CC[K, V]] =
+    new BuildFrom[Any, (K, V)] {
+      type To = CC[K, V]
+      def newBuilder(): Builder[(K, V), CC[K, V]] = orderedMapFactory.newBuilder[K, V]
+    }
+
+}
+
+class TraverseTest {
+
+  implicitly[BuildFrom[immutable.List[(Int, String)], (Int, String)]]
+  implicitly[BuildFrom[immutable.TreeMap[Int, String], (Int, String)]]
+
+  def optionSequence[CC[X] <: Iterable[X], A](xs: CC[Option[A]])(implicit bf: BuildFrom[CC[Option[A]], A]): Option[bf.To] =
+    xs.foldLeft[Option[Builder[A, bf.To]]](Some(bf.newBuilder())) {
+      case (Some(builder), Some(a)) => Some(builder += a)
+      case _ => None
+    }.map(_.result)
+
+  def eitherSequence[CC[X] <: Iterable[X], A, B](xs: CC[Either[A, B]])(implicit bf: BuildFrom[CC[Either[A, B]], B]): Either[A, bf.To] =
+    xs.foldLeft[Either[A, Builder[B, bf.To]]](Right(bf.newBuilder())) {
+      case (Right(builder), Right(b)) => Right(builder += b)
+      case (Left(a)       ,        _) => Left(a)
+      case (_             ,  Left(a)) => Left(a)
+    }.right.map(_.result)
+
 //  @Test
-//  def optionSequence1Test: Unit = {
-//    val xs1 = immutable.List(Some(1), None, Some(2))
-//    val o1 = optionSequence1(xs1)
-//    val o1t: Option[immutable.List[Int]] = o1
-//
-//    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-//    val o2 = optionSequence1(xs2)
-//    val o2t: Option[immutable.TreeSet[String]] = o2
-//  }
-//
-//  def optionSequenceTest: Unit = {
-//    val xs1 = immutable.List(Some(1), None, Some(2))
-//    val o1 = optionSequence(xs1)
-//    val o1t: Option[immutable.List[Int]] = o1
-//
-//    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-//    val o2 = optionSequence(xs2)
-//    val o2t: Option[immutable.TreeSet[String]] = o2
-//
-//    // Breakout-like use case from https://github.com/scala/scala/pull/5233:
-//    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
-//    val o4 = optionSequence(xs4)(immutable.TreeMap) // same syntax as in `.to`
-//    val o4t: Option[immutable.TreeMap[Int, String]] = o4
-//  }
-//
-//  @Test
-//  def eitherSequenceTest: Unit = {
-//    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
-//    val xs3t: mutable.ListBuffer[Either[Int, String]] = xs3
-//    val e1 = eitherSequence(xs3)
-//    val e1t: Either[Int, mutable.ListBuffer[String]] = e1
-//  }
-//}
+  def optionSequenceTest: Unit = {
+    val xs1 = immutable.List(Some(1), None, Some(2))
+    val o1 = optionSequence(xs1)
+    val o1t: Option[immutable.List[Int]] = o1
+
+    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
+    val o2 = optionSequence(xs2)
+    val o2t: Option[immutable.TreeSet[String]] = o2
+
+    // Breakout-like use case from https://github.com/scala/scala/pull/5233:
+    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
+    val o4 = optionSequence(xs4)(BuildFrom.factory(immutable.TreeMap))
+    val o4t: Option[immutable.TreeMap[Int, String]] = o4
+  }
+
+  @Test
+  def eitherSequenceTest: Unit = {
+    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
+    val xs3t: mutable.ListBuffer[Either[Int, String]] = xs3
+    val e1 = eitherSequence(xs3)
+    val e1t: Either[Int, mutable.ListBuffer[String]] = e1
+  }
+
+}

--- a/src/test/scala/strawman/collection/test/UnfoldTest.scala
+++ b/src/test/scala/strawman/collection/test/UnfoldTest.scala
@@ -1,0 +1,98 @@
+package strawman
+package collection
+package test
+
+import strawman.collection.mutable.Builder
+
+import scala.{Int, None, Option, Some, Unit}
+import scala.Predef.implicitly
+import java.lang.String
+
+import org.junit.Test
+
+/**
+  * Builds a collection of type `C`.
+  *
+  * @tparam C Type of the collection to produce (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+  */
+trait Unfolder[C] {
+
+  val bt: BuildTo[C]
+
+  def apply[S](init: S)(f: S => Option[(bt.Elem, S)]) = {
+    val builder = bt.newBuilder()
+    var state = init
+    def loop(): Unit = {
+      f(state) match {
+        case Some((elem, newState)) =>
+          state = newState
+          builder += elem
+          loop()
+        case None => ()
+      }
+    }
+    builder.result
+  }
+
+}
+
+object Unfold {
+
+  /**
+    * @return An `Unfolder` instance for the target type `C`.
+    * @tparam C The collection type to build (e.g. `List[Int]`, `TreeMap[Int, String]`)
+    */
+  def apply[C](implicit _bt: BuildTo[C]): Unfolder[C] { val bt: _bt.type } =
+    new Unfolder[C] { val bt: _bt.type = _bt }
+
+}
+
+/** Auxiliary data type used to retrieve the element type `Elem` of a complete collection type `C` */
+trait BuildTo[C] {
+
+  type Elem
+
+  def newBuilder(): Builder[Elem, C]
+
+}
+
+object BuildTo {
+
+  /** Provides a `BuildTo` based on an available `CanBuild` for a unary collection type constructor */
+  implicit def unaryTC[CC[_], A](implicit cb: CanBuild[A, CC[A]]): BuildTo[CC[A]] { type Elem = A } =
+    new BuildTo[CC[A]] {
+      type Elem = A
+      def newBuilder(): Builder[A, CC[A]] = cb.newBuilder()
+    }
+
+  /** Provides a `BuildTo` based on an available `CanBuild` for a binary collection type constructor */
+  implicit def binaryTC[CC[_, _], A, B](implicit cb: CanBuild[(A, B), CC[A, B]]): BuildTo[CC[A, B]] { type Elem = (A, B) } =
+    new BuildTo[CC[A, B]] {
+      type Elem = (A, B)
+      def newBuilder(): Builder[(A, B), CC[A, B]] = cb.newBuilder()
+    }
+
+}
+
+
+class UnfoldTest {
+
+  @Test
+  def unfoldTest: Unit = {
+    implicitly[BuildTo[immutable.List[Int]]]
+    implicitly[BuildTo[immutable.TreeMap[Int, String]]]
+
+    val xs1 = Unfold[immutable.List[Int]].apply(0)(n => if (n < 10) Some((n, n + 1)) else None)
+    val xs2: immutable.List[Int] = xs1
+
+    val xs3 = Unfold[immutable.TreeSet[Int]].apply(0)(n => if (n < 10) Some((n, n + 1)) else None)
+    val xs4: immutable.TreeSet[Int] = xs3
+
+    val xs5 = Unfold[immutable.HashMap[Int, String]].apply(0)(_ => None)
+    val xs6: immutable.HashMap[Int, String] = xs5
+
+    val xs7 = Unfold[immutable.TreeMap[Int, String]].apply(0)(_ => None)
+    val xs8: immutable.TreeMap[Int, String] = xs7
+  }
+
+}


### PR DESCRIPTION
This PR addresses #65, #44, #34 and the comments made after we merged #76.

I tried to add as few things as possible to the core of the collections and checked that the problems described in the aforementioned issues could still be fixed.

In essence, all collection factories now provide an implicit `CanBuild[A, C]` instance, making it possible to get an imperative builder yielding a collection `C` containing elements of type `A`.