### PR TITLE
Harmonize factories

### DIFF
--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -1,39 +1,40 @@
 package strawman
 package collection
 
-import strawman.collection.mutable.Builder
-
 import scala.{Any, Int, Ordering, Nothing}
 import scala.annotation.unchecked.uncheckedVariance
 
-/** Base trait for instances that can construct an unconstrained collection from an iterable */
-trait FromIterable[+CC[_]] extends Any {
-  def fromIterable[E](it: Iterable[E]): CC[E]
-}
-
-object FromIterable {
-  implicit def toSpecific[A, CC[_]](fi: FromIterable[CC]): FromSpecificIterable[A, CC[A]] =
-    new FromSpecificIterable[A, CC[A]] {
-      def fromSpecificIterable(it: Iterable[A]): CC[A] = fi.fromIterable[A](it)
-    }
-}
-
+/**
+  * Builds a collection of type `C` from elements of type `A`
+  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+  */
 trait FromSpecificIterable[-A, +C] extends Any {
   def fromSpecificIterable(it: Iterable[A]): C
 }
 
 /** Base trait for companion objects of unconstrained collection types */
-trait IterableFactory[+CC[_]] extends FromIterable[CC] {
+trait IterableFactory[+CC[_]] {
+
+  def fromIterable[E](it: Iterable[E]): CC[E]
+
   def empty[A]: CC[A]
 
   def apply[A](xs: A*): CC[A] = fromIterable(View.Elems(xs: _*))
 
   def fill[A](n: Int)(elem: => A): CC[A] = fromIterable(View.Fill(n)(elem))
+
 }
 
 object IterableFactory {
+  import scala.language.implicitConversions
 
-  class Delegate[CC[_]](protected val delegate: IterableFactory[CC]) extends IterableFactory[CC] {
+  implicit def toSpecific[A, CC[_]](factory: IterableFactory[CC]): FromSpecificIterable[A, CC[A]] =
+    new FromSpecificIterable[A, CC[A]] {
+      def fromSpecificIterable(it: Iterable[A]): CC[A] = factory.fromIterable[A](it)
+    }
+
+  class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
     def empty[A]: CC[A] = delegate.empty
     def fromIterable[E](it: Iterable[E]): CC[E] = delegate.fromIterable(it)
   }
@@ -58,10 +59,11 @@ trait MapFactory[+CC[X, Y]] {
 }
 
 object MapFactory {
-  implicit def toSpecific[K, V, CC[X, Y]]
-      (fi: MapFactory[CC]): FromSpecificIterable[(K, V), CC[K, V]] =
+  import scala.language.implicitConversions
+
+  implicit def toSpecific[K, V, CC[X, Y]](factory: MapFactory[CC]): FromSpecificIterable[(K, V), CC[K, V]] =
     new FromSpecificIterable[(K, V), CC[K, V]] {
-      def fromSpecificIterable(it: Iterable[(K, V)]): CC[K, V] = fi.fromIterable[K, V](it)
+      def fromSpecificIterable(it: Iterable[(K, V)]): CC[K, V] = factory.fromIterable[K, V](it)
     }
 
   class Delegate[C[X, Y]](delegate: MapFactory[C]) extends MapFactory[C] {
@@ -71,19 +73,10 @@ object MapFactory {
 
 }
 
-trait OrderedFromIterable[+CC[_]] extends Any {
-  def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E]
-}
-
-object OrderedFromIterable {
-  implicit def toSpecific[A: Ordering, CC[_]](fi: OrderedFromIterable[CC]): FromSpecificIterable[A, CC[A]] =
-    new FromSpecificIterable[A, CC[A]] {
-      def fromSpecificIterable(it: Iterable[A]): CC[A] = fi.orderedFromIterable[A](it)
-    }
-}
-
 /** Base trait for companion objects of collections that require an implicit evidence */
-trait OrderedSetFactory[+CC[_]] extends OrderedFromIterable[CC] {
+trait OrderedIterableFactory[+CC[_]] {
+
+  def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E]
 
   def empty[A : Ordering]: CC[A]
 
@@ -92,9 +85,15 @@ trait OrderedSetFactory[+CC[_]] extends OrderedFromIterable[CC] {
   def fill[A : Ordering](n: Int)(elem: => A): CC[A] = orderedFromIterable(View.Fill(n)(elem))
 }
 
-object OrderedSetFactory {
+object OrderedIterableFactory {
+  import scala.language.implicitConversions
 
-  class Delegate[CC[_]](protected val delegate: OrderedSetFactory[CC]) extends OrderedSetFactory[CC] {
+  implicit def toSpecific[A: Ordering, CC[_]](factory: OrderedIterableFactory[CC]): FromSpecificIterable[A, CC[A]] =
+    new FromSpecificIterable[A, CC[A]] {
+      def fromSpecificIterable(it: Iterable[A]): CC[A] = factory.orderedFromIterable[A](it)
+    }
+
+  class Delegate[CC[_]](delegate: OrderedIterableFactory[CC]) extends OrderedIterableFactory[CC] {
     def empty[A : Ordering]: CC[A] = delegate.empty
     def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E] = delegate.orderedFromIterable(it)
   }
@@ -106,8 +105,23 @@ trait OrderedMapFactory[+CC[X, Y]] {
 
   def empty[K : Ordering, V]: CC[K, V]
 
-  def fromIterable[K : Ordering, V](it: Iterable[(K, V)]): CC[K, V]
+  def orderedFromIterable[K : Ordering, V](it: Iterable[(K, V)]): CC[K, V]
 
   def apply[K : Ordering, V](elems: (K, V)*): CC[K, V] =
-    fromIterable(elems.toStrawman)
+    orderedFromIterable(elems.toStrawman)
+}
+
+object OrderedMapFactory {
+  import scala.language.implicitConversions
+
+  implicit def toSpecific[K : Ordering, V, CC[_, _]](factory: OrderedMapFactory[CC]): FromSpecificIterable[(K, V), CC[K, V]] =
+    new FromSpecificIterable[(K, V), CC[K, V]] {
+      def fromSpecificIterable(it: Iterable[(K, V)]): CC[K, V] = factory.orderedFromIterable(it)
+    }
+
+  class Delegate[CC[_, _]](delegate: OrderedMapFactory[CC]) extends OrderedMapFactory[CC] {
+    def empty[K: Ordering, V]: CC[K, V] = delegate.empty[K, V]
+    def orderedFromIterable[K: Ordering, V](it: Iterable[(K, V)]): CC[K, V] = delegate.orderedFromIterable(it)
+  }
+
 }

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -88,14 +88,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
   def empty: C
 }
 
-object Set extends IterableFactory[Set] {
-  def empty[A <: Any]: Set[A] = immutable.Set.empty
-
-  def fromIterable[E](it: Iterable[E]): Set[E] =
-    it match {
-      case s: Set[E] => s
-      case _         => empty ++ it
-    }
+object Set extends IterableFactory.Delegate[Set](immutable.Set) {
 
   // Temporary, TODO move to MurmurHash3
   def setHash(xs: Set[_]): Int = unorderedHash(xs, "Set".##)

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -1,6 +1,8 @@
 package strawman
 package collection
 
+import strawman.collection.immutable.TreeMap
+
 import scala.Ordering
 
 /** Base type of sorted sets */
@@ -28,8 +30,4 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
     orderedMapFromIterable(View.Concat(coll, xs))
 }
 
-object SortedMap extends OrderedSetFactory[SortedSet] {
-  def empty[A : Ordering]: SortedSet[A] = immutable.SortedSet.empty
-  def orderedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.orderedFromIterable(it)
-}
-
+object SortedMap extends OrderedMapFactory.Delegate[SortedMap](TreeMap)

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -32,8 +32,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
   )
 }
 
-object SortedSet extends OrderedSetFactory[SortedSet] {
-  def empty[A : Ordering]: SortedSet[A] = immutable.SortedSet.empty
-  def orderedFromIterable[E : Ordering](it: Iterable[E]): SortedSet[E] = immutable.SortedSet.orderedFromIterable(it)
-}
-
+object SortedSet extends OrderedIterableFactory.Delegate[SortedSet](immutable.SortedSet)

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -112,7 +112,11 @@ sealed class ListSet[A]
   */
 object ListSet extends IterableFactory[ListSet] {
 
-  def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] = empty ++ it
+  def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] =
+    it match {
+      case ls: ListSet[E] => ls
+      case _ => empty ++ it
+    }
 
   @SerialVersionUID(5010379588739277132L)
   private object EmptyListSet extends ListSet[Any]

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -13,8 +13,4 @@ trait Seq[+A] extends Iterable[A]
 
 trait SeqOps[+A, +CC[A] <: Seq[A], +C] extends collection.SeqOps[A, CC, C]
 
-object Seq extends IterableFactory[Seq] {
-  def empty[A <: Any]: Seq[A] = List.empty[A]
-  def newBuilder[A <: Any]: Builder[A, Seq[A]] = List.newBuilder[A]
-  def fromIterable[E](it: collection.Iterable[E]): Seq[E] = List.fromIterable(it)
-}
+object Seq extends IterableFactory.Delegate[Seq](List)

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -48,7 +48,4 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
 
 }
 
-object Set extends IterableFactory[Set] {
-  def empty[A]: Set[A] = ListSet.empty
-  def fromIterable[E](it: strawman.collection.Iterable[E]): Set[E] = ListSet.fromIterable(it)
-}
+object Set extends IterableFactory.Delegate[Set](HashSet)

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -17,7 +17,4 @@ trait SortedSetOps[A,
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 
-object SortedSet extends OrderedSetFactory[SortedSet] {
-  def empty[A : Ordering]: SortedSet[A] = TreeSet.empty
-  def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): SortedSet[E] = TreeSet.orderedFromIterable(it)
-}
+object SortedSet extends OrderedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -39,10 +39,10 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   protected[this] def fromIterable[E](it: collection.Iterable[E]): Iterable[E] = List.fromIterable(it)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    TreeMap.fromIterable(coll)
+    TreeMap.orderedFromIterable(coll)
 
   protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
-    TreeMap.fromIterable(it)
+    TreeMap.orderedFromIterable(it)
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
@@ -104,7 +104,7 @@ object TreeMap extends OrderedMapFactory[TreeMap] {
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap()
 
-  def fromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
+  def orderedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     it match {
       case tm: TreeMap[K, V] => tm
       case _ => empty[K, V] ++ it

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -103,7 +103,7 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     else newSet(RB.delete(tree, elem))
 }
 
-object TreeSet extends OrderedSetFactory[TreeSet] {
+object TreeSet extends OrderedIterableFactory[TreeSet] {
 
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -135,11 +135,9 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
       for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
       new ArrayBuffer[B](array, array.length)
     }
-    else new ArrayBuffer[B] ++= coll
+    else Growable.fromIterable[B](empty, coll)
 
-  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
-
-  def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
+  def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -101,11 +101,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
-  def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet =
-    it match {
-      case bs: BitSet => bs
-      case _ => empty ++= it
-    }
+  def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = Growable.fromIterable(empty, it)
 
   def empty: BitSet = new BitSet()
 

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -60,3 +60,16 @@ trait Growable[-A] {
    */
   def clear(): Unit
 }
+
+object Growable {
+
+  /**
+    * Fills a `Growable` instance with the elements of a given iterable
+    * @param empty Instance to fill
+    * @param it Elements to add
+    * @tparam A Element type
+    * @return The filled instance
+    */
+  def fromIterable[A](empty: Growable[A], it: collection.Iterable[A]): empty.type = empty ++= it
+
+}

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -94,11 +94,7 @@ object HashMap extends MapFactory[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 
-  def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] =
-    it match {
-      case hm: HashMap[K, V] => hm
-      case _ => empty ++= it
-    }
+  def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] = Growable.fromIterable(empty[K, V], it)
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -78,11 +78,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] =
-    it match {
-      case hs: HashSet[B] => hs
-      case _ => empty[B] ++= it
-    }
+  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
 
   def empty[A]: HashSet[A] = new HashSet[A]
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -201,8 +201,12 @@ class ListBuffer[A]
 
 object ListBuffer extends IterableFactory[ListBuffer] {
 
-  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
-  def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
-  def empty[A <: Any]: ListBuffer[A] = new ListBuffer[A]
+  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] =
+    coll match {
+      case lb: ListBuffer[A] => lb
+      case _ => empty ++= coll
+    }
+
+  def empty[A]: ListBuffer[A] = new ListBuffer[A]
 
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -201,11 +201,7 @@ class ListBuffer[A]
 
 object ListBuffer extends IterableFactory[ListBuffer] {
 
-  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] =
-    coll match {
-      case lb: ListBuffer[A] => lb
-      case _ => empty ++= coll
-    }
+  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = Growable.fromIterable(empty[A], coll)
 
   def empty[A]: ListBuffer[A] = new ListBuffer[A]
 

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
     with collection.SortedSetOps[A, CC, C]
 
 object SortedSet
-  extends OrderedSetFactory.Delegate[SortedSet](TreeSet)
+  extends OrderedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -34,9 +34,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(ord)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.fromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.orderedFromIterable(coll)
 
-  protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.fromIterable(it)
+  protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.orderedFromIterable(it)
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
@@ -174,7 +174,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   */
 object TreeMap extends OrderedMapFactory[TreeMap] {
 
-  def fromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
+  def orderedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     it match {
       case tm: TreeMap[K, V] => tm
       case _ => empty[K, V] ++= it

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -175,10 +175,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 object TreeMap extends OrderedMapFactory[TreeMap] {
 
   def orderedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    it match {
-      case tm: TreeMap[K, V] => tm
-      case _ => empty[K, V] ++= it
-    }
+    Growable.fromIterable(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
 

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -179,10 +179,6 @@ object TreeSet extends OrderedIterableFactory[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
-  def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] =
-    it match {
-      case ts: TreeSet[E] => ts
-      case _ => empty[E] ++= it
-    }
+  def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.OrderedSetFactory
+import collection.OrderedIterableFactory
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
@@ -175,7 +175,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   * @author Lucien Pereira
   *
   */
-object TreeSet extends OrderedSetFactory[TreeSet] {
+object TreeSet extends OrderedIterableFactory[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 


### PR DESCRIPTION
- Removes the `FromIterable` trait, which was only inherited from `IterableFactory`, and harmonizes the names used in the `Factories.scala` file.
- Systematically uses delegate factories for abstract collections.
- Factors out the implementation of `fromIterable` for mutable collections (into a `Growable.fromIterable` method).