### PR TITLE
Expose factories

### DIFF
--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -21,9 +21,10 @@ class ArrayOps[A](val xs: Array[A])
 
   def elemTag: ClassTag[A] = ClassTag(xs.getClass.getComponentType)
 
+  def iterableFactory = immutable.Seq
+
   protected[this] def fromTaggedIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
   protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
-  protected[this] def fromIterable[B](coll: Iterable[B]): immutable.Seq[B] = immutable.Seq.fromIterable(coll)
 
   protected[this] def newBuilder = new ArrayBuffer[A].mapResult(_.toArray(elemTag))
 

--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -74,54 +74,54 @@ object MapFactory {
 }
 
 /** Base trait for companion objects of collections that require an implicit evidence */
-trait OrderedIterableFactory[+CC[_]] {
+trait SortedIterableFactory[+CC[_]] {
 
-  def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E]
+  def sortedFromIterable[E : Ordering](it: Iterable[E]): CC[E]
 
   def empty[A : Ordering]: CC[A]
 
-  def apply[A : Ordering](xs: A*): CC[A] = orderedFromIterable(View.Elems(xs: _*))
+  def apply[A : Ordering](xs: A*): CC[A] = sortedFromIterable(View.Elems(xs: _*))
 
-  def fill[A : Ordering](n: Int)(elem: => A): CC[A] = orderedFromIterable(View.Fill(n)(elem))
+  def fill[A : Ordering](n: Int)(elem: => A): CC[A] = sortedFromIterable(View.Fill(n)(elem))
 }
 
-object OrderedIterableFactory {
+object SortedIterableFactory {
   import scala.language.implicitConversions
 
-  implicit def toSpecific[A: Ordering, CC[_]](factory: OrderedIterableFactory[CC]): FromSpecificIterable[A, CC[A]] =
+  implicit def toSpecific[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): FromSpecificIterable[A, CC[A]] =
     new FromSpecificIterable[A, CC[A]] {
-      def fromSpecificIterable(it: Iterable[A]): CC[A] = factory.orderedFromIterable[A](it)
+      def fromSpecificIterable(it: Iterable[A]): CC[A] = factory.sortedFromIterable[A](it)
     }
 
-  class Delegate[CC[_]](delegate: OrderedIterableFactory[CC]) extends OrderedIterableFactory[CC] {
+  class Delegate[CC[_]](delegate: SortedIterableFactory[CC]) extends SortedIterableFactory[CC] {
     def empty[A : Ordering]: CC[A] = delegate.empty
-    def orderedFromIterable[E : Ordering](it: Iterable[E]): CC[E] = delegate.orderedFromIterable(it)
+    def sortedFromIterable[E : Ordering](it: Iterable[E]): CC[E] = delegate.sortedFromIterable(it)
   }
 
 }
 
 /** Factory methods for collections of kind `* −> * -> *` which require an implicit evidence value for the key type */
-trait OrderedMapFactory[+CC[X, Y]] {
+trait SortedMapFactory[+CC[X, Y]] {
 
   def empty[K : Ordering, V]: CC[K, V]
 
-  def orderedFromIterable[K : Ordering, V](it: Iterable[(K, V)]): CC[K, V]
+  def sortedFromIterable[K : Ordering, V](it: Iterable[(K, V)]): CC[K, V]
 
   def apply[K : Ordering, V](elems: (K, V)*): CC[K, V] =
-    orderedFromIterable(elems.toStrawman)
+    sortedFromIterable(elems.toStrawman)
 }
 
-object OrderedMapFactory {
+object SortedMapFactory {
   import scala.language.implicitConversions
 
-  implicit def toSpecific[K : Ordering, V, CC[_, _]](factory: OrderedMapFactory[CC]): FromSpecificIterable[(K, V), CC[K, V]] =
+  implicit def toSpecific[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]): FromSpecificIterable[(K, V), CC[K, V]] =
     new FromSpecificIterable[(K, V), CC[K, V]] {
-      def fromSpecificIterable(it: Iterable[(K, V)]): CC[K, V] = factory.orderedFromIterable(it)
+      def fromSpecificIterable(it: Iterable[(K, V)]): CC[K, V] = factory.sortedFromIterable(it)
     }
 
-  class Delegate[CC[_, _]](delegate: OrderedMapFactory[CC]) extends OrderedMapFactory[CC] {
+  class Delegate[CC[_, _]](delegate: SortedMapFactory[CC]) extends SortedMapFactory[CC] {
     def empty[K: Ordering, V]: CC[K, V] = delegate.empty[K, V]
-    def orderedFromIterable[K: Ordering, V](it: Iterable[(K, V)]): CC[K, V] = delegate.orderedFromIterable(it)
+    def sortedFromIterable[K: Ordering, V](it: Iterable[(K, V)]): CC[K, V] = delegate.sortedFromIterable(it)
   }
 
 }

--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -41,7 +41,7 @@ object IterableFactory {
     }
 
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
-    override def empty[A]: CC[A] = delegate.empty
+    def empty[A]: CC[A] = delegate.empty
     def fromIterable[E](it: Iterable[E]): CC[E] = delegate.fromIterable(it)
   }
 

--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -1,7 +1,9 @@
 package strawman
 package collection
 
-import scala.{Any, Int, Ordering, Nothing}
+import strawman.collection.mutable.Builder
+
+import scala.{Any, Int, Nothing, Ordering}
 import scala.annotation.unchecked.uncheckedVariance
 
 /**
@@ -24,6 +26,10 @@ trait IterableFactory[+CC[_]] {
 
   def fill[A](n: Int)(elem: => A): CC[A] = fromIterable(View.Fill(n)(elem))
 
+}
+
+trait IterableFactoryWithBuilder[+CC[_]] extends IterableFactory[CC] {
+  def newBuilder[A](): Builder[A, CC[A]]
 }
 
 object IterableFactory {

--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -18,7 +18,7 @@ trait IterableFactory[+CC[_]] {
 
   def fromIterable[E](it: Iterable[E]): CC[E]
 
-  def empty[A]: CC[A]
+  def empty[A]: CC[A] = fromIterable(View.Empty)
 
   def apply[A](xs: A*): CC[A] = fromIterable(View.Elems(xs: _*))
 
@@ -35,7 +35,7 @@ object IterableFactory {
     }
 
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
-    def empty[A]: CC[A] = delegate.empty
+    override def empty[A]: CC[A] = delegate.empty
     def fromIterable[E](it: Iterable[E]): CC[E] = delegate.fromIterable(it)
   }
 

--- a/src/main/scala/strawman/collection/Factories.scala
+++ b/src/main/scala/strawman/collection/Factories.scala
@@ -18,7 +18,7 @@ trait IterableFactory[+CC[_]] {
 
   def fromIterable[E](it: Iterable[E]): CC[E]
 
-  def empty[A]: CC[A] = fromIterable(View.Empty)
+  def empty[A]: CC[A]
 
   def apply[A](xs: A*): CC[A] = fromIterable(View.Elems(xs: _*))
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -29,8 +29,12 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
 trait IterableOps[+A, +CC[X], +C] extends Any {
 
   protected def coll: Iterable[A]
+
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
-  protected[this] def fromIterable[E](it: Iterable[E]): CC[E]
+
+  def iterableFactory: IterableFactory[CC]
+
+  protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.fromIterable(it)
 
   /** Apply `f` to each element for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -14,17 +14,17 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
   extends MapOps[K, V, Map, C]
      with SortedOps[K, C] {
 
-  protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2]
+  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2]
 
   def firstKey: K = head._1
   def lastKey: K = last._1
 
   // And finally, we add new overloads taking an ordering
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    orderedMapFromIterable(View.Map[(K, V), (K2, V2)](coll, f))
+    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](coll, f))
 
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    orderedMapFromIterable(View.FlatMap(coll, f))
+    sortedMapFromIterable(View.FlatMap(coll, f))
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
@@ -36,16 +36,16 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
     *  @return     a new collection of type `CC[K2, V2]` which contains all elements
     *              of this $coll followed by all elements of `xs`.
     */
-  def concat[K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = orderedMapFromIterable(View.Concat(coll, xs))
+  def concat[K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(coll, xs))
 
   /** Alias for `concat` */
   @`inline` final def ++ [K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
-  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = orderedMapFromIterable(View.Concat(coll, xs))
+  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(coll, xs))
   override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
   // TODO Also override mapValues
 
 }
 
-object SortedMap extends OrderedMapFactory.Delegate[SortedMap](TreeMap)
+object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap)

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -11,19 +11,19 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 
-  protected[this] def orderedFromIterable[B: Ordering](it: Iterable[B]): CC[B]
+  protected[this] def sortedFromIterable[B: Ordering](it: Iterable[B]): CC[B]
 
   def firstKey: A = head
   def lastKey: A = last
 
   /** Map */
-  def map[B : Ordering](f: A => B): CC[B] = orderedFromIterable(View.Map(coll, f))
+  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(coll, f))
 
   /** Flatmap */
-  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = orderedFromIterable(View.FlatMap(coll, f))
+  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(coll, f))
 
   /** Zip. Interesting because it requires to align to source collections. */
-  def zip[B](xs: IterableOnce[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = orderedFromIterable(View.Zip(coll, xs))
+  def zip[B](xs: IterableOnce[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = sortedFromIterable(View.Zip(coll, xs))
   // sound bcs of VarianceNote
 
   def collect[B: Ordering](pf: scala.PartialFunction[A, B]): CC[B] = flatMap(a =>
@@ -32,4 +32,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
   )
 }
 
-object SortedSet extends OrderedIterableFactory.Delegate[SortedSet](immutable.SortedSet)
+object SortedSet extends SortedIterableFactory.Delegate[SortedSet](immutable.SortedSet)

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -13,6 +13,8 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
 
   protected[this] def sortedFromIterable[B: Ordering](it: Iterable[B]): CC[B]
 
+  def iterableFactory: IterableFactory[Set]
+
   def firstKey: A = head
   def lastKey: A = last
 

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -13,8 +13,6 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
 
   protected[this] def sortedFromIterable[B: Ordering](it: Iterable[B]): CC[B]
 
-  def iterableFactory: IterableFactory[Set]
-
   def firstKey: A = head
   def lastKey: A = last
 

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -22,7 +22,7 @@ class StringOps(val s: String)
     sb.result
   }
 
-  protected[this] def fromIterable[E](coll: Iterable[E]): List[E] = List.fromIterable(coll)
+  def iterableFactory = List
 
   protected[this] def newBuilder = new StringBuilder
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -7,11 +7,8 @@ import scala.Predef.intWrapper
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   override def view = this
 
-  /** Avoid copying if source collection is already a view. */
-  override def fromIterable[B](c: Iterable[B]): View[B] = c match {
-    case c: View[B] => c
-    case _ => View.fromIterator(c.iterator())
-  }
+  def iterableFactory = View
+
   override protected[this] def fromSpecificIterable(coll: Iterable[A]): View[A] =
     fromIterable(coll)
 
@@ -19,10 +16,20 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
 }
 
 /** This object reifies operations on views as case classes */
-object View {
+object View extends IterableFactory[View] {
+
   def fromIterator[A](it: => Iterator[A]): View[A] = new View[A] {
     def iterator() = it
   }
+
+  /** Avoid copying if source collection is already a view. */
+  def fromIterable[E](it: Iterable[E]): View[E] = it match {
+    case it: View[E] => it
+    case _ => View.fromIterator(it.iterator())
+  }
+
+  override def empty[A]: View[A] = Empty
+  override def apply[A](xs: A*): View[A] = Elems(xs: _*)
 
   /** The empty view */
   case object Empty extends View[Nothing] {

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -28,7 +28,7 @@ object View extends IterableFactory[View] {
     case _ => View.fromIterator(it.iterator())
   }
 
-  override def empty[A]: View[A] = Empty
+  def empty[A]: View[A] = Empty
   override def apply[A](xs: A*): View[A] = Elems(xs: _*)
 
   /** The empty view */

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -29,7 +29,7 @@ sealed abstract class BitSet
   def iterableFactory = Set
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecificIterable(coll)
-  protected[this] def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.orderedFromIterable(it)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.sortedFromIterable(it)
 
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -26,7 +26,8 @@ sealed abstract class BitSet
 
   def empty: BitSet = BitSet.empty
 
-  protected[this] def fromIterable[B](coll: collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
+  def iterableFactory = Set
+
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecificIterable(coll)
   protected[this] def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.orderedFromIterable(it)
 

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -33,7 +33,7 @@ sealed trait HashMap[K, +V]
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}
 
-  protected[this] def fromIterable[E](it: collection.Iterable[E]): Iterable[E] = List.fromIterable(it)
+  def iterableFactory = List
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.fromIterable(coll)
 

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -60,7 +60,7 @@ object HashSet extends IterableFactory[HashSet] {
       case _ => empty ++ it
     }
 
-  override def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+  def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -30,7 +30,8 @@ sealed trait HashSet[A]
 
   import HashSet.nullToEmpty
 
-  protected[this] def fromIterable[B](coll: collection.Iterable[B]): HashSet[B] = HashSet.fromIterable(coll)
+  def iterableFactory = HashSet
+
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
@@ -59,7 +60,7 @@ object HashSet extends IterableFactory[HashSet] {
       case _ => empty ++ it
     }
 
-  def empty[A <: Any]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+  override def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -67,5 +67,5 @@ object LazyList extends IterableFactory[LazyList] {
 
   def newBuilder[A]: Builder[A, LazyList[A]] = ???
 
-  override def empty[A]: LazyList[A] = new LazyList[A](None)
+  def empty[A]: LazyList[A] = new LazyList[A](None)
 }

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -65,7 +65,5 @@ object LazyList extends IterableFactory[LazyList] {
   def fromIterator[A](it: Iterator[A]): LazyList[A] =
     new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
 
-  def newBuilder[A]: Builder[A, LazyList[A]] = ???
-
   def empty[A]: LazyList[A] = new LazyList[A](None)
 }

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -32,7 +32,8 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
-  protected[this] def fromIterable[B](coll: collection.Iterable[B]): LazyList[B] = LazyList.fromIterable(coll)
+  def iterableFactory = LazyList
+
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
 
   override def className = "LazyList"
@@ -66,5 +67,5 @@ object LazyList extends IterableFactory[LazyList] {
 
   def newBuilder[A]: Builder[A, LazyList[A]] = ???
 
-  def empty[A]: LazyList[A] = new LazyList[A](None)
+  override def empty[A]: LazyList[A] = new LazyList[A](None)
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -64,5 +64,5 @@ object List extends IterableFactory[List] {
 
   def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
-  override def empty[A <: Any]: List[A] = Nil
+  def empty[A]: List[A] = Nil
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -55,14 +55,14 @@ case object Nil extends List[Nothing] {
   override def tail: Nothing = throw new UnsupportedOperationException("tail of empty list")
 }
 
-object List extends IterableFactory[List] {
+object List extends IterableFactoryWithBuilder[List] {
 
   def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.fromIterable(coll).toList
   }
 
-  def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
+  def newBuilder[A](): Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
   def empty[A]: List[A] = Nil
 }

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -15,7 +15,8 @@ sealed trait List[+A]
      with SeqOps[A, List, List[A]]
      with Buildable[A, List[A]] {
 
-  protected[this] def fromIterable[B](c: collection.Iterable[B]): List[B] = List.fromIterable(c)
+  def iterableFactory = List
+
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): List[A] = fromIterable(coll)
 
   protected[this] def newBuilder = List.newBuilder[A]
@@ -63,6 +64,5 @@ object List extends IterableFactory[List] {
 
   def newBuilder[A]: Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
 
-  def empty[A <: Any]: List[A] = Nil
-
+  override def empty[A <: Any]: List[A] = Nil
 }

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -48,7 +48,7 @@ sealed class ListMap[K, +V]
      with MapOps[K, V, ListMap, ListMap[K, V]]
      with Serializable {
 
-  protected[this] def fromIterable[E](it: collection.Iterable[E]): Iterable[E] = List.fromIterable(it)
+  def iterableFactory = List
 
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ListMap[K2,V2] = ListMap.fromIterable(it)
 

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -122,7 +122,7 @@ object ListSet extends IterableFactory[ListSet] {
   private object EmptyListSet extends ListSet[Any]
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
-  override def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
+  def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -59,7 +59,7 @@ sealed class ListSet[A]
 
   def toSet[B >: A]: Set[B] = this.asInstanceOf[ListSet[B]]
 
-  protected[this] def fromIterable[B](coll: collection.Iterable[B]): ListSet[B] = ListSet.fromIterable(coll)
+  def iterableFactory = ListSet
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListSet[A] = fromIterable(coll)
 
   /**
@@ -122,7 +122,7 @@ object ListSet extends IterableFactory[ListSet] {
   private object EmptyListSet extends ListSet[Any]
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
-  def empty[A <: Any]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
+  override def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -13,12 +13,21 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
   extends MapOps[K, V, Map, C]
      with collection.SortedMapOps[K, V, CC, C] {
 
+    protected[this] def coll: CC[K, V]
+
     protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
       Map.fromIterable(it)
 
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]
     override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+
+    override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
+        var result: CC[K, V2] = coll
+        val it = xs.iterator()
+        while (it.hasNext) result = result + it.next()
+        result
+    }
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A,
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 
-object SortedSet extends OrderedIterableFactory.Delegate[SortedSet](TreeSet)
+object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -2,7 +2,7 @@ package strawman
 package collection
 package immutable
 
-import strawman.collection.OrderedMapFactory
+import strawman.collection.SortedMapFactory
 import strawman.collection.immutable.{RedBlackTree => RB}
 import strawman.collection.mutable.Builder
 
@@ -39,10 +39,10 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   def iterableFactory = List
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    TreeMap.orderedFromIterable(coll)
+    TreeMap.sortedFromIterable(coll)
 
-  protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
-    TreeMap.orderedFromIterable(it)
+  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
+    TreeMap.sortedFromIterable(it)
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
@@ -100,11 +100,11 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   *  @define Coll immutable.TreeMap
   *  @define coll immutable tree map
   */
-object TreeMap extends OrderedMapFactory[TreeMap] {
+object TreeMap extends SortedMapFactory[TreeMap] {
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap()
 
-  def orderedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
+  def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     it match {
       case tm: TreeMap[K, V] => tm
       case _ => empty[K, V] ++ it

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -36,7 +36,7 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
 
-  protected[this] def fromIterable[E](it: collection.Iterable[E]): Iterable[E] = List.fromIterable(it)
+  def iterableFactory = List
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
     TreeMap.orderedFromIterable(coll)

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -61,7 +61,7 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
 
   def keysIteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
-  protected[this] def fromIterable[B](coll: strawman.collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
+  def iterableFactory = Set
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
     TreeSet.orderedFromIterable(coll)

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -64,10 +64,10 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
   def iterableFactory = Set
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.orderedFromIterable(coll)
+    TreeSet.sortedFromIterable(coll)
 
-  protected[this] def orderedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.orderedFromIterable(coll)
+  protected[this] def sortedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
+    TreeSet.sortedFromIterable(coll)
 
   def unordered: Set[A] = this
 
@@ -103,11 +103,11 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     else newSet(RB.delete(tree, elem))
 }
 
-object TreeSet extends OrderedIterableFactory[TreeSet] {
+object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
-  def orderedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
+  def sortedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
     it match {
       case ts: TreeSet[E] => ts
       case _ => empty[E] ++ it

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -45,8 +45,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def iterator() = view.iterator()
 
-  protected[this] def fromIterable[B](it: collection.Iterable[B]): ArrayBuffer[B] =
-    ArrayBuffer.fromIterable(it)
+  def iterableFactory = ArrayBuffer
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ArrayBuffer[A] = fromIterable(coll)
 
@@ -135,10 +134,11 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
       for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
       new ArrayBuffer[B](array, array.length)
     }
-    else Growable.fromIterable[B](empty, coll)
+    else new ArrayBuffer[B] ++= coll
 
-  def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
+  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
+  override def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -138,7 +138,7 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
-  override def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
+  def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -124,7 +124,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   override def className = "ArrayBuffer"
 }
 
-object ArrayBuffer extends IterableFactory[ArrayBuffer] {
+object ArrayBuffer extends IterableFactoryWithBuilder[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
   def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
@@ -136,9 +136,9 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
     }
     else new ArrayBuffer[B] ++= coll
 
-  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
+  def newBuilder[A](): Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
-  def empty[A <: Any]: ArrayBuffer[A] = new ArrayBuffer[A]()
+  def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -36,8 +36,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   def iterableFactory = Set
 
-  protected[this] def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): collection.mutable.SortedSet[B] =
-    collection.mutable.SortedSet.orderedFromIterable(it)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): collection.mutable.SortedSet[B] =
+    collection.mutable.SortedSet.sortedFromIterable(it)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
     BitSet.fromSpecificIterable(coll)

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -34,8 +34,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   def this() = this(0)
 
-  def fromIterable[B](coll: collection.Iterable[B]): collection.mutable.Set[B] =
-    collection.mutable.Set.fromIterable(coll)
+  def iterableFactory = Set
 
   protected[this] def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): collection.mutable.SortedSet[B] =
     collection.mutable.SortedSet.orderedFromIterable(it)

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -79,5 +79,5 @@ object HashSet extends IterableFactory[HashSet] {
 
   def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
 
-  override def empty[A]: HashSet[A] = new HashSet[A]
+  def empty[A]: HashSet[A] = new HashSet[A]
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -31,8 +31,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   override def iterator(): Iterator[A] = table.iterator
 
-  protected[this] def fromIterable[B](coll: strawman.collection.Iterable[B]): HashSet[B] =
-    HashSet.fromIterable(coll)
+  def iterableFactory = HashSet
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
@@ -80,6 +79,5 @@ object HashSet extends IterableFactory[HashSet] {
 
   def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
 
-  def empty[A]: HashSet[A] = new HashSet[A]
-
+  override def empty[A]: HashSet[A] = new HashSet[A]
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -35,7 +35,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
-  protected[this] def newBuilder: Builder[A, HashSet[A]] = new GrowableBuilder[A, HashSet[A]](empty)
+  protected[this] def newBuilder: Builder[A, HashSet[A]] = HashSet.newBuilder[A]()
 
   def add(elem: A): this.type = {
     table.addElem(elem)
@@ -75,9 +75,12 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
 }
 
-object HashSet extends IterableFactory[HashSet] {
+object HashSet extends IterableFactoryWithBuilder[HashSet] {
 
   def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
 
   def empty[A]: HashSet[A] = new HashSet[A]
+
+  def newBuilder[A](): Builder[A, HashSet[A]] = new GrowableBuilder[A, HashSet[A]](empty)
+
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -26,7 +26,8 @@ class ListBuffer[A]
 
   def iterator() = first.iterator()
 
-  protected[this] def fromIterable[B](c: collection.Iterable[B]) = ListBuffer.fromIterable(c)
+  def iterableFactory = ListBuffer
+
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListBuffer[A] = fromIterable(coll)
 
   def apply(i: Int) = first.apply(i)
@@ -201,8 +202,9 @@ class ListBuffer[A]
 
 object ListBuffer extends IterableFactory[ListBuffer] {
 
-  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = Growable.fromIterable(empty[A], coll)
+  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
 
-  def empty[A]: ListBuffer[A] = new ListBuffer[A]
-
+  def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
+  
+  override def empty[A]: ListBuffer[A] = new ListBuffer[A]
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -200,11 +200,11 @@ class ListBuffer[A]
   override def className = "ListBuffer"
 }
 
-object ListBuffer extends IterableFactory[ListBuffer] {
+object ListBuffer extends IterableFactoryWithBuilder[ListBuffer] {
 
   def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
 
-  def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
+  def newBuilder[A](): Builder[A, ListBuffer[A]] = new ListBuffer[A]
   
   def empty[A]: ListBuffer[A] = new ListBuffer[A]
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -206,5 +206,5 @@ object ListBuffer extends IterableFactory[ListBuffer] {
 
   def newBuilder[A]: Builder[A, ListBuffer[A]] = new ListBuffer[A]
   
-  override def empty[A]: ListBuffer[A] = new ListBuffer[A]
+  def empty[A]: ListBuffer[A] = new ListBuffer[A]
 }

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -20,7 +20,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
 
   protected def coll: Map[K, V]
 
-  def fromIterable[B](coll: collection.Iterable[B]): Iterable[B] = Iterable.fromIterable(coll)
+  def iterableFactory = Iterable
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
     with collection.SortedSetOps[A, CC, C]
 
 object SortedSet
-  extends OrderedIterableFactory.Delegate[SortedSet](TreeSet)
+  extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.{Iterator, OrderedMapFactory}
+import collection.{Iterator, SortedMapFactory}
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
@@ -34,9 +34,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(ord)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.orderedFromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.sortedFromIterable(coll)
 
-  protected[this] def orderedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.orderedFromIterable(it)
+  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.sortedFromIterable(it)
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
@@ -172,9 +172,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   * @define Coll mutable.TreeMap
   * @define coll mutable tree map
   */
-object TreeMap extends OrderedMapFactory[TreeMap] {
+object TreeMap extends SortedMapFactory[TreeMap] {
 
-  def orderedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
+  def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     Growable.fromIterable(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.OrderedIterableFactory
+import collection.SortedIterableFactory
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
@@ -39,9 +39,9 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def iterator(): collection.Iterator[A] = RB.keysIterator(tree)
 
-  protected[this] def orderedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.orderedFromIterable(it)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.sortedFromIterable(it)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.orderedFromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.sortedFromIterable(coll)
 
   def iterableFactory = Set
 
@@ -175,10 +175,10 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   * @author Lucien Pereira
   *
   */
-object TreeSet extends OrderedIterableFactory[TreeSet] {
+object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
-  def orderedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
+  def sortedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -43,7 +43,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.orderedFromIterable(coll)
 
-  def fromIterable[B](coll: collection.Iterable[B]): Set[B] = Set.fromIterable(coll)
+  def iterableFactory = Set
 
   def keysIteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
 

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -49,7 +49,7 @@ class TraverseTest {
     val o1 = optionSequence1(xs1)
     val o1t: Option[immutable.List[Int]] = o1
 
-    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
+    val xs2: immutable.Set[Option[String]] = immutable.TreeSet(Some("foo"), Some("bar"), None)
     val o2 = optionSequence1(xs2)
     val o2t: Option[immutable.Set[String]] = o2
   }

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -1,26 +1,28 @@
-//package strawman
-//
-//package collection.test
-//
-//import org.junit.Test
-//import strawman.collection.Iterable
-//import strawman.collection.mutable.Builder
-//import strawman.collection._
-//
-//import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
-//import scala.Predef.ArrowAssoc
-//import scala.math.Ordering
-//import java.lang.String
-//
-//class TraverseTest {
-//
-//  // You can either overload methods for PolyBuildable and OrderedPolyBuildable (if you want to support ordered collection types)
-//  def optionSequence1[C[X] <: Iterable[X] with PolyBuildable[X, C], A](xs: C[Option[A]]): Option[C[A]] =
-//    xs.foldLeft[Option[Builder[A, C[A]]]](Some(xs.newBuilder)) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
+package strawman
+
+package collection.test
+
+import org.junit.Test
+import strawman.collection.Iterable
+import strawman.collection.mutable.{Builder, ArrayBuffer}
+import strawman.collection._
+
+import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
+import scala.Predef.ArrowAssoc
+import scala.math.Ordering
+import java.lang.String
+
+class TraverseTest {
+
+  // You can either overload methods for PolyBuildable and OrderedPolyBuildable (if you want to support ordered collection types)
+  def optionSequence1[C[X] <: Iterable[X] with IterableOps[X, C, _], A](xs: C[Option[A]]): Option[C[A]] =
+    xs.foldLeft[Option[ArrayBuffer[A]]](Some(new ArrayBuffer[A])) { (bo, xo) =>
+      (bo, xo) match {
+        case (Some(builder), Some(a)) => Some(builder += a)
+        case _ => None
+      }
+    }.map(_.to(xs.iterableFactory))
+
 //  def optionSequence1[CC[_], A](xs: OrderedPolyBuildable[Option[A], CC] with Iterable[Option[A]])(implicit ev: Ordering[A]): Option[CC[A]] =
 //    xs.foldLeft[Option[Builder[A, CC[A]]]](Some(xs.newOrderedBuilder)) {
 //      case (Some(builder), Some(a)) => Some(builder += a)
@@ -40,18 +42,18 @@
 //      case (Left(a)       ,        _) => Left(a)
 //      case (_             ,  Left(a)) => Left(a)
 //    }.right.map(_.result)
-//
-//  @Test
-//  def optionSequence1Test: Unit = {
-//    val xs1 = immutable.List(Some(1), None, Some(2))
-//    val o1 = optionSequence1(xs1)
-//    val o1t: Option[immutable.List[Int]] = o1
-//
-//    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-//    val o2 = optionSequence1(xs2)
-//    val o2t: Option[immutable.TreeSet[String]] = o2
-//  }
-//
+
+  @Test
+  def optionSequence1Test: Unit = {
+    val xs1 = immutable.List(Some(1), None, Some(2))
+    val o1 = optionSequence1(xs1)
+    val o1t: Option[immutable.List[Int]] = o1
+
+    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
+    val o2 = optionSequence1(xs2)
+    val o2t: Option[immutable.Set[String]] = o2
+  }
+
 //  def optionSequenceTest: Unit = {
 //    val xs1 = immutable.List(Some(1), None, Some(2))
 //    val o1 = optionSequence(xs1)
@@ -74,4 +76,5 @@
 //    val e1 = eitherSequence(xs3)
 //    val e1t: Either[Int, mutable.ListBuffer[String]] = e1
 //  }
-//}
+
+}

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -4,7 +4,7 @@ package collection.test
 
 import org.junit.Test
 import strawman.collection.Iterable
-import strawman.collection.mutable.{Builder, ArrayBuffer}
+import strawman.collection.mutable.{ArrayBuffer, Builder, Growable}
 import strawman.collection._
 
 import scala.{Any, Either, Int, Left, None, Option, Right, Some, Unit}
@@ -14,67 +14,40 @@ import java.lang.String
 
 class TraverseTest {
 
-  // You can either overload methods for PolyBuildable and OrderedPolyBuildable (if you want to support ordered collection types)
-  def optionSequence1[C[X] <: Iterable[X] with IterableOps[X, C, _], A](xs: C[Option[A]]): Option[C[A]] =
-    xs.foldLeft[Option[ArrayBuffer[A]]](Some(new ArrayBuffer[A])) { (bo, xo) =>
+  def optionSequence[CC[X] <: Iterable[X] with IterableOps[X, CC, _], A](xs: CC[Option[A]]): Option[CC[A]] = {
+    def folder[F[X] <: Growable[X]]: (Option[F[A]], Option[A]) => Option[F[A]] = { (bo, xo) =>
       (bo, xo) match {
         case (Some(builder), Some(a)) => Some(builder += a)
         case _ => None
       }
-    }.map(_.to(xs.iterableFactory))
-
-//  def optionSequence1[CC[_], A](xs: OrderedPolyBuildable[Option[A], CC] with Iterable[Option[A]])(implicit ev: Ordering[A]): Option[CC[A]] =
-//    xs.foldLeft[Option[Builder[A, CC[A]]]](Some(xs.newOrderedBuilder)) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
-//  // ...or use BuildFrom to abstract over both and also allow building arbitrary collection types
-//  def optionSequence[CC[X] <: Iterable[X], A](xs: CC[Option[A]])(implicit bf: BuildFrom[CC[Option[A]], A]): Option[bf.To] =
-//    xs.foldLeft[Option[Builder[A, bf.To]]](Some(bf.newBuilder(xs))) {
-//      case (Some(builder), Some(a)) => Some(builder += a)
-//      case _ => None
-//    }.map(_.result)
-//
-//  def eitherSequence[C[X] <: Iterable[X], A, B](xs: C[Either[A, B]])(implicit bf: BuildFrom[xs.type, B]): Either[A, bf.To] =
-//    xs.foldLeft[Either[A, Builder[B, bf.To]]](Right(bf.newBuilder(xs))) {
-//      case (Right(builder), Right(b)) => Right(builder += b)
-//      case (Left(a)       ,        _) => Left(a)
-//      case (_             ,  Left(a)) => Left(a)
-//    }.right.map(_.result)
+    }
+    val factory = xs.iterableFactory
+    factory match {
+      case iterableBuilder: IterableFactoryWithBuilder[CC] =>
+        xs.foldLeft[Option[Builder[A, CC[A]]]](
+          Some(iterableBuilder.newBuilder[A]())
+        )(
+          folder[({ type l[X] = Builder[X, CC[X]] })#l]
+        ).map(_.result)
+      case _ =>
+        xs.foldLeft[Option[ArrayBuffer[A]]](Some(new ArrayBuffer[A]))(folder).map(_.to(xs.iterableFactory))
+    }
+  }
 
   @Test
   def optionSequence1Test: Unit = {
     val xs1 = immutable.List(Some(1), None, Some(2))
-    val o1 = optionSequence1(xs1)
+    val o1 = optionSequence(xs1)
     val o1t: Option[immutable.List[Int]] = o1
 
     val xs2: immutable.Set[Option[String]] = immutable.TreeSet(Some("foo"), Some("bar"), None)
-    val o2 = optionSequence1(xs2)
+    val o2 = optionSequence(xs2)
     val o2t: Option[immutable.Set[String]] = o2
-  }
 
-//  def optionSequenceTest: Unit = {
-//    val xs1 = immutable.List(Some(1), None, Some(2))
-//    val o1 = optionSequence(xs1)
-//    val o1t: Option[immutable.List[Int]] = o1
-//
-//    val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
-//    val o2 = optionSequence(xs2)
-//    val o2t: Option[immutable.TreeSet[String]] = o2
-//
-//    // Breakout-like use case from https://github.com/scala/scala/pull/5233:
-//    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
-//    val o4 = optionSequence(xs4)(immutable.TreeMap) // same syntax as in `.to`
-//    val o4t: Option[immutable.TreeMap[Int, String]] = o4
-//  }
-//
-//  @Test
-//  def eitherSequenceTest: Unit = {
-//    val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
-//    val xs3t: mutable.ListBuffer[Either[Int, String]] = xs3
-//    val e1 = eitherSequence(xs3)
-//    val e1t: Either[Int, mutable.ListBuffer[String]] = e1
-//  }
+    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
+    val o4 = optionSequence(xs4)
+    val o4t: Option[immutable.List[(Int, String)]] = o4
+    val o5: Option[immutable.TreeMap[Int, String]] = o4.map(_.to(immutable.TreeMap))
+  }
 
 }


### PR DESCRIPTION
Every collection now has a `iterableFactory` method that returns the `IterableFactory` associated with the collection type. `fromIterable` now is defined only once in terms of `IterableFactory`. 

This lets us revive fully generic forms of `TraverseTest`.

We could go further and have a subset of Factories that have `newBuilder` methods. (Lazy collections should not offer such a method). We could then avoid using an intermediate collection in traverse test for the building, and instead use the builder of the target collection directly.

