### PR TITLE
In SortedMap, override the return type of map operations that are polymorphic in values only

### DIFF
--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -81,7 +81,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
   def concat [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = mapFromIterable(View.Concat(coll, xs))
 
   /** Alias for `concat` */
-  @`inline` final def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
+  /*@`inline` final*/ def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
 
 }
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -3,7 +3,7 @@ package collection
 
 import strawman.collection.immutable.TreeMap
 
-import scala.Ordering
+import scala.{`inline`, Ordering}
 
 /** Base type of sorted sets */
 trait SortedMap[K, +V]
@@ -26,8 +26,26 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
     orderedMapFromIterable(View.FlatMap(coll, f))
 
-  def ++[K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    orderedMapFromIterable(View.Concat(coll, xs))
+  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
+    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+    *  the element types of the two operands.
+    *
+    *  @param xs   the traversable to append.
+    *  @tparam K2  the type of the keys of the returned $coll.
+    *  @tparam V2  the type of the values of the returned $coll.
+    *  @return     a new collection of type `CC[K2, V2]` which contains all elements
+    *              of this $coll followed by all elements of `xs`.
+    */
+  def concat[K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = orderedMapFromIterable(View.Concat(coll, xs))
+
+  /** Alias for `concat` */
+  @`inline` final def ++ [K2 >: K, V2 >: V](xs: IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
+
+  // We override these methods to fix their return type (which would be `Map` otherwise)
+  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = orderedMapFromIterable(View.Concat(coll, xs))
+  override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
+  // TODO Also override mapValues
+
 }
 
 object SortedMap extends OrderedMapFactory.Delegate[SortedMap](TreeMap)

--- a/src/main/scala/strawman/collection/SortedOps.scala
+++ b/src/main/scala/strawman/collection/SortedOps.scala
@@ -5,7 +5,7 @@ import scala.{Ordering, Option, Some}
 /** Base trait for sorted collections */
 trait SortedOps[A, +C] {
 
-  def ordering: Ordering[A]
+  implicit def ordering: Ordering[A]
 
   /** Returns the first key of the collection. */
   def firstKey: A

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -48,7 +48,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, _], +C <: Map[
     * @tparam V1 the type of the value in the key/value pair.
     * @return A new map with the new binding added to this map.
     */
-  @`inline` final def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+  /*@`inline` final*/ def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
   override def concat [V1 >: V](that: collection.Iterable[(K, V1)]): CC[K, V1] = {
     var result: CC[K, V1] = coll

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -14,7 +14,11 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
      with collection.SortedMapOps[K, V, CC, C] {
 
     protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
-    Map.fromIterable(it)
+      Map.fromIterable(it)
+
+    // We override these methods to fix their return type (which would be `Map` otherwise)
+    def updated[V1 >: V](key: K, value: V1): CC[K, V1]
+    override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
 }
 

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -327,7 +327,7 @@ class StrawmanTest {
     val x1 = xs.get("foo")
     val x2: Option[Int] = x1
     val xs1 = xs + ("foo", 1)
-//    val xs2: immutable.SortedMap[String, Int] = xs1
+    val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
     // val xs4: immutable.Iterable[String] = xs3  // FIXME: does not work under dotty, we get a collection.Iterable
     val xs5 = xs.map ({ case (k, v) => (v, k) }: scala.PartialFunction[(String, Int), (Int, String)])
@@ -338,6 +338,8 @@ class StrawmanTest {
     val xs8: immutable.Map[Foo, Int] = xs7
     val xs9 = xs6.to(List).to(mutable.HashMap)
     val xs9t: mutable.HashMap[Int, String] = xs9
+    val xs10 = xs1 ++ xs2
+    val xs11: immutable.SortedMap[String, Int] = xs10
   }
 
   def bitSets(xs: immutable.BitSet, ys: BitSet, zs: Set[Int]): Unit = {


### PR DESCRIPTION
Fixes #81.