### PR TITLE
Add groupBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `foldLeft`
 - [x] `foldRight`
 - [x] `get`
+- [x] `getOrElse`
+- [x] `getOrElseUpdate`
 - [x] `head`
 - [x] `indexWhere`
 - [x] `isDefinedAt`
@@ -88,7 +90,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `drop`
 - [x] `empty`
 - [x] `filter` / `filterNot`
-- [ ] `groupBy`
+- [x] `groupBy`
 - [x] `intersect`
 - [x] `partition`
 - [x] `range`

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -59,4 +59,10 @@ class HashSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -87,4 +87,10 @@ class ImmutableArrayBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
@@ -79,4 +79,10 @@ class LazyListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -87,4 +87,10 @@ class ListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -57,4 +57,10 @@ class ScalaHashSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -87,4 +87,10 @@ class ScalaListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -59,4 +59,10 @@ class ScalaTreeSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -59,4 +59,10 @@ class TreeSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -78,4 +78,10 @@ class ArrayBufferBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -77,4 +77,10 @@ class ListBufferBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -226,6 +226,21 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def slice(from: Int, until: Int): C =
     fromSpecificIterable(View.Take(View.Drop(coll, from), until - from))
 
+  /** Partitions this $coll into a map of ${coll}s according to some discriminator function.
+    *
+    *  Note: When applied to a view or a lazy collection it will always force the elements.
+    *
+    *  @param f     the discriminator function.
+    *  @tparam K    the type of keys returned by the discriminator function.
+    *  @return      A map from keys to ${coll}s such that the following invariant holds:
+    *               {{{
+    *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
+    *               }}}
+    *               That is, every key `k` is bound to a $coll of those elements `x`
+    *               for which `f(x)` equals `k`.
+    *
+    */
+  def groupBy[K](f: A => K): immutable.Map[K, C]
 
   /** Map */
   def map[B](f: A => B): CC[B] = fromIterable(View.Map(coll, f))
@@ -266,6 +281,20 @@ trait Buildable[+A, +C] extends Any with IterableOps[A, AnyConstr, C]  {
     val l, r = newBuilder
     coll.iterator().foreach(x => (if (p(x)) l else r) += x)
     (l.result(), r.result())
+  }
+
+  def groupBy[K](f: A => K): immutable.Map[K, C] = {
+    val m = mutable.Map.empty[K, Builder[A, C]]
+    for (elem <- coll) {
+      val key = f(elem)
+      val bldr = m.getOrElseUpdate(key, newBuilder)
+      bldr += elem
+    }
+    var result = immutable.Map.empty[K, C]
+    m.foreach { case (k, v) =>
+      result = result + ((k, v.result))
+    }
+    result
   }
 
   // one might also override other transforms here to avoid generating

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -283,19 +283,8 @@ trait Buildable[+A, +C] extends Any with IterableOps[A, AnyConstr, C]  {
     (l.result(), r.result())
   }
 
-  def groupBy[K](f: A => K): immutable.Map[K, C] = {
-    val m = mutable.Map.empty[K, Builder[A, C]]
-    for (elem <- coll) {
-      val key = f(elem)
-      val bldr = m.getOrElseUpdate(key, newBuilder)
-      bldr += elem
-    }
-    var result = immutable.Map.empty[K, C]
-    m.foreach { case (k, v) =>
-      result = result + ((k, v.result))
-    }
-    result
-  }
+  def groupBy[K](f: A => K): immutable.Map[K, C] =
+    generic.GroupBy.strict(f, coll, () => newBuilder)
 
   // one might also override other transforms here to avoid generating
   // iterators if it helps efficiency.

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -27,6 +27,22 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     */
   def get(key: K): Option[V]
 
+  /**  Returns the value associated with a key, or a default value if the key is not contained in the map.
+   *   @param   key      the key.
+   *   @param   default  a computation that yields a default value in case no binding for `key` is
+   *                     found in the map.
+   *   @tparam  V1       the result type of the default computation.
+   *   @return  the value associated with `key` if it exists,
+   *            otherwise the result of the `default` computation.
+   *
+   *   @usecase def getOrElse(key: K, default: => V): V
+   *     @inheritdoc
+   */
+  def getOrElse[V1 >: V](key: K, default: => V1): V1 = get(key) match {
+    case Some(v) => v
+    case None => default
+  }
+
   /** Retrieves the value which is associated with the given key. This
     *  method invokes the `default` method of the map if there is no mapping
     *  from the given key to a value. Unless overridden, the `default` method throws a

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -1,6 +1,7 @@
 package strawman.collection
 
-import strawman.collection.mutable.ArrayBuffer
+import strawman.collection.immutable.ImmutableArray
+import strawman.collection.mutable.{ArrayBuffer, Builder}
 
 import scala.{Any, Boolean, Equals, Int, Nothing, annotation}
 import scala.Predef.intWrapper
@@ -17,15 +18,15 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   override def className = "View"
 
   def groupBy[K](f: (A) => K): immutable.Map[K, View[A]] = {
-    val m = mutable.Map.empty[K, ArrayBuffer[A]]
+    val m = mutable.Map.empty[K, Builder[A, ImmutableArray[A]]]
     for (elem <- coll) {
       val key = f(elem)
-      val bldr = m.getOrElseUpdate(key, ArrayBuffer.empty)
+      val bldr = m.getOrElseUpdate(key, ImmutableArray.newBuilder())
       bldr += elem
     }
     var result = immutable.Map.empty[K, View[A]]
     m.foreach { case (k, v) =>
-      result = result + ((k, v.view))
+      result = result + ((k, v.result().view))
     }
     result
   }

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -1,5 +1,7 @@
 package strawman.collection
 
+import strawman.collection.mutable.ArrayBuffer
+
 import scala.{Any, Boolean, Equals, Int, Nothing, annotation}
 import scala.Predef.intWrapper
 
@@ -13,6 +15,20 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
     fromIterable(coll)
 
   override def className = "View"
+
+  def groupBy[K](f: (A) => K): immutable.Map[K, View[A]] = {
+    val m = mutable.Map.empty[K, ArrayBuffer[A]]
+    for (elem <- coll) {
+      val key = f(elem)
+      val bldr = m.getOrElseUpdate(key, ArrayBuffer.empty)
+      bldr += elem
+    }
+    var result = immutable.Map.empty[K, View[A]]
+    m.foreach { case (k, v) =>
+      result = result + ((k, v.view))
+    }
+    result
+  }
 }
 
 /** This object reifies operations on views as case classes */

--- a/src/main/scala/strawman/collection/generic/GroupBy.scala
+++ b/src/main/scala/strawman/collection/generic/GroupBy.scala
@@ -1,0 +1,32 @@
+package strawman
+package collection
+package generic
+
+import strawman.collection.mutable.Builder
+
+object GroupBy {
+
+  /**
+    * Generic implementation of `groupBy` that relies on a `Builder`
+    * @param f Function that computes the key of an element
+    * @param coll Collection on which to apply the `groupBy`
+    * @param newBuilder Builder for groups
+    * @tparam A Type of elements
+    * @tparam K Type of keys
+    * @tparam C Type of the collection
+    */
+  def strict[A, K, C](f: A => K, coll: Iterable[A], newBuilder: () => Builder[A, C]): immutable.Map[K, C] = {
+    val m = mutable.Map.empty[K, Builder[A, C]]
+    for (elem <- coll) {
+      val key = f(elem)
+      val bldr = m.getOrElseUpdate(key, newBuilder())
+      bldr += elem
+    }
+    var result = immutable.Map.empty[K, C]
+    m.foreach { case (k, v) =>
+      result = result + ((k, v.result()))
+    }
+    result
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -70,9 +70,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   def empty: BitSet = new BitSet1(0L)
 
   def newBuilder(): Builder[Int, BitSet] =
-    new ImmutableBuilder[Int, BitSet](empty) {
-      def add(elem: Int): this.type = { elems = elems + elem; this }
-    }
+    mutable.BitSet.newBuilder().mapResult(bs => fromBitMaskNoCopy(bs.elems))
 
   private def createSmall(a: Long, b: Long): BitSet = if (b == 0L) new BitSet1(a) else new BitSet2(a, b)
 

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -1,12 +1,14 @@
 package strawman
 package collection.immutable
 
-import collection.{Iterator, MapFactory}
+import collection.{Buildable, Iterator, MapFactory}
 import collection.Hashing.{computeHash, keepBits}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, math, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, `inline`, math, sys}
 import java.lang.{Integer, String, System}
+
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 /** This class implements immutable maps using a hash trie.
   *
@@ -28,8 +30,9 @@ import java.lang.{Integer, String, System}
 @SerialVersionUID(2L)
 sealed trait HashMap[K, +V]
   extends Map[K, V]
-     with MapOps[K, V, HashMap, HashMap[K, V]]
-     with Serializable {
+    with MapOps[K, V, HashMap, HashMap[K, V]]
+    with Buildable[(K, V), HashMap[K, V]]
+    with Serializable {
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}
 
@@ -39,6 +42,8 @@ sealed trait HashMap[K, +V]
 
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] =
     HashMap.fromIterable(it)
+
+  protected[this] def newBuilder: Builder[(K, V @uV), HashMap[K, V]] = HashMap.newBuilder()
 
   def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
@@ -104,6 +109,11 @@ object HashMap extends MapFactory[HashMap] {
     it match {
       case hm: HashMap[K, V] => hm
       case _ => empty ++ it
+    }
+
+  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] =
+    new ImmutableBuilder[(K, V), HashMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   private[collection] abstract class Merger[A, B] {

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -2,10 +2,10 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 import Hashing.computeHash
 
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, `inline`, sys}
 import scala.Predef.assert
 import java.lang.Integer
 
@@ -25,14 +25,17 @@ import java.lang.Integer
 @SerialVersionUID(2L)
 sealed trait HashSet[A]
   extends Set[A]
-     with SetOps[A, HashSet, HashSet[A]]
-     with Serializable {
+    with SetOps[A, HashSet, HashSet[A]]
+    with Buildable[A, HashSet[A]]
+    with Serializable {
 
   import HashSet.nullToEmpty
 
   def iterableFactory = HashSet
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
+
+  protected[this] def newBuilder: Builder[A, HashSet[A]] = HashSet.newBuilder()
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
@@ -61,6 +64,11 @@ object HashSet extends IterableFactory[HashSet] {
     }
 
   def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+
+  def newBuilder[A](): Builder[A, HashSet[A]] =
+    new ImmutableBuilder[A, HashSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -1,7 +1,7 @@
 package strawman.collection.immutable
 
-import strawman.collection.mutable.ArrayBuffer
-import strawman.collection.{IterableFactory, IterableOnce, Iterator, View}
+import strawman.collection.mutable.{ArrayBuffer, Builder, ImmutableBuilder}
+import strawman.collection.{Buildable, IterableFactory, IterableOnce, Iterator, View}
 
 import scala.{Any, Boolean, Int, Nothing}
 import scala.runtime.ScalaRunTime
@@ -12,11 +12,16 @@ import scala.Predef.{???, intWrapper}
   *
   * Supports efficient indexed access and has a small memory footprint.
   */
-class ImmutableArray[+A] private (private val elements: scala.Array[Any]) extends IndexedSeq[A] with SeqOps[A, ImmutableArray, ImmutableArray[A]] {
+class ImmutableArray[+A] private (private val elements: scala.Array[Any])
+  extends IndexedSeq[A]
+    with IndexedSeqOps[A, ImmutableArray, ImmutableArray[A]]
+    with Buildable[A, ImmutableArray[A]] {
 
   def iterableFactory: IterableFactory[ImmutableArray] = ImmutableArray
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): ImmutableArray[A] = fromIterable(coll)
+
+  protected[this] def newBuilder: Builder[A, ImmutableArray[A]] = ImmutableArray.newBuilder()
 
   def length: Int = elements.length
 
@@ -87,6 +92,10 @@ object ImmutableArray extends IterableFactory[ImmutableArray] {
 
   def fromIterable[A](it: strawman.collection.Iterable[A]): ImmutableArray[A] =
     new ImmutableArray(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[Any]].toArray)
+
+  def newBuilder[A](): Builder[A, ImmutableArray[A]] =
+    ArrayBuffer.newBuilder[A]()
+      .mapResult(b => new ImmutableArray[A](b.asInstanceOf[ArrayBuffer[Any]].toArray))
 
   override def fill[A](n: Int)(elem: => A): ImmutableArray[A] = tabulate(n)(_ => elem)
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -36,6 +36,16 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
 
+  def groupBy[K](f: A => K): immutable.Map[K, LazyList[A]] = {
+    var result = immutable.Map.empty[K, LazyList[A]]
+    for (elem <- coll) {
+      val key = f(elem)
+      val values = elem #:: result.getOrElse(key, LazyList.Empty)
+      result = result + ((key, values))
+    }
+    result
+  }
+
   override def className = "LazyList"
 
   override def toString =
@@ -65,5 +75,6 @@ object LazyList extends IterableFactory[LazyList] {
   def fromIterator[A](it: Iterator[A]): LazyList[A] =
     new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
 
-  def empty[A]: LazyList[A] = new LazyList[A](None)
+  def empty[A]: LazyList[A] = Empty
+
 }

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -37,13 +37,13 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
 
   def groupBy[K](f: A => K): immutable.Map[K, LazyList[A]] = {
-    var result = immutable.Map.empty[K, LazyList[A]]
+    val m = mutable.Map.empty[K, LazyList[A]]
     for (elem <- coll) {
       val key = f(elem)
-      val values = elem #:: result.getOrElse(key, LazyList.Empty)
-      result = result + ((key, values))
+      val values = m.get(key).getOrElse(LazyList.Empty)
+      m += ((key, elem #:: values))
     }
-    result
+    m.to(immutable.Map)
   }
 
   override def className = "LazyList"

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -16,7 +16,7 @@ import scala.annotation.tailrec
 import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, sys}
 import java.lang.Integer
 
-import strawman.collection.mutable.Builder
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 /**
   * This class implements immutable maps using a list-based data structure. List map iterators and
@@ -45,8 +45,9 @@ import strawman.collection.mutable.Builder
 @SerialVersionUID(301002838095710379L)
 sealed class ListMap[K, +V]
   extends Map[K, V]
-     with MapOps[K, V, ListMap, ListMap[K, V]]
-     with Serializable {
+    with MapOps[K, V, ListMap, ListMap[K, V]]
+    with Buildable[(K, V), ListMap[K, V]]
+    with Serializable {
 
   def iterableFactory = List
 
@@ -57,6 +58,8 @@ sealed class ListMap[K, +V]
       case lm: ListMap[K, V] => lm
       case _ => ListMap.fromIterable(coll)
     }
+
+  protected[this] def newBuilder: Builder[(K, V), ListMap[K, V]] = ListMap.newBuilder()
 
   def empty: ListMap[K, V] = ListMap.empty[K, V]
 
@@ -165,6 +168,11 @@ object ListMap extends MapFactory[ListMap] {
     it match {
       case lm: ListMap[K, V] => lm
       case _ => empty ++ it
+    }
+
+  def newBuilder[K, V](): Builder[(K, V), ListMap[K, V]] =
+    new ImmutableBuilder[(K, V), ListMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -2,7 +2,8 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
+
 import scala.annotation.tailrec
 import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable}
 
@@ -31,8 +32,9 @@ import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Seria
 @SerialVersionUID(-8417059026623606218L)
 sealed class ListSet[A]
   extends Set[A]
-     with SetOps[A, ListSet, ListSet[A]]
-     with Serializable {
+    with SetOps[A, ListSet, ListSet[A]]
+    with Buildable[A, ListSet[A]]
+    with Serializable {
 
   override def size: Int = 0
   override def isEmpty: Boolean = true
@@ -61,6 +63,7 @@ sealed class ListSet[A]
 
   def iterableFactory = ListSet
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListSet[A] = fromIterable(coll)
+  protected[this] def newBuilder: Builder[A, ListSet[A]] = ListSet.newBuilder()
 
   /**
     * Represents an entry in the `ListSet`.
@@ -123,6 +126,11 @@ object ListSet extends IterableFactory[ListSet] {
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 
   def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
+
+  def newBuilder[A](): Builder[A, ListSet[A]] =
+    new ImmutableBuilder[A, ListSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -1,4 +1,5 @@
-package strawman.collection.immutable
+package strawman
+package collection.immutable
 
 import strawman.collection
 import strawman.collection.{IterableFactory, Iterator}
@@ -89,6 +90,9 @@ final class NumericRange[T](
       count += 1
     }
   }
+
+  def groupBy[K](f: T => K): Map[K, IndexedSeq[T]] =
+    collection.generic.GroupBy.strict(f, coll, () => ImmutableArray.newBuilder[T]())
 
   // TODO: these private methods are straight copies from Range, duplicated
   // to guard against any (most likely illusory) performance drop.  They should

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -138,6 +138,9 @@ final class Range(
     else start + (step * idx)
   }
 
+  def groupBy[K](f: (Int) => K): Map[K, IndexedSeq[Int]] =
+    collection.generic.GroupBy.strict(f, coll, () => ImmutableArray.newBuilder[Int]())
+
   /*@`inline`*/ override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.SortedMapFactory
 import strawman.collection.immutable.{RedBlackTree => RB}
-import strawman.collection.mutable.Builder
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 
@@ -32,6 +32,7 @@ import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
+    with Buildable[(K, V), TreeMap[K, V]]
     with Serializable {
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
@@ -43,6 +44,8 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
     TreeMap.sortedFromIterable(it)
+
+  protected[this] def newBuilder: Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
@@ -108,6 +111,11 @@ object TreeMap extends SortedMapFactory[TreeMap] {
     it match {
       case tm: TreeMap[K, V] => tm
       case _ => empty[K, V] ++ it
+    }
+
+  def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] =
+    new ImmutableBuilder[(K, V), TreeMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -28,6 +28,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
+    with Buildable[Int, BitSet]
     with Serializable {
 
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
@@ -41,6 +42,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
     BitSet.fromSpecificIterable(coll)
+
+  protected[this] def newBuilder: Builder[Int, BitSet] = BitSet.newBuilder()
 
   protected[collection] final def nwords: Int = elems.length
 
@@ -103,5 +106,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = Growable.fromIterable(empty, it)
 
   def empty: BitSet = new BitSet()
+
+  def newBuilder(): Builder[Int, BitSet] = new GrowableBuilder[Int, BitSet](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/HashTable.scala
+++ b/src/main/scala/strawman/collection/mutable/HashTable.scala
@@ -139,7 +139,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
   final def findEntry(key: A): Entry =
     findEntry0(key, index(elemHashCode(key)))
 
-  protected[this] final def findEntry0(key: A, h: Int): Entry = {
+  protected[collection] final def findEntry0(key: A, h: Int): Entry = {
     var e = table(h).asInstanceOf[Entry]
     while (e != null && !elemEquals(e.key, key)) e = e.next
     e
@@ -152,7 +152,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
     addEntry0(e, index(elemHashCode(e.key)))
   }
 
-  protected[this] final def addEntry0(e: Entry, h: Int): Unit = {
+  protected[collection] final def addEntry0(e: Entry, h: Int): Unit = {
     e.next = table(h).asInstanceOf[Entry]
     table(h) = e
     tableSize = tableSize + 1
@@ -363,7 +363,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
     * Note: we take the most significant bits of the hashcode, not the lower ones
     * this is of crucial importance when populating the table in parallel
     */
-  protected final def index(hcode: Int): Int = {
+  protected[collection] final def index(hcode: Int): Int = {
     val ones = table.length - 1
     val exponent = Integer.numberOfLeadingZeros(ones)
     (improve(hcode, seedvalue) >>> exponent) & ones
@@ -408,7 +408,7 @@ private[collection] object HashTable {
     // so that:
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
-    protected def elemHashCode(key: KeyType) = key.##
+    protected[collection] def elemHashCode(key: KeyType) = key.##
 
     /**
       * Defer to a high-quality hash in [[scala.util.hashing]].

--- a/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
@@ -1,0 +1,19 @@
+package strawman
+package collection
+package mutable
+
+import scala.Unit
+
+/**
+  * Reusable builder for immutable collections
+  */
+abstract class ImmutableBuilder[-A, C](empty: C)
+  extends ReusableBuilder[A, C] {
+
+  protected var elems: C = empty
+
+  def clear(): Unit = { elems = empty }
+
+  def result(): C = elems
+
+}

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -12,7 +12,7 @@ import scala.Predef.{assert, intWrapper}
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
-  extends Seq[A]
+  extends GrowableSeq[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]
      with Buildable[A, ListBuffer[A]]
      with Builder[A, ListBuffer[A]] {

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -4,7 +4,7 @@ package mutable
 
 import strawman.collection.{IterableOnce, MapFactory}
 
-import scala.{Boolean, Option, Unit, `inline`}
+import scala.{Boolean, None, Option, Some, Unit, `inline`}
 
 /** Base type of mutable Maps */
 trait Map[K, V]
@@ -46,6 +46,26 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @param value  The new value
     */
   def update(key: K, value: V): Unit = { coll += ((key, value)) }
+
+  /** If given key is already in this map, returns associated value.
+   *
+   *  Otherwise, computes value from given expression `op`, stores with key
+   *  in map and returns that value.
+   *
+   *  Concurrent map implementations may evaluate the expression `op`
+   *  multiple times, or may evaluate `op` without inserting the result.
+   *
+   *  @param  key the key to test
+   *  @param  op  the computation yielding the value to associate with `key`, if
+   *              `key` is previously unbound.
+   *  @return     the value associated with key (either previously or as a result
+   *              of executing the method).
+   */
+  def getOrElseUpdate(key: K, op: => V): V =
+    get(key) match {
+      case Some(v) => v
+      case None => val d = op; this(key) = d; d
+    }
 
   override def clone(): C = empty ++= coll
 

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.{Iterator, SortedMapFactory}
+import collection.{Buildable, Iterator, SortedMapFactory}
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
@@ -25,6 +25,7 @@ import java.lang.String
 sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
+    with Buildable[(K, V), TreeMap[K, V]]
     with Serializable {
 
   /**
@@ -37,6 +38,8 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.sortedFromIterable(coll)
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.sortedFromIterable(it)
+
+  protected[this] def newBuilder: Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
@@ -178,5 +181,7 @@ object TreeMap extends SortedMapFactory[TreeMap] {
     Growable.fromIterable(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
+
+  def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] = new GrowableBuilder[(K, V), TreeMap[K, V]](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -1,10 +1,10 @@
 package strawman
 package collection.mutable
 
-import collection.SortedIterableFactory
+import collection.{Buildable, SortedIterableFactory}
 import collection.mutable.{RedBlackTree => RB}
 
-import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
+import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 import java.lang.String
 
 /**
@@ -25,6 +25,7 @@ import java.lang.String
 sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
+    with Buildable[A, TreeSet[A]]
     with Serializable {
 
   if (ordering eq null)
@@ -42,6 +43,8 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.sortedFromIterable(it)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.sortedFromIterable(coll)
+
+  protected[this] def newBuilder: Builder[A, TreeSet[A]] = TreeSet.newBuilder()
 
   def iterableFactory = Set
 
@@ -180,5 +183,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
   def sortedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
+
+  def newBuilder[A : Ordering](): Builder[A, TreeSet[A]] = new GrowableBuilder[A, TreeSet[A]](empty)
 
 }


### PR DESCRIPTION
# Summary

- Add a `groupBy` method to `Iterable`
    - Three implementations: a generic implementation in `Buildable` (copied from the current collections), and custom implementations in `View` and `LazyList`
- Add `getOrElse` method to `Map`
- Add `getOrElseUpdate` method to `mutable.Map`
- Add a `newBuilder()` method to appropriate collection factories

# Discussion

The current (I mean, in the current collections) implementation of `groupBy` relies on an available `newBuilder` method.

In our strawman we didn’t have such builders so I wanted to experiment with different implementations.

I compared three implementations:
 - one based on builders (current implementation)
 - one for immutable collections, which depends on an `empty` and a `cons` method to build the groups
 - one for mutable collections, based on `Growable` to build the groups

I compared the implementations with collections (`List`, `ImmutableArray`, `HashSet` and `ArrayBuffer`) of various sizes (from 1 to 7,312,102), containing elements of type `Long`. The benchmark calls the `groupBy` method with the following function `x => x % 5`. (So, the result is a `Map` of 5 groups of equivalent size)

The benchmarks show that for immutable collections with more than 7 elements it’s faster to go with the current implementation.

For mutable collections, the approach based on `Growable`s has the same performance as the current implementation, and it has even slightly better performance on small collections (less than 4 elements).

Therefore, I decided to keep the same implementation as in the current collections (based on builders). We could override the implementation of mutable collections if you think it is worth it…

For reference, here are the different `groupBy` implementations, followed by the code of the benchmarks and the charts.

~~~ scala
// Implementation similar to what we have in the current collections
def groupByBuilder[A, K, C <: Iterable[A]](
  as: C
)(
  newBuilder: () => mutable.Builder[A, C]
)(
  f: A => K
): immutable.Map[K, C] = {
  val m = mutable.Map.empty[K, mutable.Builder[A, C]]
  for (elem <- as) {
    val key = f(elem)
    val bldr = m.getOrElseUpdate(key, newBuilder())
    bldr += elem
  }
  var result = immutable.Map.empty[K, C]
  m.foreach { case (k, v) =>
    result = result + ((k, v.result))
  }
  result
}

// Alternative implementation for immutable collections
// Note that the `cons` function can either prepend or
// append the new value (we don’t guarantee to preserve
// the order of elements within groups)
def groupByImmutable[A, K, C <: Iterable[A]](
  as: C
)(
  empty: C, cons: (A, C) => C
)(
  f: A => K
): immutable.Map[K, C] = {
  var result = immutable.Map.empty[K, C]
  for (elem <- as) {
    val key = f(elem)
    val values = cons(elem, result.getOrElse(key, empty))
    result = result + ((key, values))
  }
  result
}

// Alternative implementation for growable collections
def groupByGrowable[A, K, C <: Iterable[A] with mutable.Growable[A]](
  as: C
)(
  empty: () => C
)(
  f: A => K
): immutable.Map[K, C] = {
  var result = immutable.Map.empty[K, C]
  for (elem <- as) {
    val key = f(elem)
    result.get(key) match {
      case None =>
        val values = empty()
        values += elem
        result = result + ((key, values))
      case Some(values) =>
        values += elem
    }
  }
  result
}
~~~

~~~ scala
object ListGroupByImmutable {
  @Benchmark
  def listGroupBy(bh: Blackhole): Unit = {
    val result = GroupBys.groupByImmutable[Long, Long, List[Long]](xs)(Nil, _ :: _)(_ % 5)
    bh.consume(result)
  }
}

object ListGroupByBuilder {
  @Benchmark
  def listGroupBy(bh: Blackhole): Unit = {
    val result = GroupBys.groupByBuilder[Long, Long, List[Long]](xs)(() => List.newBuilder())(_ % 5)
    bh.consume(result)
  }
}
~~~

![listgroupby](https://user-images.githubusercontent.com/332812/26979804-694c0f52-4d30-11e7-8c7e-22238fb38f1a.png)

![immutablearraygroupby](https://user-images.githubusercontent.com/332812/26979811-6eb4959a-4d30-11e7-8db0-b21106646b1e.png)

![hashsetgroupby](https://user-images.githubusercontent.com/332812/26979816-735e06b2-4d30-11e7-89a4-4d388bbee3f5.png)

![arraybuffergroupby](https://user-images.githubusercontent.com/332812/26979822-7a4d248a-4d30-11e7-8b40-e9cb5f435f14.png)

![mutablehashsetgroupby](https://user-images.githubusercontent.com/332812/26979827-7fdef252-4d30-11e7-8455-242c49b9912d.png)