### PR TITLE
Pull up the newBuilder method from Buildable to IterableOps.

### DIFF
--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -1,9 +1,9 @@
 package strawman
 package collection
 
-import scala.{Array, Char, Int, AnyVal}
+import scala.{AnyVal, Array, Char, Int}
 import scala.Predef.???
-import mutable.ArrayBuffer
+import mutable.{ArrayBuffer, GrowableBuilder}
 
 import scala.reflect.ClassTag
 
@@ -27,7 +27,7 @@ class ArrayOps[A](val xs: Array[A])
   protected[this] def fromTaggedIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
   protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
 
-  protected[this] def newSpecificBuilder() = new ArrayBuffer[A].mapResult(_.toArray(elemTag))
+  protected[this] def newSpecificBuilder() = new GrowableBuilder(ArrayBuffer.empty[A]).mapResult(_.toArray(elemTag))
 
   override def knownSize = xs.length
 

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -6,13 +6,14 @@ import scala.Predef.???
 import mutable.ArrayBuffer
 
 import scala.reflect.ClassTag
+
 class ArrayOps[A](val xs: Array[A])
   extends AnyVal
-     with SeqOps[A, immutable.Seq, Array[A]]  // should be IndexedSeq once we have an instance type
-     with Buildable[A, Array[A]]
-     with ArrayLike[A] {
+    with SeqOps[A, immutable.IndexedSeq, Array[A]]
+    with StrictOptimizedIterableOps[A, Array[A]]
+    with ArrayLike[A] {
 
-  protected def coll = new ArrayView(xs)
+  protected[this] def coll = new ArrayView(xs)
 
   def length = xs.length
   def apply(i: Int) = xs.apply(i)
@@ -21,12 +22,12 @@ class ArrayOps[A](val xs: Array[A])
 
   def elemTag: ClassTag[A] = ClassTag(xs.getClass.getComponentType)
 
-  def iterableFactory = immutable.Seq
+  def iterableFactory = immutable.IndexedSeq
 
   protected[this] def fromTaggedIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
   protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
 
-  protected[this] def newBuilder = new ArrayBuffer[A].mapResult(_.toArray(elemTag))
+  protected[this] def newSpecificBuilder() = new ArrayBuffer[A].mapResult(_.toArray(elemTag))
 
   override def knownSize = xs.length
 

--- a/src/main/scala/strawman/collection/BitSet.scala
+++ b/src/main/scala/strawman/collection/BitSet.scala
@@ -12,7 +12,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] {
   import BitSetOps._
 
-  protected def coll: C
+  protected[this] def coll: C
 
   final def ordering: Ordering[Int] = Ordering.Int
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -13,7 +13,8 @@ import java.lang.String
 trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterable[A]] {
 
   /** The collection itself */
-  protected def coll: this.type = this
+  protected[this] def coll: this.type = this
+
 }
 
 /** Base trait for Iterable operations
@@ -28,13 +29,23 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   */
 trait IterableOps[+A, +CC[X], +C] extends Any {
 
-  protected def coll: Iterable[A]
+  protected[this] def coll: Iterable[A]
 
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
 
+  protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.fromIterable(it)
+
   def iterableFactory: IterableFactory[CC]
 
-  protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.fromIterable(it)
+  /**
+    * @return a strict builder for the same collection type.
+    *
+    * Note that in the case of lazy collections (e.g. [[View]] or [[immutable.LazyList]]),
+    * it is possible to implement this method but the resulting `Builder` will break laziness.
+    * As a consequence, operations should preferably be implemented on top of views rather
+    * than builders.
+    */
+  protected[this] def newSpecificBuilder(): Builder[A, C]
 
   /** Apply `f` to each element for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
@@ -93,7 +104,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *      xs.to(ArrayBuffer)
     *      xs.to(BitSet) // for xs: Iterable[Int]
     */
-  def to[C](f: FromSpecificIterable[A, C]): C = f.fromSpecificIterable(coll)
+  def to[C1](f: FromSpecificIterable[A, C1]): C1 = f.fromSpecificIterable(coll)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =
@@ -251,25 +262,3 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def zip[B](xs: IterableOnce[B]): CC[(A @uncheckedVariance, B)] = fromIterable(View.Zip(coll, xs))
   // sound bcs of VarianceNote
 }
-
-/** Base trait for strict collections that can be built using a builder.
-  * @tparam  A    the element type of the collection
-  * @tparam C  the type of the underlying collection
-  */
-trait Buildable[+A, +C] extends Any with IterableOps[A, AnyConstr, C]  {
-
-  /** Creates a new builder. */
-  protected[this] def newBuilder: Builder[A, C]
-
-  /** Optimized, push-based version of `partition`. */
-  override def partition(p: A => Boolean): (C, C) = {
-    val l, r = newBuilder
-    coll.iterator().foreach(x => (if (p(x)) l else r) += x)
-    (l.result(), r.result())
-  }
-
-  // one might also override other transforms here to avoid generating
-  // iterators if it helps efficiency.
-}
-
-

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -14,7 +14,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
   extends IterableOps[(K, V), Iterable, C]
      with PartialFunction[K, V] {
 
-  protected def coll: Map[K, V]
+  protected[this] def coll: Map[K, V]
 
   /** Similar to fromIterable, but returns a Map collection type */
   protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): CC[K2, V2]
@@ -85,4 +85,4 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
 
 }
 
-object Map extends MapFactory.Delegate[Map](immutable.Map)
+object Map extends MapFactoryWithBuilder.Delegate[Map](immutable.Map)

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -78,7 +78,7 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
 /** Base trait for linear Seq operations */
 trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any with SeqOps[A, CC, C] {
 
-  protected def coll: Seq[A]
+  protected[this] def coll: Seq[A]
 
   /** To be overridden in implementations: */
   def isEmpty: Boolean

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -14,7 +14,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
      with (A => Boolean)
      with Equals {
 
-  protected def coll: C
+  protected[this] def coll: C
 
   def contains(elem: A): Boolean
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -48,4 +48,4 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
 
 }
 
-object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap)
+object SortedMap extends SortedMapFactoryWithBuilder.Delegate[SortedMap](TreeMap)

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -32,4 +32,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
   )
 }
 
-object SortedSet extends SortedIterableFactory.Delegate[SortedSet](immutable.SortedSet)
+object SortedSet extends SortedIterableFactoryWithBuilder.Delegate[SortedSet](immutable.SortedSet)

--- a/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -13,8 +13,6 @@ trait StrictOptimizedIterableOps[+A, +C]
   extends Any
     with IterableOps[A, AnyConstr, C] {
 
-  // def iterableFactory: IterableFactoryWithBuilder[CC]
-
   /** Optimized, push-based version of `partition`. */
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder()

--- a/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -1,0 +1,28 @@
+package strawman
+package collection
+
+import scala.{Any, Boolean}
+
+/**
+  * Trait that overrides operations to take advantage of strict builders.
+  *
+  * @tparam A  Elements type
+  * @tparam C  Collection type
+  */
+trait StrictOptimizedIterableOps[+A, +C]
+  extends Any
+    with IterableOps[A, AnyConstr, C] {
+
+  // def iterableFactory: IterableFactoryWithBuilder[CC]
+
+  /** Optimized, push-based version of `partition`. */
+  override def partition(p: A => Boolean): (C, C) = {
+    val l, r = newSpecificBuilder()
+    coll.iterator().foreach(x => (if (p(x)) l else r) += x)
+    (l.result(), r.result())
+  }
+
+  // one might also override other transforms here to avoid generating
+  // iterators if it helps efficiency.
+
+}

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -11,10 +11,10 @@ import scala.reflect.ClassTag
 class StringOps(val s: String)
   extends AnyVal
      with SeqOps[Char, Seq, String]
-     with Buildable[Char, String]
+     with StrictOptimizedIterableOps[Char, String]
      with ArrayLike[Char] {
 
-  protected def coll = new StringView(s)
+  protected[this] def coll = new StringView(s)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder
@@ -24,7 +24,7 @@ class StringOps(val s: String)
 
   def iterableFactory = List
 
-  protected[this] def newBuilder = new StringBuilder
+  protected[this] def newSpecificBuilder() = new StringBuilder
 
   def length = s.length
   def apply(i: Int) = s.charAt(i)

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -1,5 +1,7 @@
 package strawman.collection
 
+import strawman.collection.mutable.Builder
+
 import scala.{Any, Boolean, Equals, Int, Nothing, annotation}
 import scala.Predef.intWrapper
 
@@ -9,8 +11,10 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
 
   def iterableFactory = View
 
-  override protected[this] def fromSpecificIterable(coll: Iterable[A]): View[A] =
-    fromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: Iterable[A]): View[A] = fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, View[A]] =
+    immutable.IndexedSeq.newBuilder().mapResult(_.view)
 
   override def className = "View"
 }

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -3,7 +3,7 @@ package collection
 package immutable
 
 import BitSetOps.{LogWL, updateArray}
-import mutable.Builder
+import mutable.{Builder, GrowableBuilder}
 
 import scala.{Array, Boolean, Int, Long, Ordering, SerialVersionUID, Serializable, Unit}
 import scala.Predef.require
@@ -95,7 +95,7 @@ object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
   def empty: BitSet = new BitSet1(0L)
 
   def newBuilder(): Builder[Int, BitSet] =
-    mutable.BitSet.newBuilder().mapResult(bs => fromBitMaskNoCopy(bs.elems))
+    new GrowableBuilder(mutable.BitSet.empty).mapResult(bs => fromBitMaskNoCopy(bs.elems))
 
   @SerialVersionUID(2260107458435649300L)
   class BitSet1(val elems: Long) extends BitSet {

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -22,6 +22,7 @@ sealed abstract class BitSet
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
+    with StrictOptimizedIterableOps[Int, BitSet]
     with Serializable {
 
   def empty: BitSet = BitSet.empty
@@ -30,7 +31,7 @@ sealed abstract class BitSet
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecificIterable(coll)
   protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.sortedFromIterable(it)
-
+  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 
@@ -58,7 +59,7 @@ sealed abstract class BitSet
   protected def updateWord(idx: Int, w: Long): BitSet
 }
 
-object BitSet extends SpecificIterableFactory[Int, BitSet] {
+object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
 
   def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet =
     it match {
@@ -92,6 +93,9 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 
   def empty: BitSet = new BitSet1(0L)
+
+  def newBuilder(): Builder[Int, BitSet] =
+    mutable.BitSet.newBuilder().mapResult(bs => fromBitMaskNoCopy(bs.elems))
 
   @SerialVersionUID(2260107458435649300L)
   class BitSet1(val elems: Long) extends BitSet {

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -1,12 +1,14 @@
 package strawman
 package collection.immutable
 
-import collection.{Iterator, MapFactory}
+import collection.{Iterator, MapFactory, MapFactoryWithBuilder, StrictOptimizedIterableOps}
 import collection.Hashing.{computeHash, keepBits}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, math, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Unit, `inline`, math, sys}
 import java.lang.{Integer, String, System}
+
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 /** This class implements immutable maps using a hash trie.
   *
@@ -28,8 +30,9 @@ import java.lang.{Integer, String, System}
 @SerialVersionUID(2L)
 sealed trait HashMap[K, +V]
   extends Map[K, V]
-     with MapOps[K, V, HashMap, HashMap[K, V]]
-     with Serializable {
+    with MapOps[K, V, HashMap, HashMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), HashMap[K, V]]
+    with Serializable {
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}
 
@@ -39,6 +42,8 @@ sealed trait HashMap[K, +V]
 
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] =
     HashMap.fromIterable(it)
+
+  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
 
   def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
@@ -96,7 +101,7 @@ sealed trait HashMap[K, +V]
 
 }
 
-object HashMap extends MapFactory[HashMap] {
+object HashMap extends MapFactoryWithBuilder[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = EmptyHashMap.asInstanceOf[HashMap[K, V]]
 
@@ -104,6 +109,11 @@ object HashMap extends MapFactory[HashMap] {
     it match {
       case hm: HashMap[K, V] => hm
       case _ => empty ++ it
+    }
+
+  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] =
+    new ImmutableBuilder[(K, V), HashMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   private[collection] abstract class Merger[A, B] {

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -2,10 +2,10 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
 import Hashing.computeHash
 
-import scala.{Any, AnyRef, Array, Boolean, `inline`, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable, Unit, `inline`, sys}
 import scala.Predef.assert
 import java.lang.Integer
 
@@ -25,14 +25,17 @@ import java.lang.Integer
 @SerialVersionUID(2L)
 sealed trait HashSet[A]
   extends Set[A]
-     with SetOps[A, HashSet, HashSet[A]]
-     with Serializable {
+    with SetOps[A, HashSet, HashSet[A]]
+    with StrictOptimizedIterableOps[A, HashSet[A]]
+    with Serializable {
 
   import HashSet.nullToEmpty
 
   def iterableFactory = HashSet
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder()
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
@@ -52,7 +55,7 @@ sealed trait HashSet[A]
 
 }
 
-object HashSet extends IterableFactory[HashSet] {
+object HashSet extends IterableFactoryWithBuilder[HashSet] {
 
   def fromIterable[A](it: collection.Iterable[A]): HashSet[A] =
     it match {
@@ -61,6 +64,11 @@ object HashSet extends IterableFactory[HashSet] {
     }
 
   def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]
+
+  def newBuilder[A](): Builder[A, HashSet[A]] =
+    new ImmutableBuilder[A, HashSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 
   private object EmptyHashSet extends HashSet[Any] {
 

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -1,6 +1,6 @@
 package strawman.collection.immutable
 
-import strawman.collection.mutable.{ArrayBuffer, Builder}
+import strawman.collection.mutable.{ArrayBuffer, Builder, GrowableBuilder}
 import strawman.collection.{IterableFactory, IterableFactoryWithBuilder, IterableOnce, Iterator, StrictOptimizedIterableOps, View}
 
 import scala.{Any, Boolean, Int, Nothing}
@@ -95,7 +95,7 @@ object ImmutableArray extends IterableFactoryWithBuilder[ImmutableArray] {
     new ImmutableArray(ArrayBuffer.fromIterable(it).asInstanceOf[ArrayBuffer[Any]].toArray)
 
   def newBuilder[A](): Builder[A, ImmutableArray[A]] =
-    ArrayBuffer.newBuilder[A]()
+    new GrowableBuilder(ArrayBuffer.empty[A])
       .mapResult(b => new ImmutableArray[A](b.asInstanceOf[ArrayBuffer[Any]].toArray))
 
   override def fill[A](n: Int)(elem: => A): ImmutableArray[A] = tabulate(n)(_ => elem)

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -36,6 +36,9 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
 
+  protected[this] def newSpecificBuilder(): Builder[A, LazyList[A]] =
+    IndexedSeq.newBuilder().mapResult(_.to(LazyList))
+
   override def className = "LazyList"
 
   override def toString =

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -13,13 +13,13 @@ sealed trait List[+A]
   extends Seq[A]
      with LinearSeq[A]
      with SeqOps[A, List, List[A]]
-     with Buildable[A, List[A]] {
+     with StrictOptimizedIterableOps[A, List[A]] {
 
   def iterableFactory = List
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): List[A] = fromIterable(coll)
 
-  protected[this] def newBuilder = List.newBuilder[A]()
+  protected[this] def newSpecificBuilder() = List.newBuilder[A]()
 
   @tailrec final def length: Int = if (isEmpty) 0 else tail.length
 

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -4,8 +4,8 @@ package immutable
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
-import scala.{Any, Boolean, NoSuchElementException, Nothing, UnsupportedOperationException, Int}
-import mutable.{Builder, ListBuffer}
+import scala.{Any, Boolean, Int, NoSuchElementException, Nothing, UnsupportedOperationException}
+import mutable.{Builder, GrowableBuilder, ListBuffer}
 
 
 /** Concrete collection type: List */
@@ -62,7 +62,7 @@ object List extends IterableFactoryWithBuilder[List] {
     case _ => ListBuffer.fromIterable(coll).toList
   }
 
-  def newBuilder[A](): Builder[A, List[A]] = new ListBuffer[A].mapResult(_.toList)
+  def newBuilder[A](): Builder[A, List[A]] = new GrowableBuilder(ListBuffer.empty[A]).mapResult(_.toList)
 
   def empty[A]: List[A] = Nil
 }

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -2,7 +2,8 @@ package strawman
 package collection
 package immutable
 
-import mutable.Builder
+import mutable.{Builder, ImmutableBuilder}
+
 import scala.annotation.tailrec
 import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Serializable}
 
@@ -31,8 +32,9 @@ import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Seria
 @SerialVersionUID(-8417059026623606218L)
 sealed class ListSet[A]
   extends Set[A]
-     with SetOps[A, ListSet, ListSet[A]]
-     with Serializable {
+    with SetOps[A, ListSet, ListSet[A]]
+    with StrictOptimizedIterableOps[A, ListSet[A]]
+    with Serializable {
 
   override def size: Int = 0
   override def isEmpty: Boolean = true
@@ -61,6 +63,8 @@ sealed class ListSet[A]
 
   def iterableFactory = ListSet
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListSet[A] = fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, ListSet[A]] = ListSet.newBuilder()
 
   /**
     * Represents an entry in the `ListSet`.
@@ -110,7 +114,7 @@ sealed class ListSet[A]
   * @define Coll ListSet
   * @define coll list set
   */
-object ListSet extends IterableFactory[ListSet] {
+object ListSet extends IterableFactoryWithBuilder[ListSet] {
 
   def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] =
     it match {
@@ -124,5 +128,9 @@ object ListSet extends IterableFactory[ListSet] {
 
   def empty[A]: ListSet[A] = EmptyListSet.asInstanceOf[ListSet[A]]
 
+  def newBuilder[A](): Builder[A, ListSet[A]] =
+    new ImmutableBuilder[A, ListSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
 }
 

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -18,7 +18,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, _], +C <: Map[
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
-  protected def coll: CC[K, V]
+  protected[this] def coll: CC[K, V]
 
   /** Removes a key from this map, returning a new map.
     *
@@ -59,4 +59,4 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, _], +C <: Map[
 }
 
 // TODO Special case small maps
-object Map extends MapFactory.Delegate[Map](HashMap)
+object Map extends MapFactoryWithBuilder.Delegate[Map](HashMap)

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -1,11 +1,13 @@
 package strawman.collection.immutable
 
 import strawman.collection
-import strawman.collection.{IterableFactory, Iterator}
+import strawman.collection.{IterableFactory, Iterator, StrictOptimizedIterableOps}
 
-import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, `inline`, Int, Integral, math, Numeric, Ordering, Serializable, specialized, StringContext, Unit}
+import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, Int, Integral, Numeric, Ordering, Serializable, StringContext, Unit, `inline`, math, specialized}
 import scala.Predef.ArrowAssoc
 import java.lang.String
+
+import strawman.collection.mutable.Builder
 
 /** `NumericRange` is a more generic version of the
   *  `Range` class which works with arbitrary types.
@@ -38,13 +40,16 @@ final class NumericRange[T](
 )
   extends IndexedSeq[T]
     with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+    with StrictOptimizedIterableOps[T, IndexedSeq[T]]
     with Serializable {
 
   def iterator(): Iterator[T] = new NumericRangeIterator[T](start, step, last, isEmpty)
 
-  def iterableFactory: IterableFactory[IndexedSeq] = ImmutableArray // FIXME Use Vector instead of Array
+  def iterableFactory: IterableFactory[IndexedSeq] = IndexedSeq
 
   protected[this] def fromSpecificIterable(it: collection.Iterable[T]): IndexedSeq[T] = fromIterable(it)
+
+  protected[this] def newSpecificBuilder(): Builder[T, IndexedSeq[T]] = IndexedSeq.newBuilder()
 
   /** Note that NumericRange must be invariant so that constructs
     *  such as "1L to 10 by 5" do not infer the range type as AnyVal.

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -1,11 +1,13 @@
 package strawman
 package collection.immutable
 
-import collection.{IterableFactory, IterableOps, Iterator}
+import collection.{IterableFactory, IterableOps, Iterator, StrictOptimizedIterableOps}
 
 import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, Long, Numeric, SerialVersionUID, Serializable, StringContext, Unit, `inline`, specialized}
 import scala.Predef.augmentString
 import java.lang.String
+
+import strawman.collection.mutable.Builder
 
 /** The `Range` class represents integer values in range
   *  ''[start;end)'' with non-zero step value `step`.
@@ -47,12 +49,15 @@ final class Range(
 )
   extends IndexedSeq[Int]
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
+    with StrictOptimizedIterableOps[Int, IndexedSeq[Int]]
     with Serializable { range =>
 
-  def iterableFactory: IterableFactory[IndexedSeq] = ImmutableArray // FIXME Use Vector instead of Array
+  def iterableFactory: IterableFactory[IndexedSeq] = IndexedSeq
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): IndexedSeq[Int] =
     fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[Int, IndexedSeq[Int]] = IndexedSeq.newBuilder()
 
   def iterator(): Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -11,7 +11,7 @@ trait Seq[+A] extends Iterable[A]
                  with collection.Seq[A]
                  with SeqOps[A, Seq, Seq[A]]
 
-trait SeqOps[+A, +CC[A] <: Seq[A], +C] extends collection.SeqOps[A, CC, C]
+trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C]
 
 object Seq extends IterableFactory.Delegate[Seq](List)
 
@@ -19,6 +19,8 @@ object Seq extends IterableFactory.Delegate[Seq](List)
 trait IndexedSeq[+A] extends Seq[A]
                         with collection.IndexedSeq[A]
                         with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
+
+object IndexedSeq extends IterableFactoryWithBuilder.Delegate[IndexedSeq](ImmutableArray)
 
 /** Base trait for immutable indexed Seq operations */
 trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends SeqOps[A, CC, C] with collection.IndexedSeqOps[A, CC, C]

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -14,7 +14,7 @@ trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[
 trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   extends collection.SetOps[A, CC, C] {
 
-  protected def coll: C
+  protected[this] def coll: C
 
   /** Creates a new set with an additional element, unless the element is
     *  already present.

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A,
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 
-object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)
+object SortedSet extends SortedIterableFactoryWithBuilder.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -2,9 +2,8 @@ package strawman
 package collection
 package immutable
 
-import strawman.collection.SortedMapFactory
 import strawman.collection.immutable.{RedBlackTree => RB}
-import strawman.collection.mutable.Builder
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
 import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 
@@ -32,6 +31,7 @@ import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), TreeMap[K, V]]
     with Serializable {
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
@@ -43,6 +43,8 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
     TreeMap.sortedFromIterable(it)
+
+  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
@@ -100,7 +102,7 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   *  @define Coll immutable.TreeMap
   *  @define coll immutable tree map
   */
-object TreeMap extends SortedMapFactory[TreeMap] {
+object TreeMap extends SortedMapFactoryWithBuilder[TreeMap] {
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap()
 
@@ -108,6 +110,11 @@ object TreeMap extends SortedMapFactory[TreeMap] {
     it match {
       case tm: TreeMap[K, V] => tm
       case _ => empty[K, V] ++ it
+    }
+
+  def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] =
+    new ImmutableBuilder[(K, V), TreeMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -11,8 +11,7 @@ import scala.Predef.intWrapper
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   extends IndexedOptimizedGrowableSeq[A]
      with SeqOps[A, ArrayBuffer, ArrayBuffer[A]]
-     with StrictOptimizedIterableOps[A, ArrayBuffer[A]]
-     with Builder[A, ArrayBuffer[A]] {
+     with StrictOptimizedIterableOps[A, ArrayBuffer[A]] {
 
   def this() = this(new Array[AnyRef](16), 0)
 
@@ -49,7 +48,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ArrayBuffer[A] = fromIterable(coll)
 
-  protected[this] def newSpecificBuilder() = new ArrayBuffer[A]
+  protected[this] def newSpecificBuilder() = new GrowableBuilder(ArrayBuffer.empty[A])
 
   def clear(): Unit =
     end = 0
@@ -72,8 +71,6 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
     }
     this
   }
-
-  def result() = this
 
   def insert(idx: Int, elem: A): Unit = {
     checkWithinBounds(idx, idx)
@@ -124,7 +121,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   override def className = "ArrayBuffer"
 }
 
-object ArrayBuffer extends IterableFactoryWithBuilder[ArrayBuffer] {
+object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
   def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
@@ -135,8 +132,6 @@ object ArrayBuffer extends IterableFactoryWithBuilder[ArrayBuffer] {
       new ArrayBuffer[B](array, array.length)
     }
     else new ArrayBuffer[B] ++= coll
-
-  def newBuilder[A](): Builder[A, ArrayBuffer[A]] = new ArrayBuffer[A]()
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -11,7 +11,7 @@ import scala.Predef.intWrapper
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   extends IndexedOptimizedGrowableSeq[A]
      with SeqOps[A, ArrayBuffer, ArrayBuffer[A]]
-     with Buildable[A, ArrayBuffer[A]]
+     with StrictOptimizedIterableOps[A, ArrayBuffer[A]]
      with Builder[A, ArrayBuffer[A]] {
 
   def this() = this(new Array[AnyRef](16), 0)
@@ -49,9 +49,9 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ArrayBuffer[A] = fromIterable(coll)
 
-  protected[this] def newBuilder = new ArrayBuffer[A]
+  protected[this] def newSpecificBuilder() = new ArrayBuffer[A]
 
-  def clear() =
+  def clear(): Unit =
     end = 0
 
   def add(elem: A): this.type = {

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -43,7 +43,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
     BitSet.fromSpecificIterable(coll)
 
-  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
+  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = new GrowableBuilder(BitSet.empty)
 
   protected[collection] final def nwords: Int = elems.length
 
@@ -101,12 +101,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
 }
 
-object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
+object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = Growable.fromIterable(empty, it)
 
   def empty: BitSet = new BitSet()
-
-  def newBuilder(): Builder[Int, BitSet] = new GrowableBuilder[Int, BitSet](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -28,6 +28,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
+    with StrictOptimizedIterableOps[Int, BitSet]
     with Serializable {
 
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))
@@ -41,6 +42,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
     BitSet.fromSpecificIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
 
   protected[collection] final def nwords: Int = elems.length
 
@@ -98,10 +101,12 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
 }
 
-object BitSet extends SpecificIterableFactory[Int, BitSet] {
+object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
 
   def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = Growable.fromIterable(empty, it)
 
   def empty: BitSet = new BitSet()
+
+  def newBuilder(): Builder[Int, BitSet] = new GrowableBuilder[Int, BitSet](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -41,7 +41,7 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.fromIterable(coll)
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] = HashMap.fromIterable(it)
 
-  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
+  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] =  new GrowableBuilder(HashMap.empty[K, V])
 
   def iterator(): Iterator[(K, V)] = table.entriesIterator.map(e => (e.key, e.value))
 
@@ -93,13 +93,11 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
 
 }
 
-object HashMap extends MapFactoryWithBuilder[HashMap] {
+object HashMap extends MapFactory[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 
   def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] = Growable.fromIterable(empty[K, V], it)
-
-  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] = new GrowableBuilder[(K, V), HashMap[K, V]](empty)
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import strawman.collection.{Iterator, MapFactory}
+import strawman.collection.{Iterator, MapFactory, MapFactoryWithBuilder, StrictOptimizedIterableOps}
 
 import scala.{Boolean, Int, None, Option, SerialVersionUID, Serializable, Some, Unit}
 import java.lang.String
@@ -24,6 +24,7 @@ import java.lang.String
 final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, DefaultEntry[K, V]])
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), HashMap[K, V]]
     with Serializable {
 
   private[this] val table: HashTable[K, V, DefaultEntry[K, V]] =
@@ -39,6 +40,8 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.fromIterable(coll)
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] = HashMap.fromIterable(it)
+
+  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
 
   def iterator(): Iterator[(K, V)] = table.entriesIterator.map(e => (e.key, e.value))
 
@@ -90,11 +93,13 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
 
 }
 
-object HashMap extends MapFactory[HashMap] {
+object HashMap extends MapFactoryWithBuilder[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 
   def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] = Growable.fromIterable(empty[K, V], it)
+
+  def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] = new GrowableBuilder[(K, V), HashMap[K, V]](empty)
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -35,7 +35,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
-  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder[A]()
+  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] =  new GrowableBuilder(HashSet.empty[A])
 
   def add(elem: A): this.type = {
     table.addElem(elem)
@@ -75,12 +75,10 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
 }
 
-object HashSet extends IterableFactoryWithBuilder[HashSet] {
+object HashSet extends IterableFactory[HashSet] {
 
   def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
 
   def empty[A]: HashSet[A] = new HashSet[A]
-
-  def newBuilder[A](): Builder[A, HashSet[A]] = new GrowableBuilder[A, HashSet[A]](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -22,7 +22,7 @@ import scala.{Any, Boolean, Option, Serializable, SerialVersionUID, Unit}
 final class HashSet[A](contents: FlatHashTable.Contents[A])
   extends Set[A]
     with SetOps[A, HashSet, HashSet[A]]
-    with Buildable[A, HashSet[A]]
+    with StrictOptimizedIterableOps[A, HashSet[A]]
     with Serializable {
 
   private[this] val table = new FlatHashTable[A]
@@ -35,7 +35,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
 
-  protected[this] def newBuilder: Builder[A, HashSet[A]] = HashSet.newBuilder[A]()
+  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder[A]()
 
   def add(elem: A): this.type = {
     table.addElem(elem)

--- a/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/ImmutableBuilder.scala
@@ -1,0 +1,19 @@
+package strawman
+package collection
+package mutable
+
+import scala.Unit
+
+/**
+  * Reusable builder for immutable collections
+  */
+abstract class ImmutableBuilder[-A, C](empty: C)
+  extends ReusableBuilder[A, C] {
+
+  protected var elems: C = empty
+
+  def clear(): Unit = { elems = empty }
+
+  def result(): C = elems
+
+}

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -12,10 +12,9 @@ import scala.Predef.{assert, intWrapper}
 
 /** Concrete collection type: ListBuffer */
 class ListBuffer[A]
-  extends Seq[A]
+  extends GrowableSeq[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]
-     with StrictOptimizedIterableOps[A, ListBuffer[A]]
-     with Builder[A, ListBuffer[A]] {
+     with StrictOptimizedIterableOps[A, ListBuffer[A]] {
 
   private var first: List[A] = Nil
   private var last0: ::[A] = null
@@ -35,10 +34,10 @@ class ListBuffer[A]
   def length = len
   override def knownSize = len
 
-  protected[this] def newSpecificBuilder() = new ListBuffer[A]
+  protected[this] def newSpecificBuilder() = new GrowableBuilder(ListBuffer.empty[A])
 
   private def copyElems(): Unit = {
-    val buf = ListBuffer.fromIterable(result())
+    val buf = ListBuffer.fromIterable(this)
     first = buf.first
     last0 = buf.last0
     aliased = false
@@ -195,16 +194,12 @@ class ListBuffer[A]
     this
   }
 
-  def result() = this
-
   override def className = "ListBuffer"
 }
 
-object ListBuffer extends IterableFactoryWithBuilder[ListBuffer] {
+object ListBuffer extends IterableFactory[ListBuffer] {
 
   def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
-
-  def newBuilder[A](): Builder[A, ListBuffer[A]] = new ListBuffer[A]
 
   def empty[A]: ListBuffer[A] = new ListBuffer[A]
 }

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -14,7 +14,7 @@ import scala.Predef.{assert, intWrapper}
 class ListBuffer[A]
   extends Seq[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]
-     with Buildable[A, ListBuffer[A]]
+     with StrictOptimizedIterableOps[A, ListBuffer[A]]
      with Builder[A, ListBuffer[A]] {
 
   private var first: List[A] = Nil
@@ -35,7 +35,7 @@ class ListBuffer[A]
   def length = len
   override def knownSize = len
 
-  protected[this] def newBuilder = new ListBuffer[A]
+  protected[this] def newSpecificBuilder() = new ListBuffer[A]
 
   private def copyElems(): Unit = {
     val buf = ListBuffer.fromIterable(result())

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -18,7 +18,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
-  protected def coll: Map[K, V]
+  protected[this] def coll: Map[K, V]
 
   def iterableFactory = Iterable
 
@@ -89,4 +89,4 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
 
 }
 
-object Map extends MapFactory.Delegate[Map](HashMap)
+object Map extends MapFactoryWithBuilder.Delegate[Map](HashMap)

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -89,4 +89,4 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
 
 }
 
-object Map extends MapFactoryWithBuilder.Delegate[Map](HashMap)
+object Map extends MapFactory.Delegate[Map](HashMap)

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
     with collection.SortedSetOps[A, CC, C]
 
 object SortedSet
-  extends SortedIterableFactoryWithBuilder.Delegate[SortedSet](TreeSet)
+  extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -17,4 +17,4 @@ trait SortedSetOps[A, +CC[X], +C <: SortedSet[A]]
     with collection.SortedSetOps[A, CC, C]
 
 object SortedSet
-  extends SortedIterableFactory.Delegate[SortedSet](TreeSet)
+  extends SortedIterableFactoryWithBuilder.Delegate[SortedSet](TreeSet)

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -39,7 +39,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.sortedFromIterable(it)
 
-  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
+  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] =  new GrowableBuilder(TreeMap.empty[K, V])
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
@@ -175,13 +175,11 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   * @define Coll mutable.TreeMap
   * @define coll mutable tree map
   */
-object TreeMap extends SortedMapFactoryWithBuilder[TreeMap] {
+object TreeMap extends SortedMapFactory[TreeMap] {
 
   def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     Growable.fromIterable(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
-
-  def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] = new GrowableBuilder[(K, V), TreeMap[K, V]](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.{Iterator, SortedMapFactory}
+import collection.{Iterator, SortedMapFactory, SortedMapFactoryWithBuilder, StrictOptimizedIterableOps}
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
@@ -25,6 +25,7 @@ import java.lang.String
 sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), TreeMap[K, V]]
     with Serializable {
 
   /**
@@ -37,6 +38,8 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.sortedFromIterable(coll)
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.sortedFromIterable(it)
+
+  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
@@ -172,11 +175,13 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   * @define Coll mutable.TreeMap
   * @define coll mutable tree map
   */
-object TreeMap extends SortedMapFactory[TreeMap] {
+object TreeMap extends SortedMapFactoryWithBuilder[TreeMap] {
 
   def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
     Growable.fromIterable(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
+
+  def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] = new GrowableBuilder[(K, V), TreeMap[K, V]](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -1,10 +1,10 @@
 package strawman
 package collection.mutable
 
-import collection.SortedIterableFactory
+import collection.{SortedIterableFactory, SortedIterableFactoryWithBuilder, StrictOptimizedIterableOps}
 import collection.mutable.{RedBlackTree => RB}
 
-import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
+import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 import java.lang.String
 
 /**
@@ -25,6 +25,7 @@ import java.lang.String
 sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
+    with StrictOptimizedIterableOps[A, TreeSet[A]]
     with Serializable {
 
   if (ordering eq null)
@@ -42,6 +43,8 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.sortedFromIterable(it)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.sortedFromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder[A]()
 
   def iterableFactory = Set
 
@@ -175,10 +178,12 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   * @author Lucien Pereira
   *
   */
-object TreeSet extends SortedIterableFactory[TreeSet] {
+object TreeSet extends SortedIterableFactoryWithBuilder[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
   def sortedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
+
+  def newBuilder[A : Ordering](): Builder[A, TreeSet[A]] = new GrowableBuilder[A, TreeSet[A]](empty)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -44,7 +44,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.sortedFromIterable(coll)
 
-  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder[A]()
+  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = new GrowableBuilder(TreeSet.empty[A])
 
   def iterableFactory = Set
 
@@ -178,12 +178,10 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   * @author Lucien Pereira
   *
   */
-object TreeSet extends SortedIterableFactoryWithBuilder[TreeSet] {
+object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
   def sortedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
-
-  def newBuilder[A : Ordering](): Builder[A, TreeSet[A]] = new GrowableBuilder[A, TreeSet[A]](empty)
 
 }


### PR DESCRIPTION
And also:
- Rename newBuilder to newSpecificBuilder.
- Rename Buildable to StrictOptimizedIterableOps.
- Add XxxWithBuilder variants to all kinds of factories.

But the main change is that now all `Iterabe` have this protected method that makes it possible to create a strict builder for them. This change is supposed to make it simpler to provide default implementations for several methods (such as `groupBy`, see #108). It might also simplify #97.