### PR TITLE
Add groupBy (on top of #110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `foldLeft`
 - [x] `foldRight`
 - [x] `get`
+- [x] `getOrElse`
+- [x] `getOrElseUpdate`
 - [x] `head`
 - [x] `indexWhere`
 - [x] `isDefinedAt`
@@ -88,7 +90,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `drop`
 - [x] `empty`
 - [x] `filter` / `filterNot`
-- [ ] `groupBy`
+- [x] `groupBy`
 - [x] `intersect`
 - [x] `partition`
 - [x] `range`

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -59,4 +59,10 @@ class HashSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -87,4 +87,10 @@ class ImmutableArrayBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
@@ -79,4 +79,10 @@ class LazyListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -87,4 +87,10 @@ class ListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -57,4 +57,10 @@ class ScalaHashSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -87,4 +87,10 @@ class ScalaListBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -59,4 +59,10 @@ class ScalaTreeSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -59,4 +59,10 @@ class TreeSetBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -78,4 +78,10 @@ class ArrayBufferBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -77,4 +77,10 @@ class ListBufferBenchmark {
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
 
+  @Benchmark
+  def groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_ % 5)
+    bh.consume(result)
+  }
+
 }

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -27,6 +27,22 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     */
   def get(key: K): Option[V]
 
+  /**  Returns the value associated with a key, or a default value if the key is not contained in the map.
+   *   @param   key      the key.
+   *   @param   default  a computation that yields a default value in case no binding for `key` is
+   *                     found in the map.
+   *   @tparam  V1       the result type of the default computation.
+   *   @return  the value associated with `key` if it exists,
+   *            otherwise the result of the `default` computation.
+   *
+   *   @usecase def getOrElse(key: K, default: => V): V
+   *     @inheritdoc
+   */
+  def getOrElse[V1 >: V](key: K, default: => V1): V1 = get(key) match {
+    case Some(v) => v
+    case None => default
+  }
+
   /** Retrieves the value which is associated with the given key. This
     *  method invokes the `default` method of the map if there is no mapping
     *  from the given key to a value. Unless overridden, the `default` method throws a

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -67,6 +67,11 @@ object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
       case _          => empty.++(it)
     }
 
+  def empty: BitSet = new BitSet1(0L)
+
+  def newBuilder(): Builder[Int, BitSet] =
+    new GrowableBuilder(mutable.BitSet.empty).mapResult(bs => fromBitMaskNoCopy(bs.elems))
+
   private def createSmall(a: Long, b: Long): BitSet = if (b == 0L) new BitSet1(a) else new BitSet2(a, b)
 
   /** A bitset containing all the bits in an array */
@@ -91,11 +96,6 @@ object BitSet extends SpecificIterableFactoryWithBuilder[Int, BitSet] {
     else if (len == 2) createSmall(elems(0), elems(1))
     else new BitSetN(elems)
   }
-
-  def empty: BitSet = new BitSet1(0L)
-
-  def newBuilder(): Builder[Int, BitSet] =
-    new GrowableBuilder(mutable.BitSet.empty).mapResult(bs => fromBitMaskNoCopy(bs.elems))
 
   @SerialVersionUID(2260107458435649300L)
   class BitSet1(val elems: Long) extends BitSet {

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.immutable
 
-import collection.{Iterator, MapFactory, MapFactoryWithBuilder, StrictOptimizedIterableOps}
+import collection.{Iterator, MapFactoryWithBuilder, StrictOptimizedIterableOps}
 import collection.Hashing.{computeHash, keepBits}
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -14,7 +14,7 @@ import scala.Predef.{???, intWrapper}
   */
 class ImmutableArray[+A] private (private val elements: scala.Array[Any])
   extends IndexedSeq[A]
-    with SeqOps[A, ImmutableArray, ImmutableArray[A]]
+    with IndexedSeqOps[A, ImmutableArray, ImmutableArray[A]]
     with StrictOptimizedIterableOps[A, ImmutableArray[A]] {
 
   def iterableFactory: IterableFactory[ImmutableArray] = ImmutableArray

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -68,5 +68,6 @@ object LazyList extends IterableFactory[LazyList] {
   def fromIterator[A](it: Iterator[A]): LazyList[A] =
     new LazyList(if (it.hasNext) Some(it.next(), fromIterator(it)) else None)
 
-  def empty[A]: LazyList[A] = new LazyList[A](None)
+  def empty[A]: LazyList[A] = Empty
+
 }

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -34,6 +34,16 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
 
   def this()(implicit ordering: Ordering[A]) = this(null)(ordering)
 
+  def iterableFactory = Set
+
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
+    TreeSet.sortedFromIterable(coll)
+
+  protected[this] def sortedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
+    TreeSet.sortedFromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
+
   private def newSet(t: RB.Tree[A, Unit]) = new TreeSet[A](t)
 
   override def size: Int = RB.count(tree)
@@ -61,16 +71,6 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
   def iterator(): Iterator[A] = RB.keysIterator(tree)
 
   def keysIteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
-
-  def iterableFactory = Set
-
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.sortedFromIterable(coll)
-
-  protected[this] def sortedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.sortedFromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
 
   def unordered: Set[A] = this
 

--- a/src/main/scala/strawman/collection/mutable/HashTable.scala
+++ b/src/main/scala/strawman/collection/mutable/HashTable.scala
@@ -139,7 +139,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
   final def findEntry(key: A): Entry =
     findEntry0(key, index(elemHashCode(key)))
 
-  protected[this] final def findEntry0(key: A, h: Int): Entry = {
+  protected[collection] final def findEntry0(key: A, h: Int): Entry = {
     var e = table(h).asInstanceOf[Entry]
     while (e != null && !elemEquals(e.key, key)) e = e.next
     e
@@ -152,7 +152,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
     addEntry0(e, index(elemHashCode(e.key)))
   }
 
-  protected[this] final def addEntry0(e: Entry, h: Int): Unit = {
+  protected[collection] final def addEntry0(e: Entry, h: Int): Unit = {
     e.next = table(h).asInstanceOf[Entry]
     table(h) = e
     tableSize = tableSize + 1
@@ -363,7 +363,7 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
     * Note: we take the most significant bits of the hashcode, not the lower ones
     * this is of crucial importance when populating the table in parallel
     */
-  protected final def index(hcode: Int): Int = {
+  protected[collection] final def index(hcode: Int): Int = {
     val ones = table.length - 1
     val exponent = Integer.numberOfLeadingZeros(ones)
     (improve(hcode, seedvalue) >>> exponent) & ones
@@ -408,7 +408,7 @@ private[collection] object HashTable {
     // so that:
     protected final def sizeMapBucketSize = 1 << sizeMapBucketBitSize
 
-    protected def elemHashCode(key: KeyType) = key.##
+    protected[collection] def elemHashCode(key: KeyType) = key.##
 
     /**
       * Defer to a high-quality hash in [[scala.util.hashing]].

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -4,7 +4,7 @@ package mutable
 
 import strawman.collection.{IterableOnce, MapFactory}
 
-import scala.{Boolean, Option, Unit, `inline`}
+import scala.{Boolean, None, Option, Some, Unit, `inline`}
 
 /** Base type of mutable Maps */
 trait Map[K, V]
@@ -46,6 +46,26 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @param value  The new value
     */
   def update(key: K, value: V): Unit = { coll += ((key, value)) }
+
+  /** If given key is already in this map, returns associated value.
+   *
+   *  Otherwise, computes value from given expression `op`, stores with key
+   *  in map and returns that value.
+   *
+   *  Concurrent map implementations may evaluate the expression `op`
+   *  multiple times, or may evaluate `op` without inserting the result.
+   *
+   *  @param  key the key to test
+   *  @param  op  the computation yielding the value to associate with `key`, if
+   *              `key` is previously unbound.
+   *  @return     the value associated with key (either previously or as a result
+   *              of executing the method).
+   */
+  def getOrElseUpdate(key: K, op: => V): V =
+    get(key) match {
+      case Some(v) => v
+      case None => val d = op; this(key) = d; d
+    }
 
   override def clone(): C = empty ++= coll
 


### PR DESCRIPTION
I rebased #108 on top of #110. Now all the collections reuse the same implementation of `groupBy`.