### PR TITLE
Drop Scala 2.12.x support

### DIFF
--- a/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
+++ b/benchmarks/memory/src/main/scala/strawman/collection/MemoryFootprint.scala
@@ -2,7 +2,7 @@ package bench
 
 import strawman.collection.immutable.{LazyList, List, Range, NumericRange}
 
-import scala.{Any, AnyRef, App, Int, Long, Seq, StringContext}
+import scala.{Any, AnyRef, App, Int, List => SList, Long, StringContext}
 import scala.Predef.{ArrowAssoc, println, intWrapper}
 import scala.compat.Platform
 import java.lang.Runtime
@@ -54,24 +54,25 @@ object MemoryFootprint extends App {
 
   // We use a format similar to the one used by JMH so that
   // our charts can be generated in the same way
-  import jawn.ast._
+  import org.json4s.native.JsonMethods._
+  import org.json4s.JsonAST._
   val report =
-    JArray.fromSeq(
+    JArray(
       memories.flatMap { case (name, values) =>
         values.map { case (size, value) =>
-          JObject.fromSeq(Seq(
+          JObject(
             "benchmark" -> JString(s"$name.memory-footprint"),
-            "params" -> JObject.fromSeq(Seq(
+            "params" -> JObject(
               "size" -> JString(size.toString)
-            )),
-            "primaryMetric" -> JObject.fromSeq(Seq(
-              "score" -> JNum(value),
-              "scoreConfidence" -> JArray.fromSeq(Seq(JNum(value), JNum(value)))
-            ))
-          ))
+            ),
+            "primaryMetric" -> JObject(
+              "score" -> JLong(value),
+              "scoreConfidence" -> JArray(SList(JLong(value), JLong(value)))
+            )
+          )
         }
-      }.to[Seq]
+      }.to[SList]
     )
-  Files.write(reportPath, FastRenderer.render(report).getBytes)
+  Files.write(reportPath, compact(render(report)).getBytes)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,8 @@ dotty in ThisBuild := dottyLatestNightlyBuild.get
 val commonSettings = Seq(
   organization := "ch.epfl.scala",
   version := "0.2.0-SNAPSHOT",
-  resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots",
-  scalaVersion := "2.12.2-ebe1180-SNAPSHOT", // from https://github.com/scala/scala/pull/5742
-  scalaBinaryVersion := { if (!scalaVersion.value.startsWith("2.12.")) scalaBinaryVersion.value else "2.12" },
-  crossScalaVersions := scalaVersion.value :: "2.13.0-M1" :: dotty.value :: Nil,
+  scalaVersion := "2.13.0-M1",
+  crossScalaVersions := scalaVersion.value :: dotty.value :: Nil,
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-opt-warnings", "-Yno-imports", "-language:higherKinds", "-opt:l:classpath"),
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
   fork in Test := true,
@@ -21,10 +19,8 @@ val collections =
     .settings(
       name := "collection-strawman",
       libraryDependencies ++= Seq(
-        ("org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0").withDottyCompat(),
         "com.novocode" % "junit-interface" % "0.11" % Test
       ),
-      scalacOptions ++= { if (isDotty.value) Seq("-language:Scala2") else Nil },
       pomExtra :=
         <developers>
           <developer><id>ichoran</id><name>Rex Kerr</name></developer>
@@ -92,7 +88,7 @@ val memoryBenchmark =
     .dependsOn(collections)
     .settings(commonSettings: _*)
     .settings(
-      libraryDependencies += "org.spire-math" %% "jawn-ast" % "0.10.4",
+      libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.2",
       charts := Def.inputTaskDyn {
         val targetDir = crossTarget.value
         val report = targetDir / "report.json"

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -359,7 +359,7 @@ class StrawmanTest {
   }
 
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
-    val xs1 = xs.map((x: Int) => x.toString) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
+    val xs1 = xs.map(x => x.toString)
     val xs2: immutable.SortedSet[String] = xs1
     val l = List(1,2,3)
     val s1 = l.to(immutable.TreeSet)
@@ -369,10 +369,10 @@ class StrawmanTest {
    }
 
   def mapOps(xs: Map[Int, String]): Unit = {
-    val xs1 = xs.map ({ case (k, v) => (v, k) }: scala.PartialFunction[(Int, String), (String, Int)])
+    val xs1 = xs.map ({ case (k, v) => (v, k) })
     val xs2: strawman.collection.Map[String, Int] = xs1
     val xs3 = xs.map(kv => (kv._2, kv._1))
-    val xs4: strawman.collection.Iterable[(String, Int)] = xs3
+    val xs4: Map[String, Int] = xs3
     println(xs1)
     println(xs2)
     println(xs3)
@@ -386,11 +386,11 @@ class StrawmanTest {
     val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
     // val xs4: immutable.Iterable[String] = xs3  // FIXME: does not work under dotty, we get a collection.Iterable
-    val xs5 = xs.map ({ case (k, v) => (v, k) }: scala.PartialFunction[(String, Int), (Int, String)])
+    val xs5 = xs.map ({ case (k, v) => (v, k) })
     val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo
 //    val xs7 = xs.map((k: String, v: Int) => (new Foo, v)) Error: No implicit Ordering defined for Foo
-    val xs7 = (xs: immutable.Map[String, Int]) map ({ case (k, v) => (new Foo, v) }: scala.PartialFunction[(String, Int), (Foo, Int)])
+    val xs7 = (xs: immutable.Map[String, Int]) map ({ case (k, v) => (new Foo, v) })
     val xs8: immutable.Map[Foo, Int] = xs7
     val xs9 = xs6.to(List).to(mutable.HashMap)
     val xs9t: mutable.HashMap[Int, String] = xs9
@@ -406,7 +406,7 @@ class StrawmanTest {
     val b = xs.subsetOf(zs)
     val xs5 = xs.map(x => x + 1)
     val xs6: immutable.BitSet = xs5
-    val xs7 = (xs: immutable.SortedSet[Int]).map((x: Int) => x.toString)
+    val xs7 = (xs: immutable.SortedSet[Int]).map(x => x.toString)
     val xs8: immutable.SortedSet[String] = xs7
     val xs9 = (xs: immutable.Set[Int]).map(x => Left(x): Either[Int, Nothing])
     //val xs10: immutable.Set[Either[Int, Nothing]] = xs9


### PR DESCRIPTION
This lets us remove some type annotations in the tests.

In the `memoryBenchmarks` project I now use json4s instead of jawn to produce JSON, because jawn is not yet compatible with 2.13.