### PR TITLE
Add most of the current methods of Traversable to IterableOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `lastKey`
 - [x] `mkString`
 - [x] `size`
+- [x] `span`
 - [x] `sum`
 - [x] `to`
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -3,7 +3,8 @@ package collection
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, `inline`, Int, Numeric, Ordering, StringContext, Unit}
+import scala.{Any, Array, Boolean, `inline`, Int, None, Numeric, Option, Ordering, StringContext, Some, Unit}
+import scala.Predef.<:<
 import java.lang.{String, UnsupportedOperationException}
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}
@@ -60,13 +61,147 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
    */
   def foreach[U](f: A => U): Unit = coll.iterator().foreach(f)
 
+  /** Tests whether a predicate holds for all elements of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if this $coll is empty or the given predicate `p`
+   *                 holds for all elements of this $coll, otherwise `false`.
+   */
   def forall(p: A => Boolean): Boolean = coll.iterator().forall(p)
+
+  /** Tests whether a predicate holds for at least one element of this $coll.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if the given predicate `p` is satisfied by at least one element of this $coll, otherwise `false`
+   */
+  def exists(p: A => Boolean): Boolean = coll.iterator().exists(p)
+
+  /** Counts the number of elements in the $coll which satisfy a predicate.
+   *
+   *  @param p     the predicate  used to test elements.
+   *  @return      the number of elements satisfying the predicate `p`.
+   */
+  def count(p: A => Boolean): Int = coll.iterator().count(p)
+
+  /** Finds the first element of the $coll satisfying a predicate, if any.
+    *
+    *  $mayNotTerminateInf
+    *  $orderDependent
+    *
+    *  @param p       the predicate used to test elements.
+    *  @return        an option value containing the first element in the $coll
+    *                 that satisfies `p`, or `None` if none exists.
+    */
+  def find(p: A => Boolean): Option[A] = coll.iterator().find(p)
 
   /** Fold left */
   def foldLeft[B](z: B)(op: (B, A) => B): B = coll.iterator().foldLeft(z)(op)
 
   /** Fold right */
   def foldRight[B](z: B)(op: (A, B) => B): B = coll.iterator().foldRight(z)(op)
+
+  /** Reduces the elements of this $coll using the specified associative binary operator.
+   *
+   *  $undefinedorder
+   *
+   *  @tparam B      A type parameter for the binary operator, a supertype of `A`.
+   *  @param op       A binary operator that must be associative.
+   *  @return         The result of applying reduce operator `op` between all the elements if the $coll is nonempty.
+   *  @throws UnsupportedOperationException
+   *  if this $coll is empty.
+   */
+  def reduce[B >: A](op: (B, B) => B): B = reduceLeft(op)
+
+  /** Reduces the elements of this $coll, if any, using the specified
+   *  associative binary operator.
+   *
+   *  $undefinedorder
+   *
+   *  @tparam B     A type parameter for the binary operator, a supertype of `A`.
+   *  @param op      A binary operator that must be associative.
+   *  @return        An option value containing result of applying reduce operator `op` between all
+   *                 the elements if the collection is nonempty, and `None` otherwise.
+   */
+  def reduceOption[B >: A](op: (B, B) => B): Option[B] = reduceLeftOption(op)
+
+  /** Applies a binary operator to all elements of this $coll,
+   *  going left to right.
+   *  $willNotTerminateInf
+   *  $orderDependentFold
+   *
+   *  @param  op    the binary operator.
+   *  @tparam  B    the result type of the binary operator.
+   *  @return  the result of inserting `op` between consecutive elements of this $coll,
+   *           going left to right:
+   *           {{{
+   *             op( op( ... op(x_1, x_2) ..., x_{n-1}), x_n)
+   *           }}}
+   *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+   *  @throws UnsupportedOperationException if this $coll is empty.   */
+  def reduceLeft[B >: A](op: (B, A) => B): B = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.reduceLeft")
+
+    var first = true
+    var acc: B = 0.asInstanceOf[B]
+
+    for (x <- coll) {
+      if (first) {
+        acc = x
+        first = false
+      }
+      else acc = op(acc, x)
+    }
+    acc
+  }
+
+  /** Applies a binary operator to all elements of this $coll, going right to left.
+   *  $willNotTerminateInf
+   *  $orderDependentFold
+   *
+   *  @param  op    the binary operator.
+   *  @tparam  B    the result type of the binary operator.
+   *  @return  the result of inserting `op` between consecutive elements of this $coll,
+   *           going right to left:
+   *           {{{
+   *             op(x_1, op(x_2, ..., op(x_{n-1}, x_n)...))
+   *           }}}
+   *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+   *  @throws UnsupportedOperationException if this $coll is empty.
+   */
+  def reduceRight[B >: A](op: (A, B) => B): B = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.reduceRight")
+
+    reversed.reduceLeft[B]((x, y) => op(y, x))
+  }
+
+  /** Optionally applies a binary operator to all elements of this $coll, going left to right.
+   *  $willNotTerminateInf
+   *  $orderDependentFold
+   *
+   *  @param  op    the binary operator.
+   *  @tparam  B    the result type of the binary operator.
+   *  @return  an option value containing the result of `reduceLeft(op)` if this $coll is nonempty,
+   *           `None` otherwise.
+   */
+  def reduceLeftOption[B >: A](op: (B, A) => B): Option[B] = if (isEmpty) None else Some(reduceLeft(op))
+
+  /** Optionally applies a binary operator to all elements of this $coll, going
+   *  right to left.
+   *  $willNotTerminateInf
+   *  $orderDependentFold
+   *
+   *  @param  op    the binary operator.
+   *  @tparam  B    the result type of the binary operator.
+   *  @return  an option value containing the result of `reduceRight(op)` if this $coll is nonempty,
+   *           `None` otherwise.
+   */
+  def reduceRightOption[B >: A](op: (A, B) => B): Option[B] = if (isEmpty) None else Some(reduceRight(op))
 
   /** The index of the first element in this collection for which `p` holds. */
   def indexWhere(p: A => Boolean): Int = coll.iterator().indexWhere(p)
@@ -91,6 +226,13 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     while (it.hasNext) lst = it.next()
     lst
   }
+
+  /** Optionally selects the last element.
+    *  $orderDependent
+    *  @return  the last element of this $coll$ if it is nonempty,
+    *           `None` if it is empty.
+    */
+  def lastOption: Option[A] = if (isEmpty) None else Some(last)
 
   /** The number of elements in this collection, if it can be cheaply computed,
     *  -1 otherwise. Cheaply usually means: Not requiring a collection traversal.
@@ -176,6 +318,123 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   def sum[B >: A](implicit num: Numeric[B]): B = foldLeft(num.zero)(num.plus)
 
+  /** Multiplies up the elements of this collection.
+   *
+   *   @param   num  an implicit parameter defining a set of numeric operations
+   *                 which includes the `*` operator to be used in forming the product.
+   *   @tparam  B   the result type of the `*` operator.
+   *   @return       the product of all elements of this $coll with respect to the `*` operator in `num`.
+   *
+   *   @usecase def product: A
+   *     @inheritdoc
+   *
+   *     @return       the product of all elements in this $coll of numbers of type `Int`.
+   *     Instead of `Int`, any other type `T` with an implicit `Numeric[T]` implementation
+   *     can be used as element type of the $coll and as result type of `product`.
+   *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
+   */
+  def product[B >: A](implicit num: Numeric[B]): B = foldLeft(num.one)(num.times)
+
+  /** Finds the smallest element.
+   *
+   *  @param    ord   An ordering to be used for comparing elements.
+   *  @tparam   B    The type over which the ordering is defined.
+   *  @return   the smallest element of this $coll with respect to the ordering `ord`.
+   *
+   *  @usecase def min: A
+   *    @inheritdoc
+   *
+   *    @return   the smallest element of this $coll
+   */
+  def min[B >: A](implicit ord: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.min")
+
+    reduceLeft((x, y) => if (ord.lteq(x, y)) x else y)
+  }
+
+  /** Finds the largest element.
+   *
+   *  @param    ord   An ordering to be used for comparing elements.
+   *  @tparam   B    The type over which the ordering is defined.
+   *  @return   the largest element of this $coll with respect to the ordering `ord`.
+   *
+   *  @usecase def max: A
+   *    @inheritdoc
+   *
+   *    @return   the largest element of this $coll.
+   */
+  def max[B >: A](implicit ord: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.max")
+
+    reduceLeft((x, y) => if (ord.gteq(x, y)) x else y)
+  }
+
+  /** Finds the first element which yields the largest value measured by function f.
+   *
+   *  @param    cmp   An ordering to be used for comparing elements.
+   *  @tparam   B     The result type of the function f.
+   *  @param    f     The measuring function.
+   *  @return   the first element of this $coll with the largest value measured by function f
+   *  with respect to the ordering `cmp`.
+   *
+   *  @usecase def maxBy[B](f: A => B): A
+   *    @inheritdoc
+   *
+   *    @return   the first element of this $coll with the largest value measured by function f.
+   */
+  def maxBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.maxBy")
+
+    var maxF: B = null.asInstanceOf[B]
+    var maxElem: A = null.asInstanceOf[A]
+    var first = true
+
+    for (elem <- coll) {
+      val fx = f(elem)
+      if (first || cmp.gt(fx, maxF)) {
+        maxElem = elem
+        maxF = fx
+        first = false
+      }
+    }
+    maxElem
+  }
+
+  /** Finds the first element which yields the smallest value measured by function f.
+   *
+   *  @param    cmp   An ordering to be used for comparing elements.
+   *  @tparam   B     The result type of the function f.
+   *  @param    f     The measuring function.
+   *  @return   the first element of this $coll with the smallest value measured by function f
+   *  with respect to the ordering `cmp`.
+   *
+   *  @usecase def minBy[B](f: A => B): A
+   *    @inheritdoc
+   *
+   *    @return   the first element of this $coll with the smallest value measured by function f.
+   */
+  def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.minBy")
+
+    var minF: B = null.asInstanceOf[B]
+    var minElem: A = null.asInstanceOf[A]
+    var first = true
+
+    for (elem <- coll) {
+      val fx = f(elem)
+      if (first || cmp.lt(fx, minF)) {
+        minElem = elem
+        minF = fx
+        first = false
+      }
+    }
+    minElem
+  }
+
   /** Selects all elements of this $coll which satisfy a predicate.
     *
     *  @param pred  the predicate used to test elements.
@@ -230,6 +489,15 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  linear, immutable collections this should avoid making a copy.
     */
   def dropRight(n: Int): C = fromSpecificIterable(View.DropRight(coll, n))
+
+  /** Skips longest sequence of elements of this iterator which satisfy given
+    *  predicate `p`, and returns an iterator of the remaining elements.
+    *
+    *  @param p the predicate used to skip elements.
+    *  @return  an iterator consisting of the remaining elements
+    *  @note    Reuse: $consumesAndProducesIterator
+    */
+  def dropWhile(p: A => Boolean): C = fromSpecificIterable(View.DropWhile(coll, p))
 
   /** The rest of the collection without its first element. */
   def tail: C = {
@@ -287,7 +555,63 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     result
   }
 
-  /** Map */
+  /** Computes a prefix scan of the elements of the collection.
+    *
+    *  Note: The neutral element `z` may be applied more than once.
+    *
+    *  @tparam B         element type of the resulting collection
+    *  @param z          neutral element for the operator `op`
+    *  @param op         the associative operator for the scan
+    *
+    *  @return           a new $coll containing the prefix scan of the elements in this $coll
+    */
+  def scan[B >: A](z: B)(op: (B, B) => B): CC[B] = scanLeft(z)(op)
+
+  /** Produces a collection containing cumulative results of applying the
+    *  operator going left to right.
+    *
+    *  $willNotTerminateInf
+    *  $orderDependent
+    *
+    *  @tparam B      the type of the elements in the resulting collection
+    *  @param z       the initial value
+    *  @param op      the binary operator applied to the intermediate result and the element
+    *  @return        collection with intermediate results
+    */
+  def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = fromIterable(View.ScanLeft(coll, z, op))
+
+  /** Produces a collection containing cumulative results of applying the operator going right to left.
+    *  The head of the collection is the last cumulative result.
+    *  $willNotTerminateInf
+    *  $orderDependent
+    *
+    *  Example:
+    *  {{{
+    *    List(1, 2, 3, 4).scanRight(0)(_ + _) == List(10, 9, 7, 4, 0)
+    *  }}}
+    *
+    *  @tparam B      the type of the elements in the resulting collection
+    *  @param z       the initial value
+    *  @param op      the binary operator applied to the intermediate result and the element
+    *  @return        collection with intermediate results
+    */
+  def scanRight[B](z: B)(op: (A, B) => B): CC[B] = {
+    var scanned = z :: immutable.Nil
+    var acc = z
+    for (x <- reversed) {
+      acc = op(x, acc)
+      scanned ::= acc
+    }
+    fromIterable(scanned)
+  }
+
+  /** Builds a new collection by applying a function to all elements of this $coll.
+    *
+    *  @param f      the function to apply to each element.
+    *  @tparam B     the element type of the returned collection.
+    *  @return       a new $coll resulting from applying the given function
+    *                `f` to each element of this $coll and collecting the results.
+    */
   def map[B](f: A => B): CC[B] = fromIterable(View.Map(coll, f))
 
   /** Flatmap */
@@ -313,4 +637,29 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: IterableOnce[B]): CC[(A @uncheckedVariance, B)] = fromIterable(View.Zip(coll, xs))
   // sound bcs of VarianceNote
+
+  /** Converts this $coll of pairs into two collections of the first and second
+    *  half of each pair.
+    *
+    *    {{{
+    *    val xs = $Coll(
+    *               (1, "one"),
+    *               (2, "two"),
+    *               (3, "three")).unzip
+    *    // xs == ($Coll(1, 2, 3),
+    *    //        $Coll(one, two, three))
+    *    }}}
+    *
+    *  @tparam A1    the type of the first half of the element pairs
+    *  @tparam A2    the type of the second half of the element pairs
+    *  @param asPair an implicit conversion which asserts that the element type
+    *                of this $coll is a pair.
+    *  @return       a pair of ${coll}s, containing the first, respectively second
+    *                half of each element pair of this $coll.
+    */
+  def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
+    val unzipped = View.Unzip(coll)
+    (fromIterable(unzipped.left), fromIterable(unzipped.right))
+  }
+
 }

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -481,6 +481,27 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** A collection containing the last `n` elements of this collection. */
   def takeRight(n: Int): C = fromSpecificIterable(View.TakeRight(coll, n))
 
+  /** Takes longest prefix of elements that satisfy a predicate.
+    *  $orderDependent
+    *  @param   pred  The predicate used to test elements.
+    *  @return  the longest prefix of this $coll whose elements all satisfy
+    *           the predicate `p`.
+    */
+  def takeWhile(pred: A => Boolean): C = fromSpecificIterable(View.TakeWhile(coll, pred))
+
+  /** Splits this $coll into a prefix/suffix pair according to a predicate.
+    *
+    *  Note: `c span p`  is equivalent to (but possibly more efficient than)
+    *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
+    *  predicate `p` does not cause any side-effects.
+    *  $orderDependent
+    *
+    *  @param p the test predicate
+    *  @return  a pair consisting of the longest prefix of this $coll whose
+    *           elements all satisfy `p`, and the rest of this $coll.
+    */
+  def span(p: A => Boolean): (C, C) = (takeWhile(p), dropWhile(p))
+
   /** The rest of the collection without its `n` first elements. For
     *  linear, immutable collections this should avoid making a copy.
     */

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -6,6 +6,7 @@ import scala.reflect.ClassTag
 import scala.{Any, Array, Boolean, `inline`, Int, None, Numeric, Option, Ordering, StringContext, Some, Unit}
 import scala.Predef.<:<
 import java.lang.{String, UnsupportedOperationException}
+import scala.Predef.<:<
 
 import strawman.collection.mutable.{ArrayBuffer, Builder, StringBuilder}
 import java.lang.String
@@ -460,7 +461,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   def partition(p: A => Boolean): (C, C) = {
     val pn = View.Partition(coll, p)
-    (fromSpecificIterable(pn.left), fromSpecificIterable(pn.right))
+    (fromSpecificIterable(pn.first), fromSpecificIterable(pn.second))
   }
 
   /** Splits this $coll into two at a given position.
@@ -659,7 +660,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
     val unzipped = View.Unzip(coll)
-    (fromIterable(unzipped.left), fromIterable(unzipped.right))
+    (fromIterable(unzipped.first), fromIterable(unzipped.second))
   }
 
 }

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -235,6 +235,28 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     }
   }
 
+  /** Takes longest prefix of values produced by this iterator that satisfy a predicate.
+    *
+    *  @param   p  The predicate used to test elements.
+    *  @return  An iterator returning the values produced by this iterator, until
+    *           this iterator produces a value that does not satisfy
+    *           the predicate `p`.
+    *  @note    Reuse: $consumesAndProducesIterator
+    */
+  def takeWhile(p: A => Boolean): Iterator[A] = new Iterator[A] {
+    private var hd: A = _
+    private var hdDefined: Boolean = false
+    private var tail: Iterator[A] = self
+
+    def hasNext = hdDefined || tail.hasNext && {
+      hd = tail.next()
+      if (p(hd)) hdDefined = true
+      else tail = Iterator.empty
+      hdDefined
+    }
+    def next() = if (hasNext) { hdDefined = false; hd } else Iterator.empty.next()
+  }
+
   def drop(n: Int): Iterator[A] = {
     var i = 0
     while (i < n && hasNext) {

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -90,12 +90,12 @@ object View extends IterableFactory[View] {
     /** The view consisting of all elements of the underlying collection
      *  that satisfy `p`.
      */
-    val left = Partitioned(this, true)
+    val first = Partitioned(this, true)
 
     /** The view consisting of all elements of the underlying collection
      *  that do not satisfy `p`.
      */
-    val right = Partitioned(this, false)
+    val second = Partitioned(this, false)
   }
 
   /** A view representing one half of a partition. */
@@ -209,12 +209,12 @@ object View extends IterableFactory[View] {
   }
 
   case class Unzip[A, A1, A2](underlying: Iterable[A])(implicit asPair: A <:< (A1, A2)) {
-    val left: View[A1] =
+    val first: View[A1] =
       new View[A1] {
         def iterator(): Iterator[A1] = underlying.iterator().map(_._1)
         override def knownSize: Int = underlying.knownSize
       }
-    val right: View[A2] =
+    val second: View[A2] =
       new View[A2] {
         def iterator(): Iterator[A2] = underlying.iterator().map(_._2)
         override def knownSize: Int = underlying.knownSize

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -139,6 +139,10 @@ object View extends IterableFactory[View] {
       if (underlying.knownSize >= 0) underlying.knownSize min normN else -1
   }
 
+  case class TakeWhile[A](underlying: Iterable[A], p: A => Boolean) extends View[A] {
+    def iterator(): Iterator[A] = underlying.iterator().takeWhile(p)
+  }
+
   case class ScanLeft[A, B](underlying: Iterable[A], z: B, op: (B, A) => B) extends View[B] {
     def iterator(): Iterator[B] = underlying.iterator().scanLeft(z)(op)
     override def knownSize: Int =

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -80,7 +80,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
 
   override def partition(p: A => Boolean): (ImmutableArray[A], ImmutableArray[A]) = {
     val pn = View.Partition(coll, p)
-    (ImmutableArray.fromIterable(pn.left), ImmutableArray.fromIterable(pn.right))
+    (ImmutableArray.fromIterable(pn.first), ImmutableArray.fromIterable(pn.second))
   }
 
   override def take(n: Int): ImmutableArray[A] = ImmutableArray.tabulate(n)(apply)

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -39,6 +39,16 @@ sealed trait List[+A]
     case _ => super.concat(xs)
   }
 
+  override def span(p: A => Boolean): (List[A], List[A]) = {
+    val b = new ListBuffer[A]
+    var these = this
+    while (!these.isEmpty && p(these.head)) {
+      b += these.head
+      these = these.tail
+    }
+    (b.toList, these)
+  }
+
   override def className = "List"
 }
 

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -134,17 +134,17 @@ final class NumericRange[T](
 
   import NumericRange.defaultOrdering
 
-//  override def min[T1 >: T](implicit ord: Ordering[T1]): T =
-//    if (ord eq defaultOrdering(num)) {
-//      if (num.signum(step) > 0) start
-//      else last
-//    } else super.min(ord)
-//
-//  override def max[T1 >: T](implicit ord: Ordering[T1]): T =
-//    if (ord eq defaultOrdering(num)) {
-//      if (num.signum(step) > 0) last
-//      else start
-//    } else super.max(ord)
+  override def min[T1 >: T](implicit ord: Ordering[T1]): T =
+    if (ord eq defaultOrdering(num)) {
+      if (num.signum(step) > 0) start
+      else last
+    } else super.min(ord)
+
+  override def max[T1 >: T](implicit ord: Ordering[T1]): T =
+    if (ord eq defaultOrdering(num)) {
+      if (num.signum(step) > 0) last
+      else start
+    } else super.max(ord)
 
   // Motivated by the desire for Double ranges with BigDecimal precision,
   // we need some way to map a Range and get another Range.  This can't be

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -5,7 +5,7 @@ package immutable
 import strawman.collection.immutable.{RedBlackTree => RB}
 import strawman.collection.mutable.{Builder, ImmutableBuilder}
 
-import scala.{Int, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
+import scala.{Boolean, Int, math, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
 
 /** This class implements immutable maps using a tree.
   *
@@ -99,6 +99,30 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     else if (n >= size) this
     else new TreeMap(RB.take(tree, n))
   }
+
+  override def slice(from: Int, until: Int) = {
+    if (until <= from) empty
+    else if (from <= 0) take(until)
+    else if (until >= size) drop(from)
+    else new TreeMap(RB.slice(tree, from, until))
+  }
+
+  override def dropRight(n: Int): TreeMap[K, V] = take(size - math.max(n, 0))
+
+  override def takeRight(n: Int): TreeMap[K, V] = drop(size - math.max(n, 0))
+
+  private[this] def countWhile(p: ((K, V)) => Boolean): Int = {
+    var result = 0
+    val it = iterator()
+    while (it.hasNext && p(it.next())) result += 1
+    result
+  }
+
+  override def dropWhile(p: ((K, V)) => Boolean): TreeMap[K, V] = drop(countWhile(p))
+
+  override def takeWhile(p: ((K, V)) => Boolean): TreeMap[K, V] = take(countWhile(p))
+
+  override def span(p: ((K, V)) => Boolean): (TreeMap[K, V], TreeMap[K, V]) = splitAt(countWhile(p))
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -5,7 +5,7 @@ package immutable
 import mutable.{Builder, ImmutableBuilder}
 import immutable.{RedBlackTree => RB}
 
-import scala.{Boolean, Int, NullPointerException, Option, Ordering, Some, Unit}
+import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Some, Unit}
 
 /** This class implements immutable sorted sets using a tree.
   *
@@ -69,6 +69,29 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     else if (n >= size) this
     else newSet(RB.take(tree, n))
   }
+
+  override def slice(from: Int, until: Int): TreeSet[A] = {
+    if (until <= from) empty
+    else if (from <= 0) take(until)
+    else if (until >= size) drop(from)
+    else newSet(RB.slice(tree, from, until))
+  }
+
+  override def dropRight(n: Int): TreeSet[A] = take(size - math.max(n, 0))
+
+  override def takeRight(n: Int): TreeSet[A] = drop(size - math.max(n, 0))
+
+  private[this] def countWhile(p: A => Boolean): Int = {
+    var result = 0
+    val it = iterator()
+    while (it.hasNext && p(it.next())) result += 1
+    result
+  }
+  override def dropWhile(p: A => Boolean): TreeSet[A] = drop(countWhile(p))
+
+  override def takeWhile(p: A => Boolean): TreeSet[A] = take(countWhile(p))
+
+  override def span(p: A => Boolean): (TreeSet[A], TreeSet[A]) = splitAt(countWhile(p))
 
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
 

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -154,7 +154,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     }
 
     override def last = lastOption.get
-    /*override*/ def lastOption = {
+    override def lastOption = {
       val entry = if (until.isDefined) RB.maxBefore(tree, until.get) else RB.max(tree)
       (entry, from) match {
         case (Some(e), Some(fr)) if ordering.compare(e._1, fr) < 0 => None

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -152,7 +152,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     }
 
     override def last = lastOption.get
-    /*override*/ def lastOption = {
+    override def lastOption = {
       val elem = if (until.isDefined) RB.maxKeyBefore(tree, until.get) else RB.maxKey(tree)
       (elem, from) match {
         case (Some(e), Some(fr)) if ordering.compare(e, fr) < 0 => None

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -12,7 +12,14 @@ import org.junit.Test
 
 class StrawmanTest {
 
+  def iterableOps(xs: Iterable[Int]): Unit = {
+    val x1 = xs.map(x => (x, x))
+    val (x2, x3) = x1.unzip
+    assert(xs == x2 && xs == x3)
+  }
+
   def seqOps(xs: Seq[Int]): Unit = {
+    iterableOps(xs)
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
     val x2 = xs.foldRight("")(_ + _)
@@ -136,6 +143,7 @@ class StrawmanTest {
   }
 
   def stringOps(xs: String): Unit = {
+    iterableOps(xs.map(_.intValue))
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
     val x2 = xs.foldRight("")(_ + _)
@@ -274,6 +282,7 @@ class StrawmanTest {
   }
 
   def immutableArrayOps(xs: immutable.ImmutableArray[Int]): Unit = {
+    iterableOps(xs)
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
     val x2 = xs.foldRight("")(_ + _)
@@ -441,6 +450,7 @@ class StrawmanTest {
   }
 
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
+    iterableOps(xs)
     val xs1 = xs.map((x: Int) => x.toString) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
     val xs2: immutable.SortedSet[String] = xs1
     val l = List(1,2,3)
@@ -481,6 +491,7 @@ class StrawmanTest {
   }
 
   def bitSets(xs: immutable.BitSet, ys: BitSet, zs: Set[Int]): Unit = {
+    iterableOps(xs)
     val xs1 = xs & zs
     val xs2: immutable.BitSet = xs1
     val xs3 = xs ^ ys


### PR DESCRIPTION
Essentially, the approach is to implement them directly in `IterableOps` when they are “terminal” methods (e.g. `max`, `reduce`) and to have a view based implementation when a collection is returned (e.g. `dropWhile`, `scanLeft`). When we return a collection but have no other choice than consuming all the elements (e.g. `scanRight`), a custom implementation is done in `IterableOps`.

Fixes #119.