### PR TITLE
Laziness tweaks

### DIFF
--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -16,6 +16,8 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   protected[this] def newSpecificBuilder(): Builder[A, View[A]] =
     immutable.IndexedSeq.newBuilder().mapResult(_.view)
 
+  override def toString = "View(?)"
+
   override def className = "View"
 }
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -30,7 +30,6 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   @tailrec final def length: Int = if (isEmpty) 0 else tail.length
 
-  def #:: [B >: A](elem: B): LazyList[B] = new LazyList(Some((elem, this)))
   def prepend[B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
   def iterableFactory = LazyList
@@ -56,6 +55,10 @@ object LazyList extends IterableFactory[LazyList] {
   type Evaluated[+A] = Option[(A, LazyList[A])]
 
   object Empty extends LazyList[Nothing](None)
+
+  implicit class Deferrer[A](l: => LazyList[A]) {
+    def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, l)))
+  }
 
   object #:: {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -30,7 +30,7 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   @tailrec final def length: Int = if (isEmpty) 0 else tail.length
 
-  def prepend[B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
+  def prependLazy[B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
   def iterableFactory = LazyList
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -30,7 +30,8 @@ class LazyList[+A](expr: => LazyList.Evaluated[A])
 
   @tailrec final def length: Int = if (isEmpty) 0 else tail.length
 
-  def #:: [B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
+  def #:: [B >: A](elem: B): LazyList[B] = new LazyList(Some((elem, this)))
+  def prepend[B >: A](elem: => B): LazyList[B] = new LazyList(Some((elem, this)))
 
   def iterableFactory = LazyList
 

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -413,6 +413,13 @@ class StrawmanTest {
     println(xs17.to(List))
     println(xs19)
     println(xs19.to(List))
+
+    var lazeCount = 0
+    def laze(i: Int) = {lazeCount += 1; i}
+    val xs20 = laze(1) #:: laze (2) #:: laze(3) #:: LazyList.empty
+    assert(1==lazeCount)
+    val xs21 = laze(4) #:: xs20
+    assert(2==lazeCount)
   }
 
   def equality(): Unit = {

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -414,15 +414,21 @@ class StrawmanTest {
     println(xs19)
     println(xs19.to(List))
 
-    var lazeCount = 0
-    def laze(i: Int) = {lazeCount += 1; i}
-    val xs20 = laze(1) #:: laze (2) #:: laze(3) #:: LazyList.empty
-    assert(1==lazeCount)
-    val xs21 = laze(4) #:: xs20
-    assert(2==lazeCount)
-    import scala.math.BigInt
-    lazy val fibs: LazyList[BigInt] = BigInt(0) #:: BigInt(1) #:: fibs.zip(fibs.tail).map { n => n._1 + n._2 }
-    assert(List(0,1,1,2)==fibs.take(4).to(List))
+    // laziness may differ in dotty, so test only that we are as lazy as Stream
+    import scala.collection.{immutable => old}
+    lazy val fibsStream: old.Stream[Int] = 0 #:: 1 #:: fibsStream.zip(fibsStream.tail).map { n => n._1 + n._2 }
+    if(old.List(0,1,1,2)==fibsStream.take(4).toList) {
+      lazy val fibs: LazyList[Int] = 0 #:: 1 #:: fibs.zip(fibs.tail).map { n => n._1 + n._2 }
+      assert(List(0, 1, 1, 2) == fibs.take(4).to(List))
+    }
+
+    var lazeCountS = 0
+    var lazeCountL = 0
+    def lazeL(i: Int) = {lazeCountL += 1; i}
+    def lazeS(i: Int) = {lazeCountS += 1; i}
+    val xs20 = lazeS(1) #:: lazeS(2) #:: lazeS(3) #:: old.Stream.empty
+    val xs21 = lazeL(1) #:: lazeL(2) #:: lazeL(3) #:: LazyList.empty
+    assert(lazeCountS==lazeCountL)
   }
 
   def equality(): Unit = {

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -420,6 +420,9 @@ class StrawmanTest {
     assert(1==lazeCount)
     val xs21 = laze(4) #:: xs20
     assert(2==lazeCount)
+    import scala.math.BigInt
+    lazy val fibs: LazyList[BigInt] = BigInt(0) #:: BigInt(1) #:: fibs.zip(fibs.tail).map { n => n._1 + n._2 }
+    assert(List(0,1,1,2)==fibs.take(4).to(List))
   }
 
   def equality(): Unit = {


### PR DESCRIPTION
Make `LazyList.#::`'s argument non-lazy, as it will actually be evaluated eagerly; add a truly lazy `prepend` method.
Somewhat related: stub out `View.toString` so views don't get forced prematurely.