### PR TITLE
Remove dropRight and takeRight from Iterator

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -519,7 +519,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   def dropRight(n: Int): C = {
     val b = newSpecificBuilder()
-    if (n >= 0) b.sizeHint(coll, -n)
+    if (n >= 0) b.sizeHint(coll, delta = -n)
     val lead = coll.iterator() drop n
     val it = coll.iterator()
     while (lead.hasNext) {

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -475,7 +475,18 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def take(n: Int): C = fromSpecificIterable(View.Take(coll, n))
 
   /** A collection containing the last `n` elements of this collection. */
-  def takeRight(n: Int): C = fromSpecificIterable(View.TakeRight(coll, n))
+  def takeRight(n: Int): C = {
+    val b = newSpecificBuilder()
+    b.sizeHintBounded(n, coll)
+    val lead = coll.iterator() drop n
+    val it = coll.iterator()
+    while (lead.hasNext) {
+      lead.next()
+      it.next()
+    }
+    while (it.hasNext) b += it.next()
+    b.result()
+  }
 
   /** Takes longest prefix of elements that satisfy a predicate.
     *  $orderDependent
@@ -506,7 +517,17 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** The rest of the collection without its `n` last elements. For
     *  linear, immutable collections this should avoid making a copy.
     */
-  def dropRight(n: Int): C = fromSpecificIterable(View.DropRight(coll, n))
+  def dropRight(n: Int): C = {
+    val b = newSpecificBuilder()
+    if (n >= 0) b.sizeHint(coll, -n)
+    val lead = coll.iterator() drop n
+    val it = coll.iterator()
+    while (lead.hasNext) {
+      b += it.next
+      lead.next()
+    }
+    b.result()
+  }
 
   /** Skips longest sequence of elements of this iterator which satisfy given
     *  predicate `p`, and returns an iterator of the remaining elements.

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -379,44 +379,6 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       else Iterator.empty.next()
   }
 
-  /*
-   * Implemented by means of a buffer to keep track of the last n elements during iteration.
-   */
-  def takeRight(n: Int): Iterator[A] = {
-    if (n <= 0) Iterator.empty
-    else {
-      // Return an iterator that iterates over the elements via a buffer
-      new Iterator[A]() {
-        private[this] var index = 0
-        private[this] var count = 0
-        // Use a lazy val for the buffer to make sure initialization is done only if needed and at most once
-        private[this] lazy val buffer = {
-          // Iterate over all elements while keeping track of the last n
-          var buf = ArrayBuffer[A]()
-          while (self.hasNext) {
-            if (index >= buf.length) buf += self.next()
-            else buf(index) = self.next()
-            index = if ((index + 1) >= n) 0 else index + 1
-            if (count < n) count += 1
-          }
-          // Adjust the starting index if needed
-          index = if (index >= buf.length) 0 else index
-          buf
-        }
-        def hasNext: Boolean = {
-          // Force initialization of buffer and return whether there are any elements left in the buffer
-          buffer != null && count > 0
-        }
-        def next(): A = {
-          val value = buffer(index)
-          index = if (index + 1 >= buffer.length) 0 else index + 1
-          count -= 1
-          value
-        }
-      }
-    }
-  }
-
   /** Takes longest prefix of values produced by this iterator that satisfy a predicate.
     *
     *  @param   p  The predicate used to test elements.
@@ -446,40 +408,6 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       i += 1
     }
     this
-  }
-
-  /*
-   * Implemented by means of a buffer to keep the last n elements from being returned during iteration.
-   */
-  def dropRight(n: Int): Iterator[A] = {
-    if (n <= 0) self
-    else {
-      // Return an iterator that returns already buffered elements as it buffers new ones (using a buffer of most n elements)
-      new Iterator[A]() {
-        private[this] var index = 0
-        private[this] lazy val buffer = {
-          // Fill the buffer with the first n elements (or fewer if the n is greater than the iterator length)
-          val buf = ArrayBuffer[A]()
-          while (index < n && self.hasNext) {
-            buf += self.next()
-            index += 1
-          }
-          index = 0
-          buf
-        }
-
-        def hasNext: Boolean = {
-          // Force initialization of buffer and don't stop until the iterator is exhausted (without having returned the elements currently in the buffer since those are the ones to drop)
-          buffer != null && self.hasNext
-        }
-        def next(): A = {
-          val value = buffer(index)
-          buffer(index) = self.next()
-          index = if (index + 1 >= buffer.length) 0 else index + 1
-          value
-        }
-      }
-    }
   }
 
   /** Skips longest sequence of elements of this iterator which satisfy given

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -273,9 +273,8 @@ object IndexedView {
   }
 
   class TakeRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
-    private val normN = n max 0
-    private val delta = underlying.length - normN
-    def length = underlying.length min normN
+    private[this] val delta = (underlying.length - (n max 0)) max 0
+    def length = underlying.length - delta
     def apply(i: Int) = underlying.apply(i + delta)
   }
 
@@ -287,8 +286,8 @@ object IndexedView {
   }
 
   class DropRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
-    private val normN = n max 0
-    def length = (underlying.length - normN) max 0
+    private[this] val len = (underlying.length - (n max 0)) max 0
+    def length = len
     def apply(i: Int) = underlying.apply(i)
   }
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -113,14 +113,6 @@ object View extends IterableFactory[View] {
       if (underlying.knownSize >= 0) (underlying.knownSize - normN) max 0 else -1
   }
 
-  /** A view that drops trailing elements of the underlying collection. */
-  case class DropRight[A](underlying: Iterable[A], n: Int) extends View[A] {
-    def iterator() = underlying.iterator().dropRight(n)
-    protected val normN = n max 0
-    override def knownSize =
-      if (underlying.knownSize >= 0) (underlying.knownSize - normN) max 0 else -1
-  }
-
   case class DropWhile[A](underlying: Iterable[A], p: A => Boolean) extends View[A] {
     def iterator() = underlying.iterator().dropWhile(p)
   }
@@ -128,14 +120,6 @@ object View extends IterableFactory[View] {
   /** A view that takes leading elements of the underlying collection. */
   case class Take[A](underlying: Iterable[A], n: Int) extends View[A] {
     def iterator() = underlying.iterator().take(n)
-    protected val normN = n max 0
-    override def knownSize =
-      if (underlying.knownSize >= 0) underlying.knownSize min normN else -1
-  }
-
-  /** A view that takes trailing elements of the underlying collection. */
-  case class TakeRight[A](underlying: Iterable[A], n: Int) extends View[A] {
-    def iterator() = underlying.iterator().takeRight(n)
     protected val normN = n max 0
     override def knownSize =
       if (underlying.knownSize >= 0) underlying.knownSize min normN else -1
@@ -269,6 +253,8 @@ trait IndexedView[+A] extends View[A] with ArrayLike[A] { self =>
     }
   }
 
+  override def knownSize: Int = length
+
   override def take(n: Int): IndexedView[A] = new IndexedView.Take(this, n)
   override def takeRight(n: Int): IndexedView[A] = new IndexedView.TakeRight(this, n)
   override def drop(n: Int): IndexedView[A] = new IndexedView.Drop(this, n)
@@ -286,11 +272,11 @@ object IndexedView {
     def apply(i: Int) = underlying.apply(i)
   }
 
-  class TakeRight[A](underlying: IndexedView[A], n: Int)
-  extends View.TakeRight(underlying, n) with IndexedView[A] {
-    override def iterator() = super.iterator() // needed to avoid "conflicting overrides" error
+  class TakeRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
+    private val normN = n max 0
+    private val delta = underlying.length - normN
     def length = underlying.length min normN
-    def apply(i: Int) = underlying.apply(i)
+    def apply(i: Int) = underlying.apply(i + delta)
   }
 
   class Drop[A](underlying: IndexedView[A], n: Int)
@@ -300,16 +286,13 @@ object IndexedView {
     def apply(i: Int) = underlying.apply(i + normN)
   }
 
-  class DropRight[A](underlying: IndexedView[A], n: Int)
-  extends View.DropRight(underlying, n) with IndexedView[A] {
-    override def iterator() = super.iterator()
+  class DropRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
+    private val normN = n max 0
     def length = (underlying.length - normN) max 0
-    def apply(i: Int) = underlying.apply(i + normN)
+    def apply(i: Int) = underlying.apply(i)
   }
 
-  class Map[A, B](underlying: IndexedView[A], f: A => B)
-  extends View.Map(underlying, f) with IndexedView[B] {
-    override def iterator() = super.iterator()
+  class Map[A, B](underlying: IndexedView[A], f: A => B) extends IndexedView[B] {
     def length = underlying.length
     def apply(n: Int) = f(underlying.apply(n))
   }

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -136,7 +136,10 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
     }
     else new ArrayBuffer[B] ++= coll
 
-  def newBuilder[A](): Builder[A, ArrayBuffer[A]] = new GrowableBuilder(empty[A])
+  def newBuilder[A](): Builder[A, ArrayBuffer[A]] =
+    new GrowableBuilder[A, ArrayBuffer[A]](empty) {
+      override def sizeHint(size: Int): Unit = elems.ensureSize(size)
+    }
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }

--- a/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -28,6 +28,41 @@ trait Builder[-A, +To] extends Growable[A] { self =>
     */
   def sizeHint(size: Int): Unit = ()
 
+  /** Gives a hint that one expects the `result` of this builder
+    *  to have the same size as the given collection, plus some delta. This will
+    *  provide a hint only if the collection has a known size
+    *  Some builder classes
+    *  will optimize their representation based on the hint. However,
+    *  builder implementations are still required to work correctly even if the hint is
+    *  wrong, i.e. a different number of elements is added.
+    *
+    *  @param coll  the collection which serves as a hint for the result's size.
+    *  @param delta a correction to add to the `coll.size` to produce the size hint.
+    */
+  final def sizeHint(coll: strawman.collection.Iterable[_], delta: Int): Unit = {
+    if (coll.knownSize != -1) {
+      sizeHint(coll.knownSize + delta)
+    }
+  }
+
+  /** Gives a hint how many elements are expected to be added
+    *  when the next `result` is called, together with an upper bound
+    *  given by the size of some other collection. Some builder classes
+    *  will optimize their representation based on the hint. However,
+    *  builder implementations are still required to work correctly even if the hint is
+    *  wrong, i.e. a different number of elements is added.
+    *
+    *  @param size  the hint how many elements will be added.
+    *  @param boundingColl  the bounding collection. If it is
+    *                       an IndexedSeqLike, then sizes larger
+    *                       than collection's size are reduced.
+    */
+  final def sizeHintBounded(size: Int, boundingColl: strawman.collection.Iterable[_]): Unit = {
+    if (boundingColl.knownSize != -1) {
+      sizeHint(scala.math.min(boundingColl.knownSize, size))
+    }
+  }
+
   /** A builder resulting from this builder my mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo) = new Builder[A, NewTo] {
     def add(x: A): this.type = { self += x; this }

--- a/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
@@ -15,7 +15,7 @@ import scala.Unit
   * @define Coll `GrowingBuilder`
   * @define coll growing builder
   */
-class GrowableBuilder[Elem, To <: Growable[Elem]](elems: To) extends Builder[Elem, To] {
+class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To) extends Builder[Elem, To] {
   def clear(): Unit = elems.clear()
   def result(): To = elems
   def add(elem: Elem): this.type = { elems += elem; this }


### PR DESCRIPTION
Fixes #131.

Note that I kept the `grouped` and `sliding` methods of `Iterator` even though they also use buffers. Since these methods do exist in 2.12 we have to discuss before we remove them…