### PR TITLE
Add `@throws` annotations; fix iterators

### DIFF
--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{AnyVal, Array, Char, Int}
+import scala.{AnyVal, Array, ArrayIndexOutOfBoundsException, Char, Int, throws}
 import scala.Predef.???
 import mutable.{ArrayBuffer, GrowableBuilder}
 
@@ -19,6 +19,7 @@ class ArrayOps[A](val xs: Array[A])
   protected[this] def seq: Seq[A] = iterableFactory.fromIterable(coll)
 
   def length = xs.length
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int) = xs.apply(i)
 
   override def view = ArrayView(xs)
@@ -45,6 +46,7 @@ class ArrayOps[A](val xs: Array[A])
 
 case class ArrayView[A](xs: Array[A]) extends IndexedView[A] {
   def length = xs.length
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(n: Int) = xs(n)
   override def className = "ArrayView"
 }

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import scala.{Any, Array, Boolean, Int, math, None, NoSuchElementException, Nothing, Option, StringContext, Some, Unit}
+import scala.{Any, Array, Boolean, Int, math, None, NoSuchElementException, Nothing, Option, StringContext, Some, Unit, throws}
 import scala.Predef.{intWrapper, require}
 import strawman.collection.mutable.ArrayBuffer
 
@@ -13,6 +13,7 @@ import strawman.collection.mutable.ArrayBuffer
   */
 trait Iterator[+A] extends IterableOnce[A] { self =>
   def hasNext: Boolean
+  @throws[NoSuchElementException]
   def next(): A
   def iterator() = this
 
@@ -190,7 +191,8 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     }
 
     def hasNext = filled || fill()
-    def next = {
+    @throws[NoSuchElementException]
+    def next() = {
       if (!filled)
         fill()
 

--- a/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/src/main/scala/strawman/collection/LinearSeq.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, IndexOutOfBoundsException, Int}
+import scala.{Any, Boolean, IndexOutOfBoundsException, Int, throws}
 
 /** Base trait for linearly accessed sequences that have efficient `head` and
   *  `tail` operations.
@@ -57,6 +57,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
   /** `apply` is defined in terms of `drop`, which is in turn defined in
     *  terms of `tail`.
     */
+  @throws[IndexOutOfBoundsException]
   override def apply(n: Int): A = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val skipped = drop(n)

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -3,7 +3,7 @@ package collection
 
 import collection.mutable.Builder
 
-import scala.{Any, Boolean, ClassCastException, Equals, Int, NoSuchElementException, None, Nothing, Option, Ordering, PartialFunction, Some, `inline`}
+import scala.{Any, Boolean, ClassCastException, Equals, Int, NoSuchElementException, None, Nothing, Option, Ordering, PartialFunction, Some, `inline`, throws}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
 
@@ -56,6 +56,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @return     the value associated with the given key, or the result of the
     *              map's `default` method, if none exists.
     */
+  @throws[NoSuchElementException]
   def apply(key: K): V = get(key) match {
     case None => default(key)
     case Some(value) => value
@@ -69,6 +70,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @param key the given key value for which a binding is missing.
     *  @throws NoSuchElementException
     */
+  @throws[NoSuchElementException]
   def default(key: K): V =
     throw new NoSuchElementException("key not found: " + key)
 

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import scala.{Any, AnyRef, Array, Boolean, Equals, IndexOutOfBoundsException, Int, Ordering, Unit, math}
+import scala.{Any, AnyRef, Array, Boolean, Equals, IndexOutOfBoundsException, Int, NoSuchElementException, Ordering, Unit, math, throws}
 import scala.Predef.intWrapper
 import java.lang.Object
 
@@ -228,6 +228,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     private var _hasNext = true
 
     def hasNext = _hasNext
+    @throws[NoSuchElementException]
     def next(): C = {
       if (!hasNext)
         Iterator.empty.next()

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{Any, Array, Boolean, Equals, `inline`, Int}
+import scala.{Any, Array, Boolean, Equals, Int, NoSuchElementException, `inline`, throws}
 import scala.Predef.intWrapper
 import scala.util.hashing.MurmurHash3
 
@@ -56,7 +56,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     private var itr: Iterator[C] = Iterator.empty
 
     def hasNext = len <= elms.size || itr.hasNext
-    def next = {
+    def next() = {
       if (!itr.hasNext) {
         if (len > elms.size) Iterator.empty.next()
         else {
@@ -81,6 +81,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     idxs(len) = elms.size
 
     def hasNext = _hasNext
+    @throws[NoSuchElementException]
     def next(): C = {
       if (!hasNext) Iterator.empty.next()
 

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import scala.{Array, Char, Int, AnyVal}
+import scala.{Array, Char, Int, StringIndexOutOfBoundsException, AnyVal, throws}
 import scala.Predef.String
 import strawman.collection.mutable.StringBuilder
 
@@ -28,6 +28,8 @@ class StringOps(val s: String)
   protected[this] def newSpecificBuilder() = new StringBuilder
 
   def length = s.length
+
+  @throws[StringIndexOutOfBoundsException]
   def apply(i: Int) = s.charAt(i)
 
   override def knownSize = s.length
@@ -69,6 +71,7 @@ class StringOps(val s: String)
 
 case class StringView(s: String) extends IndexedView[Char] {
   def length = s.length
+  @throws[StringIndexOutOfBoundsException]
   def apply(n: Int) = s.charAt(n)
   override def className = "StringView"
 }

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -2,7 +2,7 @@ package strawman.collection
 
 import strawman.collection.mutable.{ArrayBuffer, Builder}
 
-import scala.{Any, Boolean, Equals, Int, Nothing, annotation}
+import scala.{Any, Boolean, Equals, IndexOutOfBoundsException, Int, Nothing, annotation, throws}
 import scala.Predef.{<:<, intWrapper}
 
 /** Concrete collection type: View */
@@ -253,6 +253,7 @@ object View extends IterableFactory[View] {
 /** A trait representing indexable collections with finite length */
 trait ArrayLike[+A] extends Any {
   def length: Int
+  @throws[IndexOutOfBoundsException]
   def apply(i: Int): A
 }
 
@@ -283,6 +284,7 @@ object IndexedView {
   extends View.Take(underlying, n) with IndexedView[A] {
     override def iterator() = super.iterator() // needed to avoid "conflicting overrides" error
     def length = underlying.length min normN
+    @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i)
   }
 
@@ -290,6 +292,7 @@ object IndexedView {
   extends View.TakeRight(underlying, n) with IndexedView[A] {
     override def iterator() = super.iterator() // needed to avoid "conflicting overrides" error
     def length = underlying.length min normN
+    @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i)
   }
 
@@ -297,6 +300,7 @@ object IndexedView {
   extends View.Drop(underlying, n) with IndexedView[A] {
     override def iterator() = super.iterator()
     def length = (underlying.length - normN) max 0
+    @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + normN)
   }
 
@@ -304,6 +308,7 @@ object IndexedView {
   extends View.DropRight(underlying, n) with IndexedView[A] {
     override def iterator() = super.iterator()
     def length = (underlying.length - normN) max 0
+    @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + normN)
   }
 
@@ -311,11 +316,13 @@ object IndexedView {
   extends View.Map(underlying, f) with IndexedView[B] {
     override def iterator() = super.iterator()
     def length = underlying.length
+    @throws[IndexOutOfBoundsException]
     def apply(n: Int) = f(underlying.apply(n))
   }
 
   case class Reverse[A](underlying: IndexedView[A]) extends IndexedView[A] {
     def length = underlying.length
+    @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(length - 1 - i)
   }
 }

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -4,7 +4,7 @@ package collection.immutable
 import strawman.collection.mutable.{ArrayBuffer, Builder, GrowableBuilder}
 import strawman.collection.{IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps, View}
 
-import scala.{Any, Boolean, Int, Nothing}
+import scala.{Any, ArrayIndexOutOfBoundsException, Boolean, Int, Nothing, throws}
 import scala.runtime.ScalaRunTime
 import scala.Predef.{???, intWrapper}
 
@@ -28,6 +28,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
 
   override def knownSize: Int = elements.length
 
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A = ScalaRunTime.array_apply(elements, i).asInstanceOf[A]
 
   def iterator(): Iterator[A] = view.iterator()

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -13,7 +13,7 @@ package immutable
 import collection.{Iterator, MapFactory}
 
 import scala.annotation.tailrec
-import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, NoSuchElementException, Nothing, Option, SerialVersionUID, Serializable, Some, sys, throws}
+import scala.{Any, AnyRef, Array, Boolean, Int, None, NoSuchElementException, Nothing, Option, SerialVersionUID, Serializable, Some, sys, throws}
 import java.lang.Integer
 
 import strawman.collection.mutable.{Builder, ImmutableBuilder}

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -13,7 +13,7 @@ package immutable
 import collection.{Iterator, MapFactory}
 
 import scala.annotation.tailrec
-import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, sys}
+import scala.{Any, AnyRef, Array, Boolean, Int, NoSuchElementException, None, NoSuchElementException, Nothing, Option, SerialVersionUID, Serializable, Some, sys, throws}
 import java.lang.Integer
 
 import strawman.collection.mutable.{Builder, ImmutableBuilder}
@@ -101,6 +101,7 @@ sealed class ListMap[K, +V]
 
     override def isEmpty: Boolean = false
 
+    @throws[NoSuchElementException]
     override def apply(k: K): V1 = applyInternal(this, k)
 
     @tailrec private[this] def applyInternal(cur: ListMap[K, V1], k: K): V1 =

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -3,7 +3,7 @@ package strawman.collection.immutable
 import strawman.collection
 import strawman.collection.{IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
 
-import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, Int, Integral, Numeric, Ordering, Serializable, StringContext, Unit, `inline`, math, specialized}
+import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, Int, Integral, NoSuchElementException, Numeric, Ordering, Serializable, StringContext, Unit, `inline`, math, specialized, throws}
 import scala.Predef.ArrowAssoc
 import java.lang.String
 
@@ -80,6 +80,7 @@ final class NumericRange[T](
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange[T](start, end, step, isInclusive)
 
+  @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
     if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
     else locationAfterN(idx)
@@ -403,7 +404,9 @@ private class NumericRangeIterator[T](
   private var _hasNext: Boolean = !initiallyEmpty
   private var _next: T = start
   def hasNext: Boolean = _hasNext
+  @throws[NoSuchElementException]
   def next(): T = {
+    if (!_hasNext) Iterator.empty.next()
     val value = _next
     _hasNext = value != lastElement
     _next = num.plus(value, step)

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -3,7 +3,7 @@ package collection.immutable
 
 import collection.{IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
 
-import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, Long, Numeric, Ordering, SerialVersionUID, Serializable, StringContext, Unit, `inline`, specialized}
+import scala.{Any, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, Long, NoSuchElementException, Numeric, Ordering, SerialVersionUID, Serializable, StringContext, Unit, `inline`, specialized, throws}
 import scala.Predef.augmentString
 import java.lang.String
 
@@ -150,6 +150,7 @@ final class Range(
   private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
   private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
 
+  @throws[IndexOutOfBoundsException]
   def apply(idx: Int): Int = {
     validateMaxLength()
     if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
@@ -453,7 +454,9 @@ private class RangeIterator(
   private var _hasNext: Boolean = !initiallyEmpty
   private var _next: Int = start
   def hasNext: Boolean = _hasNext
+  @throws[NoSuchElementException]
   def next(): Int = {
+    if (!_hasNext) Iterator.empty.next()
     val value = _next
     _hasNext = value != lastElement
     _next = value + step

--- a/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
+++ b/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
@@ -14,7 +14,7 @@ import collection.Iterator
 import scala.annotation.tailrec
 import scala.annotation.meta.getter
 
-import scala.{Array, Boolean, `inline`, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit}
+import scala.{Array, Boolean, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit, `inline`, throws}
 import java.lang.{Integer, String}
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
@@ -472,6 +472,7 @@ private[collection] object RedBlackTree {
 
     override def hasNext: Boolean = lookahead ne null
 
+    @throws[NoSuchElementException]
     override def next(): R = lookahead match {
       case null =>
         throw new NoSuchElementException("next on empty iterator")

--- a/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -10,7 +10,7 @@ import strawman.collection.mutable.ArrayBuffer
 
 import scala.annotation.unchecked.{uncheckedVariance => uV}
 import scala.annotation.tailrec
-import scala.{AnyRef, Array, Boolean, Int}
+import scala.{AnyRef, Array, Boolean, Int, NoSuchElementException, throws}
 import scala.Predef.intWrapper
 
 /** Abandons any pretense of type safety for speed.  You can't say I
@@ -91,6 +91,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
     }
 
   def hasNext = (subIter ne null) || depth >= 0
+  @throws[NoSuchElementException]
   def next(): T = {
     if (subIter ne null) {
       val el = subIter.next()

--- a/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -5,7 +5,7 @@ package immutable
 import strawman.collection.mutable.{Builder, ReusableBuilder}
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.{AnyRef, Array, Boolean, IllegalArgumentException, IndexOutOfBoundsException, `inline`, Int, math, NoSuchElementException, Nothing, Serializable, SerialVersionUID, Unit, UnsupportedOperationException}
+import scala.{AnyRef, Array, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, math, NoSuchElementException, Nothing, Serializable, SerialVersionUID, Unit, UnsupportedOperationException, `inline`, throws}
 import scala.Predef.intWrapper
 
 /** Companion object to the Vector class
@@ -105,11 +105,13 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
   // In principle, escape analysis could even remove the iterator/builder allocations and do it
   // with local variables exclusively. But we're not quite there yet ...
 
+  @throws[IndexOutOfBoundsException]
   def apply(index: Int): A = {
     val idx = checkRangeConvert(index)
     getElem(idx, idx ^ focus)
   }
 
+  @throws[IndexOutOfBoundsException]
   private def checkRangeConvert(index: Int) = {
     val idx = index + startIndex
     if (index >= 0 && idx < endIndex)

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -4,7 +4,7 @@ package mutable
 
 import java.lang.IndexOutOfBoundsException
 
-import scala.{AnyRef, Array, Boolean, Exception, Int, Long, StringContext, Unit, math, Any}
+import scala.{AnyRef, Array, ArrayIndexOutOfBoundsException, Boolean, Exception, Int, Long, StringContext, Unit, math, Any, throws}
 import scala.Predef.intWrapper
 
 /** Concrete collection type: ArrayBuffer */
@@ -36,6 +36,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
     if (hi > end) throw new IndexOutOfBoundsException(hi.toString)
   }
 
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(n: Int) = array(n).asInstanceOf[A]
 
   def update(n: Int, elem: A): Unit = array(n) = elem.asInstanceOf[AnyRef]
@@ -142,6 +143,7 @@ object ArrayBuffer extends IterableFactory[ArrayBuffer] {
 }
 
 class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {
+  @throws[ArrayIndexOutOfBoundsException]
   def apply(n: Int) = array(n).asInstanceOf[A]
   override def className = "ArrayBufferView"
 }

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -3,7 +3,7 @@ package collection.mutable
 
 import strawman.collection.{Iterator, MapFactory, StrictOptimizedIterableOps}
 
-import scala.{Boolean, Int, None, Option, SerialVersionUID, Serializable, Some, Unit}
+import scala.{Boolean, Int, None, NoSuchElementException, Option, SerialVersionUID, Serializable, Some, Unit, throws}
 import java.lang.String
 
 /** This class implements mutable maps using a hashtable.
@@ -68,6 +68,7 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
 
   override def contains(key: K): Boolean = table.findEntry(key) != null
 
+  @throws[NoSuchElementException]
   override def apply(key: K): V = {
     val e = table.findEntry(key)
     if (e eq null) default(key)

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -2,7 +2,7 @@ package strawman.collection
 package mutable
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.{Any, Int, Unit, Boolean}
+import scala.{Any, Boolean, Int, Unit, throws}
 import scala.Int._
 import strawman.collection
 import strawman.collection.immutable.{List, Nil, ::}
@@ -29,6 +29,7 @@ class ListBuffer[A]
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListBuffer[A] = fromIterable(coll)
 
+  @throws[IndexOutOfBoundsException]
   def apply(i: Int) = first.apply(i)
 
   def length = len

--- a/src/main/scala/strawman/collection/mutable/RedBlackTree.scala
+++ b/src/main/scala/strawman/collection/mutable/RedBlackTree.scala
@@ -4,7 +4,7 @@ package collection.mutable
 import scala.annotation.tailrec
 import collection.Iterator
 
-import scala.{Boolean, `inline`, Int, None, NoSuchElementException, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
+import scala.{Boolean, `inline`, Int, None, NoSuchElementException, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit, throws}
 import java.lang.String
 
 /**
@@ -481,6 +481,7 @@ private[collection] object RedBlackTree {
 
     def hasNext: Boolean = nextNode ne null
 
+    @throws[NoSuchElementException]
     def next(): R = nextNode match {
       case null => throw new NoSuchElementException("next on empty iterator")
       case node =>


### PR DESCRIPTION
Add `@throws` annotations for `Map.apply`, `Seq.apply` and `Iterator.next()`.

Fix two cases where iterators did not bounds check.

Attempts to resolve #152 (though I may not have thought of some methods which should have `@throws` annotations).