### PR TITLE
Clean up Match case Unreachable Warning

### DIFF
--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -572,7 +572,6 @@ object HashMap extends MapFactory[HashMap] {
         new HashTrieMap[K, V1](this.bitmap | that.bitmap, merged, totalelems)
       case hm: HashMapCollision1[_, _] => that.merge0(this, level, merger.invert)
       case hm: HashMap[_, _] => this
-      case _ => sys.error("section supposed to be unreachable.")
     }
   }
 


### PR DESCRIPTION
Probably dont need this case
https://travis-ci.org/scala/collection-strawman#L1056

```
[warn] -- [E029] Match case Unreachable Warning: /home/travis/build/scala/collection-strawman/src/main/scala/strawman/collection/immutable/HashMap.scala:575:13 
[warn] 575 |      case _ => sys.error("section supposed to be unreachable.")
[warn]     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]     |             unreachable code
[warn] one warning found
```