### PR TITLE
Add StrictOptimizedSeqOps

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -21,6 +21,7 @@ class ListBenchmark {
 
   var xs: List[Long] = _
   var xss: scala.Array[List[Long]] = _
+  var zipped: List[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
@@ -28,6 +29,7 @@ class ListBenchmark {
     def freshCollection() = List((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
+    zipped = xs.map(x => (x, x))
     if (size > 0) {
       randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
     }
@@ -92,5 +94,26 @@ class ListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  @OperationsPerInvocation(100)
+  def span(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      bh.consume(xs1)
+      bh.consume(xs2)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
+
+  @Benchmark
+  def padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+
+  @Benchmark
+  def append(bh: Blackhole): Unit = bh.consume(xs.append(42))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -6,7 +6,7 @@ import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit}
-import scala.Predef.intWrapper
+import scala.Predef.{intWrapper, $conforms}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -21,6 +21,7 @@ class ScalaListBenchmark {
 
   var xs: scala.List[Long] = _
   var xss: scala.Array[scala.List[Long]] = _
+  var zipped: scala.List[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
@@ -28,6 +29,7 @@ class ScalaListBenchmark {
     def freshCollection() = scala.List((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
+    zipped = xs.map(x => (x, x))
     if (size > 0) {
       randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
     }
@@ -92,5 +94,26 @@ class ScalaListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  @OperationsPerInvocation(100)
+  def span(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      bh.consume(xs1)
+      bh.consume(xs2)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
+
+  @Benchmark
+  def padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
+
+  @Benchmark
+  def append(bh: Blackhole): Unit = bh.consume(xs :+ 42)
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
@@ -6,7 +6,7 @@ import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.{Any, AnyRef, Int, Long, Unit}
-import scala.Predef.intWrapper
+import scala.Predef.{intWrapper, $conforms}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -21,6 +21,7 @@ class ScalaVectorBenchmark {
 
   var xs: scala.Vector[Long] = _
   var xss: scala.Array[scala.Vector[Long]] = _
+  var zipped: scala.Vector[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
@@ -28,6 +29,7 @@ class ScalaVectorBenchmark {
     def freshCollection() = scala.Vector((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
+    zipped = xs.map(x => (x, x))
     if (size > 0) {
       randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
     }
@@ -81,5 +83,23 @@ class ScalaVectorBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  @OperationsPerInvocation(100)
+  def span(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      bh.consume(xs1)
+      bh.consume(xs2)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
+
+  @Benchmark
+  def padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
 
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
@@ -21,6 +21,7 @@ class VectorBenchmark {
 
   var xs: Vector[Long] = _
   var xss: scala.Array[Vector[Long]] = _
+  var zipped: Vector[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
 
   @Setup(Level.Trial)
@@ -28,6 +29,7 @@ class VectorBenchmark {
     def freshCollection() = Vector((1 to size).map(_.toLong): _*)
     xs = freshCollection()
     xss = scala.Array.fill(1000)(freshCollection())
+    zipped = xs.map(x => (x, x))
     if (size > 0) {
       randomIndices = scala.Array.fill(1000)(scala.util.Random.nextInt(size))
     }
@@ -75,5 +77,23 @@ class VectorBenchmark {
 
   @Benchmark
   def map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
+
+  @Benchmark
+  @OperationsPerInvocation(100)
+  def span(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      val (xs1, xs2) = xs.span(x => x < randomIndices(i))
+      bh.consume(xs1)
+      bh.consume(xs2)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
+
+  @Benchmark
+  def padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
 
 }

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -11,7 +11,7 @@ class ArrayOps[A](val xs: Array[A])
   extends AnyVal
     with IterableOnce[A]
     with IndexedSeqOps[A, immutable.IndexedSeq, Array[A]]
-    with StrictOptimizedIterableOps[A, Array[A]]
+    with StrictOptimizedIterableOps[A, Seq, Array[A]]
     with ArrayLike[A] {
 
   protected[this] def coll = ArrayView(xs)

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -10,7 +10,7 @@ class StringOps(val s: String)
   extends AnyVal
     with IterableOnce[Char]
     with IndexedSeqOps[Char, immutable.IndexedSeq, String]
-    with StrictOptimizedIterableOps[Char, String]
+    with StrictOptimizedIterableOps[Char, immutable.IndexedSeq, String]
     with ArrayLike[Char] {
 
   protected[this] def coll = StringView(s)

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -218,7 +218,7 @@ object View extends IterableFactory[View] {
   case class PadTo[A](underlying: Iterable[A], len: Int, elem: A) extends View[A] {
     def iterator(): Iterator[A] = new Iterator[A] {
       private var i = 0
-      private var it = underlying.iterator()
+      private val it = underlying.iterator()
       def next(): A = {
         val a =
           if (it.hasNext) it.next()
@@ -227,7 +227,7 @@ object View extends IterableFactory[View] {
         i += 1
         a
       }
-      def hasNext: Boolean = i < len
+      def hasNext: Boolean = it.hasNext || i < len
     }
     override def knownSize: Int = if (underlying.knownSize >= 0) underlying.knownSize max len else -1
   }

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -22,7 +22,7 @@ sealed abstract class BitSet
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
-    with StrictOptimizedIterableOps[Int, BitSet]
+    with StrictOptimizedIterableOps[Int, Set, BitSet]
     with Serializable {
 
   def empty: BitSet = BitSet.empty

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -31,7 +31,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
 sealed trait HashMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), HashMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
     with Serializable {
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -26,7 +26,7 @@ import java.lang.Integer
 sealed trait HashSet[A]
   extends Set[A]
     with SetOps[A, HashSet, HashSet[A]]
-    with StrictOptimizedIterableOps[A, HashSet[A]]
+    with StrictOptimizedIterableOps[A, HashSet, HashSet[A]]
     with Serializable {
 
   import HashSet.nullToEmpty

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -16,7 +16,7 @@ import scala.Predef.{???, intWrapper}
 class ImmutableArray[+A] private[collection] (private val elements: scala.Array[Any])
   extends IndexedSeq[A]
     with IndexedSeqOps[A, ImmutableArray, ImmutableArray[A]]
-    with StrictOptimizedIterableOps[A, ImmutableArray[A]] {
+    with StrictOptimizedSeqOps[A, ImmutableArray, ImmutableArray[A]] {
 
   def iterableFactory: IterableFactory[ImmutableArray] = ImmutableArray
 

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -12,7 +12,7 @@ import scala.{Any, Boolean, Int, NoSuchElementException, Nothing, UnsupportedOpe
 sealed trait List[+A]
   extends LinearSeq[A]
      with LinearSeqOps[A, List, List[A]]
-     with StrictOptimizedIterableOps[A, List[A]] {
+     with StrictOptimizedSeqOps[A, List, List[A]] {
 
   def iterableFactory = List
 

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -46,7 +46,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
 sealed class ListMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, ListMap, ListMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), ListMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
     with Serializable {
 
   def iterableFactory = List

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -33,7 +33,7 @@ import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Seria
 sealed class ListSet[A]
   extends Set[A]
     with SetOps[A, ListSet, ListSet[A]]
-    with StrictOptimizedIterableOps[A, ListSet[A]]
+    with StrictOptimizedIterableOps[A, ListSet, ListSet[A]]
     with Serializable {
 
   override def size: Int = 0

--- a/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -40,7 +40,7 @@ final class NumericRange[T](
 )
   extends IndexedSeq[T]
     with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
-    with StrictOptimizedIterableOps[T, IndexedSeq[T]]
+    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
     with Serializable {
 
   def iterator(): Iterator[T] = new NumericRangeIterator[T](start, step, last, isEmpty)

--- a/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/src/main/scala/strawman/collection/immutable/Range.scala
@@ -49,7 +49,7 @@ final class Range(
 )
   extends IndexedSeq[Int]
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
-    with StrictOptimizedIterableOps[Int, IndexedSeq[Int]]
+    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
     with Serializable { range =>
 
   def iterableFactory: IterableFactory[IndexedSeq] = IndexedSeq

--- a/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
@@ -1,0 +1,53 @@
+package strawman
+package collection
+package immutable
+
+import scala.{Any, IndexOutOfBoundsException, Int}
+
+/**
+  * Trait that overrides operations to take advantage of strict builders.
+  */
+trait StrictOptimizedSeqOps[+A, +CC[_], +C]
+  extends SeqOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, CC, C] {
+
+  override def prepend[B >: A](elem: B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    if (knownSize >= 0) {
+      b.sizeHint(size + 1)
+    }
+    b += elem
+    b ++= coll
+    b.result()
+  }
+
+  override def append[B >: A](elem: B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    if (knownSize >= 0) {
+      b.sizeHint(size + 1)
+    }
+    b ++= coll
+    b += elem
+    b.result()
+  }
+
+  override def updated[B >: A](index: Int, elem: B): CC[B] = {
+    if (index < 0) throw new IndexOutOfBoundsException(index.toString)
+    val b = iterableFactory.newBuilder[B]()
+    if (knownSize >= 0) {
+      b.sizeHint(size)
+    }
+    var i = 0
+    val it = coll.iterator()
+    while (i < index && it.hasNext) {
+      b += it.next()
+      i += 1
+    }
+    if (!it.hasNext) throw new IndexOutOfBoundsException(index.toString)
+    b += elem
+    it.next()
+    while (it.hasNext) b += it.next()
+    b.result()
+  }
+
+}

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -31,7 +31,7 @@ import scala.{Boolean, Int, math, Option, Ordering, SerialVersionUID, Serializab
 final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), TreeMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
     with Serializable {
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -28,7 +28,7 @@ import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Some, 
 final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
-    with StrictOptimizedIterableOps[A, TreeSet[A]] {
+    with StrictOptimizedIterableOps[A, Set, TreeSet[A]] {
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")
 

--- a/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -64,6 +64,7 @@ object Vector extends IterableFactory[Vector] {
 final class Vector[+A] private[immutable] (private[collection] val startIndex: Int, private[collection] val endIndex: Int, focus: Int)
   extends IndexedSeq[A]
     with IndexedSeqOps[A, Vector, Vector[A]]
+    with StrictOptimizedSeqOps[A, Vector, Vector[A]]
     with VectorPointer[A @uncheckedVariance]
     with Serializable { self =>
 

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -12,7 +12,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   extends IndexedSeq[A]
     with IndexedSeqOps[A, ArrayBuffer, ArrayBuffer[A]]
     with IndexedOptimizedGrowableSeq[A]
-    with StrictOptimizedIterableOps[A, ArrayBuffer[A]] {
+    with StrictOptimizedIterableOps[A, ArrayBuffer, ArrayBuffer[A]] {
 
   def this() = this(new Array[AnyRef](16), 0)
 

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -28,7 +28,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     with collection.BitSet
     with SortedSetOps[Int, SortedSet, BitSet]
     with collection.BitSetOps[BitSet]
-    with StrictOptimizedIterableOps[Int, BitSet]
+    with StrictOptimizedIterableOps[Int, Set, BitSet]
     with Serializable {
 
   def this(initSize: Int) = this(new Array[Long](math.max((initSize + 63) >> 6, 1)))

--- a/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
+++ b/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
@@ -15,8 +15,13 @@ import scala.Unit
   * @define Coll `GrowingBuilder`
   * @define coll growing builder
   */
-class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To) extends Builder[Elem, To] {
+class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
+  extends Builder[Elem, To] {
+
   def clear(): Unit = elems.clear()
+
   def result(): To = elems
+
   def add(elem: Elem): this.type = { elems += elem; this }
+
 }

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -24,7 +24,7 @@ import java.lang.String
 final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, DefaultEntry[K, V]])
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), HashMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
     with Serializable {
 
   def mapFactory = HashMap

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -22,7 +22,7 @@ import scala.{Any, Boolean, Option, Serializable, SerialVersionUID, Unit}
 final class HashSet[A](contents: FlatHashTable.Contents[A])
   extends Set[A]
     with SetOps[A, HashSet, HashSet[A]]
-    with StrictOptimizedIterableOps[A, HashSet[A]]
+    with StrictOptimizedIterableOps[A, HashSet, HashSet[A]]
     with Serializable {
 
   private[this] val table = new FlatHashTable[A]

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -14,7 +14,7 @@ import scala.Predef.{assert, intWrapper}
 class ListBuffer[A]
   extends GrowableSeq[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]
-     with StrictOptimizedIterableOps[A, ListBuffer[A]] {
+     with StrictOptimizedIterableOps[A, ListBuffer, ListBuffer[A]] {
 
   private var first: List[A] = Nil
   private var last0: ::[A] = null

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -25,7 +25,7 @@ import java.lang.String
 sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
-    with StrictOptimizedIterableOps[(K, V), TreeMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
     with Serializable {
 
   def mapFactory = Map

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -25,7 +25,7 @@ import java.lang.String
 sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
-    with StrictOptimizedIterableOps[A, TreeSet[A]]
+    with StrictOptimizedIterableOps[A, Set, TreeSet[A]]
     with Serializable {
 
   if (ordering eq null)


### PR DESCRIPTION
Fixes #125.

We get a performance boost on some collection types by overriding some operations to use strict builders. For instance, here is the benchmark for `span` on `Vector`:

![span](https://user-images.githubusercontent.com/332812/28316370-e1eb4ea4-6bc2-11e7-927e-9fd39c6fb1da.png)

Here is the benchmark for `append` on `List`:

![append](https://user-images.githubusercontent.com/332812/28316391-fc8ac690-6bc2-11e7-933d-9aadb819bfb9.png)

Some operations are worse when implemented on top of builders (so, for those, I kept the view-based implementation). E.g. `padTo` on `List`:

![padto](https://user-images.githubusercontent.com/332812/28316418-19242198-6bc3-11e7-957e-643b9c1757c2.png)

I’m still not 100% sure it is worth adding this `StrictOptimizedSeqOps` trait because it is currently inherited only by `Vector`, `List` and `ImmutableArray`, but only `List` actually benefits from the optimizations brought to `append` and `updated` because `Vector` and `ImmutableArray` override these operations anyway. Maybe we should just override `List` methods without introducing `StrictOptimizedSeqOps`…