### PR TITLE
Make `length` implementation final in LinearSeq.

### DIFF
--- a/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/src/main/scala/strawman/collection/LinearSeq.scala
@@ -34,7 +34,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     len
   }
 
-  def length: Int = size
+  final def length: Int = size
 
   /** Optimized version of `drop` that avoids copying
     *  Note: `drop` is defined here, rather than in a trait like `LinearSeqMonoTransforms`,


### PR DESCRIPTION
As noticed by @Ichoran, when a method aliases another method, it’s better to make it final.