### PR TITLE
Drop PartialFunction type annotations.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // Convenient setting that allows writing `set scalaVersion := dotty.value` in sbt shell to switch from Scala to Dotty
 val dotty = settingKey[String]("dotty version")
-dotty in ThisBuild := "0.2.0-RC1"
+dotty in ThisBuild := "0.3.0-bin-20170725-b7cafd8-NIGHTLY"
 
 val commonSettings = Seq(
   organization := "ch.epfl.scala",

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -31,7 +31,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
     sortedMapFromIterable(View.FlatMap(coll, f))
 
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    flatMap { (kv: (K, V)) =>
+    flatMap { kv =>
       if (pf.isDefinedAt(kv)) View.Single(pf(kv))
       else View.Empty
     }

--- a/src/test/scala/strawman/collection/test/Test.scala
+++ b/src/test/scala/strawman/collection/test/Test.scala
@@ -474,7 +474,7 @@ class StrawmanTest {
    }
 
   def mapOps(xs: Map[Int, String]): Unit = {
-    val xs1 = xs.map ({ case (k, v) => (v, k) }: scala.PartialFunction[(Int, String), (String, Int)])
+    val xs1 = xs.map ({ case (k, v) => (v, k) })
     val xs2: strawman.collection.Map[String, Int] = xs1
     val xs3 = xs.map(kv => (kv._2, kv._1))
     val xs4: strawman.collection.Iterable[(String, Int)] = xs3
@@ -491,17 +491,17 @@ class StrawmanTest {
     val xs2: immutable.SortedMap[String, Int] = xs1
     val xs3 = xs.map(kv => kv._1)
     // val xs4: immutable.Iterable[String] = xs3  // FIXME: does not work under dotty, we get a collection.Iterable
-    val xs5 = xs.map ({ case (k, v) => (v, k) }: scala.PartialFunction[(String, Int), (Int, String)])
+    val xs5 = xs.map ({ case (k, v) => (v, k) })
     val xs6: immutable.SortedMap[Int, String] = xs5
     class Foo
 //    val xs7 = xs.map((k: String, v: Int) => (new Foo, v)) Error: No implicit Ordering defined for Foo
-    val xs7 = (xs: immutable.Map[String, Int]) map ({ case (k, v) => (new Foo, v) }: scala.PartialFunction[(String, Int), (Foo, Int)])
+    val xs7 = (xs: immutable.Map[String, Int]) map ({ case (k, v) => (new Foo, v) })
     val xs8: immutable.Map[Foo, Int] = xs7
     val xs9 = xs6.to(List).to(mutable.HashMap)
     val xs9t: mutable.HashMap[Int, String] = xs9
     val xs10 = xs1 ++ xs2
     val xs11: immutable.SortedMap[String, Int] = xs10
-    val xs12 = xs11.collect({ case (k, v) if k.length == v => (v, k) }: scala.PartialFunction[(String, Int), (Int, String)])
+    val xs12 = xs11.collect({ case (k, v) if k.length == v => (v, k) })
     val xs13: immutable.SortedMap[Int, String] = xs12
   }
 


### PR DESCRIPTION
Type inference in dotty can now handle this without needing
the annotation.