### PR TITLE
Add WithFilter (using BuildFrom)

### DIFF
--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -28,8 +28,8 @@ class ArrayOps[A](val xs: Array[A])
 
   def iterableFactory = immutable.IndexedSeq
 
-  protected[this] def fromTaggedIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
-  protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
+  protected[this] def fromTaggedIterable[B: ClassTag](it: Iterable[B]): Array[B] = it.toArray[B]
+  protected[this] def fromSpecificIterable(it: Iterable[A]): Array[A] = it.toArray[A](elemTag)
 
   protected[this] def newSpecificBuilder() = new GrowableBuilder(ArrayBuffer.empty[A]).mapResult(_.toArray(elemTag))
 

--- a/src/main/scala/strawman/collection/BitSet.scala
+++ b/src/main/scala/strawman/collection/BitSet.scala
@@ -12,8 +12,6 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] {
   import BitSetOps._
 
-  protected[this] def coll: C
-
   final def ordering: Ordering[Int] = Ordering.Int
 
   /** The number of words (each with 64 bits) making up the set */
@@ -88,7 +86,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   }
 
   def rangeImpl(from: Option[Int], until: Option[Int]): C = {
-    val a = coll.toBitMask
+    val a = c.toBitMask
     val len = a.length
     if (from.isDefined) {
       var f = from.get
@@ -111,7 +109,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
       }
       if (w < len) a(w) &= (1L << b)-1
     }
-    coll.fromBitMaskNoCopy(a)
+    c.fromBitMaskNoCopy(a)
   }
 
   /** Computes the symmetric difference of this bitset and another bitset by performing
@@ -122,11 +120,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     *              bitset or the other bitset that are not contained in both bitsets.
     */
   def xor(other: BitSet): C = {
-    val len = coll.nwords max other.nwords
+    val len = c.nwords max other.nwords
     val words = new Array[Long](len)
     for (idx <- 0 until len)
-      words(idx) = coll.word(idx) ^ other.word(idx)
-    coll.fromBitMaskNoCopy(words)
+      words(idx) = c.word(idx) ^ other.word(idx)
+    c.fromBitMaskNoCopy(words)
   }
 
   @`inline` final def ^ (other: BitSet): C = xor(other)

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -32,6 +32,8 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
 
   protected[this] def coll: Iterable[A]
 
+  protected[this] def c: C
+
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
 
   protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.fromIterable(it)
@@ -447,6 +449,23 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *               predicate `pred`. Their order may not be preserved.
     */
   def filterNot(pred: A => Boolean): C = fromSpecificIterable(View.Filter(coll, (a: A) => !pred(a)))
+
+  /** Creates a non-strict filter of this $coll.
+    *
+    *  Note: the difference between `c filter p` and `c withFilter p` is that
+    *        the former creates a new collection, whereas the latter only
+    *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
+    *        and `withFilter` operations.
+    *  $orderDependent
+    *
+    *  @param p   the predicate used to test elements.
+    *  @return    an object of class `WithFilter`, which supports
+    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
+    *             All these operations apply to those elements of this $coll
+    *             which satisfy the predicate `p`.
+    */
+  def withFilter(p: A => Boolean): WithFilter[A, C] =
+    new WithFilter[A, C](c, coll, p)
 
   /** A pair of, first, all elements that satisfy prediacte `p` and, second,
     *  all elements that do not. Interesting because it splits a collection in two.

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -8,15 +8,15 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
 
 /** Base Map type */
-trait Map[K, +V] extends Iterable[(K, V)] with MapOps[K, V, Map, Map[K, V]]
+trait Map[K, +V] extends Iterable[(K, V)] with MapOps[K, V, Map, Map[K, V]] {
+  protected[this] def c: this.type = this
+}
 
 /** Base Map implementation type */
 trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V]
     with Equals {
-
-  protected[this] def coll: Map[K, V]
 
   /** Similar to fromIterable, but returns a Map collection type */
   protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): CC[K2, V2]

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -22,7 +22,6 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   with ArrayLike[A]
   with Equals {
 
-  protected[this] def c: C
   protected[this] def seq: Seq[A]
 
   /** Returns new $coll with elements in reversed order.

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -4,6 +4,7 @@ package collection
 import scala.{Any, Array, Boolean, Equals, Int, NoSuchElementException, `inline`, throws}
 import scala.Predef.intWrapper
 import scala.util.hashing.MurmurHash3
+import java.lang.String
 
 /** Base trait for set collections.
   */
@@ -25,7 +26,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     *  @param elem the element to test for membership.
     *  @return  `true` if `elem` is contained in this set, `false` otherwise.
     */
-  @`inline` final def apply(elem: A): Boolean = this.contains(elem)
+  /*@`inline`*/ final def apply(elem: A): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
     *
@@ -116,6 +117,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     }
 
   override def hashCode(): Int = Set.setHash(c)
+
+  override def toString(): String = super[IterableOps].toString() // Because `Function1` overrides `toString` too
 
   /** Computes the intersection between this set and another set.
     *

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -7,15 +7,15 @@ import scala.util.hashing.MurmurHash3
 
 /** Base trait for set collections.
   */
-trait Set[A] extends Iterable[A] with SetOps[A, Set, Set[A]]
+trait Set[A] extends Iterable[A] with SetOps[A, Set, Set[A]] {
+  protected[this] def c: this.type = this
+}
 
 /** Base trait for set operations */
 trait SetOps[A, +CC[X], +C <: Set[A]]
   extends IterableOps[A, CC, C]
      with (A => Boolean)
      with Equals {
-
-  protected[this] def coll: C
 
   def contains(elem: A): Boolean
 
@@ -115,7 +115,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
       case _ => false
     }
 
-  override def hashCode(): Int = Set.setHash(coll)
+  override def hashCode(): Int = Set.setHash(c)
 
   /** Computes the intersection between this set and another set.
     *

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -13,13 +13,13 @@ class StringOps(val s: String)
     with StrictOptimizedIterableOps[Char, String]
     with ArrayLike[Char] {
 
-  protected[this] def coll = StringView(s)
+  protected[this] def coll: Iterable[Char] = StringView(s)
   protected[this] def c: String = s
   protected[this] def seq: Seq[Char] = iterableFactory.fromIterable(coll)
 
-  protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
+  protected[this] def fromSpecificIterable(it: Iterable[Char]): String = {
     val sb = new StringBuilder
-    for (ch <- coll) sb += ch
+    for (ch <- it) sb += ch
     sb.result()
   }
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -16,6 +16,8 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   protected[this] def newSpecificBuilder(): Builder[A, View[A]] =
     immutable.IndexedSeq.newBuilder().mapResult(_.view)
 
+  protected[this] def c: View[A] = this
+
   override def toString = "View(?)"
 
   override def className = "View"

--- a/src/main/scala/strawman/collection/WithFilter.scala
+++ b/src/main/scala/strawman/collection/WithFilter.scala
@@ -1,0 +1,76 @@
+package strawman.collection
+
+import scala.{Boolean, Unit}
+
+/** A template trait that contains just the `map`, `flatMap`, `foreach` and `withFilter` methods
+  *  of trait `Iterable`.
+  *
+  * @tparam A Element type (e.g. `Int`)
+  * @tparam C Collection type (e.g. `List[Int]`)
+  */
+class WithFilter[+A, +C](coll: C, iterable: Iterable[A], p: A => Boolean) {
+
+  /** Builds a new collection by applying a function to all elements of the
+    *  outer $coll containing this `WithFilter` instance that satisfy predicate `p`.
+    *
+    *  @param f      the function to apply to each element.
+    *  @tparam B     the element type of the returned collection.
+    *  @tparam C2    the type of the returned collection.
+    *  @param bf     $bfinfo
+    *  @return       a new collection of type `C2` resulting from applying
+    *                the given function `f` to each element of the outer $coll
+    *                that satisfies predicate `p` and collecting the results.
+    */
+  def map[B, C2](f: A => B)(implicit bf: BuildFrom[C, B, C2]): C2 = {
+    val b = bf.newBuilder(coll)
+    for (x <- iterable)
+      if (p(x)) b += f(x)
+    b.result()
+  }
+
+  /** Builds a new collection by applying a function to all elements of the
+    *  outer $coll containing this `WithFilter` instance that satisfy
+    *  predicate `p` and concatenating the results.
+    *
+    *  @param f      the function to apply to each element.
+    *  @tparam B     the element type of the returned collection.
+    *  @tparam C2    the type of the returned collection.
+    *  @param bf     $bfinfo
+    *  @return       a new collection of type `C2` resulting from applying
+    *                the given collection-valued function `f` to each element
+    *                of the outer $coll that satisfies predicate `p` and
+    *                concatenating the results.
+    */
+  def flatMap[B, C2](f: A => IterableOnce[B])(implicit bf: BuildFrom[C, B, C2]): C2 = {
+    val b = bf.newBuilder(coll)
+    for (x <- iterable)
+      if (p(x)) b ++= f(x)
+    b.result()
+  }
+
+  /** Applies a function `f` to all elements of the outer $coll containing
+    *  this `WithFilter` instance that satisfy predicate `p`.
+    *
+    *  @param  f   the function that is applied for its side-effect to every element.
+    *              The result of function `f` is discarded.
+    *
+    *  @tparam  U  the type parameter describing the result of function `f`.
+    *              This result will always be ignored. Typically `U` is `Unit`,
+    *              but this is not necessary.
+    */
+  def foreach[U](f: A => U): Unit =
+    for (x <- iterable)
+      if (p(x)) f(x)
+
+  /** Further refines the filter for this $coll.
+    *
+    *  @param q   the predicate used to test elements.
+    *  @return    an object of class `WithFilter`, which supports
+    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
+    *             All these operations apply to those elements of this $coll which
+    *             satisfy the predicate `q` in addition to the predicate `p`.
+    */
+  def withFilter(q: A => Boolean): WithFilter[A, C] =
+    new WithFilter(coll, iterable, (a: A) => p(a) && q(a))
+
+}

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -23,7 +23,7 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   def incl(elem: A): C
 
   /** Alias for `incl` */
-  @`inline` final def + (elem: A): C = incl(elem)
+  /*@`inline`*/ final def + (elem: A): C = incl(elem)
 
   /** Creates a new set with a given element removed from this set.
     *

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -26,8 +26,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
         toRemove -= elem
       }
     }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) c -= elem
+    for (elem <- toAdd) c += elem
     this
   }
 
@@ -39,12 +39,12 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
 
   def insert(elem: A): Boolean =
     !contains(elem) && {
-      coll += elem; true
+      c += elem; true
     }
 
   def remove(elem: A): Option[A] = {
     val res = get(elem)
-    coll -= elem
+    c -= elem
     res
   }
 
@@ -60,8 +60,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
           toAdd += mapped
           toRemove -= elem
         }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) c -= elem
+    for (elem <- toAdd) c += elem
     this
   }
 
@@ -70,7 +70,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     for (elem <- this)
       if (!p(elem)) toRemove += elem
     for (elem <- toRemove)
-      coll -= elem
+      c -= elem
     this
   }
 

--- a/src/test/scala/strawman/collection/test/WithFilterTest.scala
+++ b/src/test/scala/strawman/collection/test/WithFilterTest.scala
@@ -1,0 +1,65 @@
+package strawman
+package collection
+package test
+
+import immutable.{List, TreeMap, TreeSet}
+
+import scala.{Char, Int, Unit}
+import scala.Predef.{ArrowAssoc, assert}
+import org.junit.Test
+
+class WithFilterTest {
+
+  @Test
+  def iterables(): Unit = {
+    val xs1 =
+      for {
+        x <- List(1, 2, 3)
+        if x % 2 == 0
+      } yield x + 1
+    val xs1t: List[Int] = xs1
+    assert(xs1 == List(3))
+  }
+
+  @Test
+  def maps(): Unit = {
+    val xs1 =
+      for {
+        (k, v) <- Map(1 -> 'a', 2 -> 'b', 3 -> 'c')
+        if k % 2 == 0
+      } yield (v, k)
+    val xs1t: Map[Char, Int] = xs1
+    assert(xs1 == Map('b' -> 2))
+
+    val xs2 =
+      for {
+        (k, v) <- Map(1 -> 'a', 2 -> 'b', 3 -> 'c')
+        if k % 2 == 0
+      } yield v
+    val xs2t: Iterable[Char] = xs2
+    assert(List('b') == xs2)
+  }
+
+  @Test
+  def sorted(): Unit = {
+    val xs1 =
+      for {
+        x <- TreeSet(1, 2, 3)
+        if x % 2 == 0
+      } yield x + 1
+    val xs1t: TreeSet[Int] = xs1
+    assert(xs1 == TreeSet(3))
+  }
+
+  @Test
+  def sortedMap(): Unit = {
+    val xs1 =
+      for {
+        (k, v) <- TreeMap(1 -> 'a', 2 -> 'b', 3 -> 'c')
+        if k % 2 == 0
+      } yield (v, k)
+    val xs1t: TreeMap[Char, Int] = xs1
+    assert(xs1 == TreeMap('b' -> 2))
+  }
+
+}


### PR DESCRIPTION
This is an alternative to #165 using `BuildFrom` to abstract over the different kinds of collections (`Map` and `Sorted`).

The resulting implementation is probably simpler (only one class `WithFilter`, no subclasses of it). However the user facing `map` and `flatMap` methods of `WithFilter` now take an implicit `BuildFrom` parameter (which is not consistent with the way `map` and `flatMap` are defined in `Iterable` and … well it re-introduces the `BuildFrom` that we tried to get rid of…).

Also, to implement this version I had to generalize the solution I implemented to make `StringOps` and `ArrayOps` able to extend `SeqOps`. More details in the diff.