### PR TITLE
Distinction between collection type C and Iterable[A]

### DIFF
--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -16,7 +16,7 @@ class ArrayOps[A](val xs: Array[A])
 
   def toIterable = ArrayView(xs)
   protected[this] def coll: Array[A] = xs
-  def toSeq: Seq[A] = iterableFactory.fromIterable(toIterable)
+  def toSeq: Seq[A] = fromIterable(toIterable)
 
   def length = xs.length
   @throws[ArrayIndexOutOfBoundsException]

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -14,9 +14,9 @@ class ArrayOps[A](val xs: Array[A])
     with StrictOptimizedIterableOps[A, Seq, Array[A]]
     with ArrayLike[A] {
 
-  protected[this] def iterable = ArrayView(xs)
+  def toIterable = ArrayView(xs)
   protected[this] def coll: Array[A] = xs
-  def toSeq: Seq[A] = iterableFactory.fromIterable(iterable)
+  def toSeq: Seq[A] = iterableFactory.fromIterable(toIterable)
 
   def length = xs.length
   @throws[ArrayIndexOutOfBoundsException]
@@ -37,9 +37,9 @@ class ArrayOps[A](val xs: Array[A])
 
   override def className = "Array"
 
-  def iterator(): Iterator[A] = iterable.iterator()
+  def iterator(): Iterator[A] = toIterable.iterator()
 
-  def map[B: ClassTag](f: A => B): Array[B] = fromTaggedIterable(View.Map(iterable, f))
+  def map[B: ClassTag](f: A => B): Array[B] = fromTaggedIterable(View.Map(toIterable, f))
 
   def mapInPlace(f: A => A): Array[A] = {
     var i = 0
@@ -50,11 +50,11 @@ class ArrayOps[A](val xs: Array[A])
     xs
   }
 
-  def flatMap[B: ClassTag](f: A => IterableOnce[B]): Array[B] = fromTaggedIterable(View.FlatMap(iterable, f))
+  def flatMap[B: ClassTag](f: A => IterableOnce[B]): Array[B] = fromTaggedIterable(View.FlatMap(toIterable, f))
 
-  def ++[B >: A : ClassTag](xs: Iterable[B]): Array[B] = fromTaggedIterable(View.Concat(iterable, xs))
+  def ++[B >: A : ClassTag](xs: Iterable[B]): Array[B] = fromTaggedIterable(View.Concat(toIterable, xs))
 
-  def zip[B: ClassTag](xs: Iterable[B]): Array[(A, B)] = fromTaggedIterable(View.Zip(iterable, xs))
+  def zip[B: ClassTag](xs: Iterable[B]): Array[(A, B)] = fromTaggedIterable(View.Zip(toIterable, xs))
 
 }
 

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -16,7 +16,7 @@ class ArrayOps[A](val xs: Array[A])
 
   protected[this] def iterable = ArrayView(xs)
   protected[this] def coll: Array[A] = xs
-  protected[this] def seq: Seq[A] = iterableFactory.fromIterable(iterable)
+  def toSeq: Seq[A] = iterableFactory.fromIterable(iterable)
 
   def length = xs.length
   @throws[ArrayIndexOutOfBoundsException]

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -15,7 +15,7 @@ class ArrayOps[A](val xs: Array[A])
     with ArrayLike[A] {
 
   protected[this] def iterable = ArrayView(xs)
-  protected[this] def c: Array[A] = xs
+  protected[this] def coll: Array[A] = xs
   protected[this] def seq: Seq[A] = iterableFactory.fromIterable(iterable)
 
   def length = xs.length

--- a/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/src/main/scala/strawman/collection/ArrayOps.scala
@@ -14,9 +14,9 @@ class ArrayOps[A](val xs: Array[A])
     with StrictOptimizedIterableOps[A, Seq, Array[A]]
     with ArrayLike[A] {
 
-  protected[this] def coll = ArrayView(xs)
+  protected[this] def iterable = ArrayView(xs)
   protected[this] def c: Array[A] = xs
-  protected[this] def seq: Seq[A] = iterableFactory.fromIterable(coll)
+  protected[this] def seq: Seq[A] = iterableFactory.fromIterable(iterable)
 
   def length = xs.length
   @throws[ArrayIndexOutOfBoundsException]
@@ -37,9 +37,9 @@ class ArrayOps[A](val xs: Array[A])
 
   override def className = "Array"
 
-  def iterator(): Iterator[A] = coll.iterator()
+  def iterator(): Iterator[A] = iterable.iterator()
 
-  def map[B: ClassTag](f: A => B): Array[B] = fromTaggedIterable(View.Map(coll, f))
+  def map[B: ClassTag](f: A => B): Array[B] = fromTaggedIterable(View.Map(iterable, f))
 
   def mapInPlace(f: A => A): Array[A] = {
     var i = 0
@@ -50,11 +50,11 @@ class ArrayOps[A](val xs: Array[A])
     xs
   }
 
-  def flatMap[B: ClassTag](f: A => IterableOnce[B]): Array[B] = fromTaggedIterable(View.FlatMap(coll, f))
+  def flatMap[B: ClassTag](f: A => IterableOnce[B]): Array[B] = fromTaggedIterable(View.FlatMap(iterable, f))
 
-  def ++[B >: A : ClassTag](xs: Iterable[B]): Array[B] = fromTaggedIterable(View.Concat(coll, xs))
+  def ++[B >: A : ClassTag](xs: Iterable[B]): Array[B] = fromTaggedIterable(View.Concat(iterable, xs))
 
-  def zip[B: ClassTag](xs: Iterable[B]): Array[(A, B)] = fromTaggedIterable(View.Zip(coll, xs))
+  def zip[B: ClassTag](xs: Iterable[B]): Array[(A, B)] = fromTaggedIterable(View.Zip(iterable, xs))
 
 }
 

--- a/src/main/scala/strawman/collection/BitSet.scala
+++ b/src/main/scala/strawman/collection/BitSet.scala
@@ -12,7 +12,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] {
   import BitSetOps._
 
-  protected[this] def coll: C
+  protected[this] def iterable: C
 
   final def ordering: Ordering[Int] = Ordering.Int
 
@@ -88,7 +88,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   }
 
   def rangeImpl(from: Option[Int], until: Option[Int]): C = {
-    val a = coll.toBitMask
+    val a = iterable.toBitMask
     val len = a.length
     if (from.isDefined) {
       var f = from.get
@@ -111,7 +111,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
       }
       if (w < len) a(w) &= (1L << b)-1
     }
-    coll.fromBitMaskNoCopy(a)
+    iterable.fromBitMaskNoCopy(a)
   }
 
   /** Computes the symmetric difference of this bitset and another bitset by performing
@@ -122,11 +122,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     *              bitset or the other bitset that are not contained in both bitsets.
     */
   def xor(other: BitSet): C = {
-    val len = coll.nwords max other.nwords
+    val len = iterable.nwords max other.nwords
     val words = new Array[Long](len)
     for (idx <- 0 until len)
-      words(idx) = coll.word(idx) ^ other.word(idx)
-    coll.fromBitMaskNoCopy(words)
+      words(idx) = iterable.word(idx) ^ other.word(idx)
+    iterable.fromBitMaskNoCopy(words)
   }
 
   @`inline` final def ^ (other: BitSet): C = xor(other)
@@ -137,9 +137,9 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     * @return a new bitset resulting from applying the given function ''f'' to
     *         each element of this bitset and collecting the results
     */
-  def map(f: Int => Int): C = fromSpecificIterable(View.Map(coll, f))
+  def map(f: Int => Int): C = fromSpecificIterable(View.Map(iterable, f))
 
-  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecificIterable(View.FlatMap(coll, f))
+  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecificIterable(View.FlatMap(iterable, f))
 
 }
 

--- a/src/main/scala/strawman/collection/BitSet.scala
+++ b/src/main/scala/strawman/collection/BitSet.scala
@@ -12,8 +12,6 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] {
   import BitSetOps._
 
-  protected[this] def iterable: C
-
   final def ordering: Ordering[Int] = Ordering.Int
 
   /** The number of words (each with 64 bits) making up the set */
@@ -88,7 +86,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   }
 
   def rangeImpl(from: Option[Int], until: Option[Int]): C = {
-    val a = iterable.toBitMask
+    val a = coll.toBitMask
     val len = a.length
     if (from.isDefined) {
       var f = from.get
@@ -111,7 +109,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
       }
       if (w < len) a(w) &= (1L << b)-1
     }
-    iterable.fromBitMaskNoCopy(a)
+    coll.fromBitMaskNoCopy(a)
   }
 
   /** Computes the symmetric difference of this bitset and another bitset by performing
@@ -122,11 +120,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     *              bitset or the other bitset that are not contained in both bitsets.
     */
   def xor(other: BitSet): C = {
-    val len = iterable.nwords max other.nwords
+    val len = coll.nwords max other.nwords
     val words = new Array[Long](len)
     for (idx <- 0 until len)
-      words(idx) = iterable.word(idx) ^ other.word(idx)
-    iterable.fromBitMaskNoCopy(words)
+      words(idx) = coll.word(idx) ^ other.word(idx)
+    coll.fromBitMaskNoCopy(words)
   }
 
   @`inline` final def ^ (other: BitSet): C = xor(other)
@@ -137,9 +135,9 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     * @return a new bitset resulting from applying the given function ''f'' to
     *         each element of this bitset and collecting the results
     */
-  def map(f: Int => Int): C = fromSpecificIterable(View.Map(iterable, f))
+  def map(f: Int => Int): C = fromSpecificIterable(View.Map(toIterable, f))
 
-  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecificIterable(View.FlatMap(iterable, f))
+  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecificIterable(View.FlatMap(toIterable, f))
 
 }
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -14,7 +14,7 @@ import java.lang.String
 trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterable[A]] {
 
   /** The collection itself */
-  protected[this] def coll: this.type = this
+  final protected[this] def iterable: this.type = this
 
 }
 
@@ -30,7 +30,10 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   */
 trait IterableOps[+A, +CC[X], +C] extends Any {
 
-  protected[this] def coll: Iterable[A]
+  /**
+    * @return This collection as an `Iterable[A]`.
+    */
+  protected[this] def iterable: Iterable[A]
 
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
 
@@ -51,7 +54,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   // Consumes all the collection!
   protected[this] def reversed: Iterable[A] = {
     var xs: immutable.List[A] = immutable.Nil
-    val it = coll.iterator()
+    val it = iterable.iterator()
     while (it.hasNext) xs = it.next() :: xs
     xs
   }
@@ -59,7 +62,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** Apply `f` to each element for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
-  def foreach[U](f: A => U): Unit = coll.iterator().foreach(f)
+  def foreach[U](f: A => U): Unit = iterable.iterator().foreach(f)
 
   /** Tests whether a predicate holds for all elements of this $coll.
    *
@@ -69,7 +72,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
    *  @return        `true` if this $coll is empty or the given predicate `p`
    *                 holds for all elements of this $coll, otherwise `false`.
    */
-  def forall(p: A => Boolean): Boolean = coll.iterator().forall(p)
+  def forall(p: A => Boolean): Boolean = iterable.iterator().forall(p)
 
   /** Tests whether a predicate holds for at least one element of this $coll.
    *
@@ -78,14 +81,14 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
    *  @param   p     the predicate used to test elements.
    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this $coll, otherwise `false`
    */
-  def exists(p: A => Boolean): Boolean = coll.iterator().exists(p)
+  def exists(p: A => Boolean): Boolean = iterable.iterator().exists(p)
 
   /** Counts the number of elements in the $coll which satisfy a predicate.
    *
    *  @param p     the predicate  used to test elements.
    *  @return      the number of elements satisfying the predicate `p`.
    */
-  def count(p: A => Boolean): Int = coll.iterator().count(p)
+  def count(p: A => Boolean): Int = iterable.iterator().count(p)
 
   /** Finds the first element of the $coll satisfying a predicate, if any.
     *
@@ -96,13 +99,13 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return        an option value containing the first element in the $coll
     *                 that satisfies `p`, or `None` if none exists.
     */
-  def find(p: A => Boolean): Option[A] = coll.iterator().find(p)
+  def find(p: A => Boolean): Option[A] = iterable.iterator().find(p)
 
   /** Fold left */
-  def foldLeft[B](z: B)(op: (B, A) => B): B = coll.iterator().foldLeft(z)(op)
+  def foldLeft[B](z: B)(op: (B, A) => B): B = iterable.iterator().foldLeft(z)(op)
 
   /** Fold right */
-  def foldRight[B](z: B)(op: (A, B) => B): B = coll.iterator().foldRight(z)(op)
+  def foldRight[B](z: B)(op: (A, B) => B): B = iterable.iterator().foldRight(z)(op)
 
   /** Reduces the elements of this $coll using the specified associative binary operator.
    *
@@ -149,7 +152,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     var first = true
     var acc: B = 0.asInstanceOf[B]
 
-    for (x <- coll) {
+    for (x <- iterable) {
       if (first) {
         acc = x
         first = false
@@ -204,13 +207,13 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def reduceRightOption[B >: A](op: (A, B) => B): Option[B] = if (isEmpty) None else Some(reduceRight(op))
 
   /** Is the collection empty? */
-  def isEmpty: Boolean = !coll.iterator().hasNext
+  def isEmpty: Boolean = !iterable.iterator().hasNext
 
   /** Is the collection not empty? */
-  def nonEmpty: Boolean = coll.iterator().hasNext
+  def nonEmpty: Boolean = iterable.iterator().hasNext
 
   /** The first element of the collection. */
-  def head: A = coll.iterator().next()
+  def head: A = iterable.iterator().next()
 
   /** Selects the last element.
     * $orderDependent
@@ -218,7 +221,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A = {
-    val it = coll.iterator()
+    val it = iterable.iterator()
     var lst = it.next()
     while (it.hasNext) lst = it.next()
     lst
@@ -239,10 +242,10 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** The number of elements in this collection. Does not terminate for
     *  infinite collections.
     */
-  def size: Int = if (knownSize >= 0) knownSize else coll.iterator().length
+  def size: Int = if (knownSize >= 0) knownSize else iterable.iterator().length
 
   /** A view representing the elements of this collection. */
-  def view: View[A] = View.fromIterator(coll.iterator())
+  def view: View[A] = View.fromIterator(iterable.iterator())
 
   /** Given a collection factory `fi`, convert this collection to the appropriate
     * representation for the current element type `A`. Example uses:
@@ -251,17 +254,17 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *      xs.to(ArrayBuffer)
     *      xs.to(BitSet) // for xs: Iterable[Int]
     */
-  def to[C1](f: CanBuild[A, C1]): C1 = f.fromSpecificIterable(coll)
+  def to[C1](f: CanBuild[A, C1]): C1 = f.fromSpecificIterable(iterable)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =
     if (knownSize >= 0) copyToArray(new Array[B](knownSize), 0)
-    else ArrayBuffer.fromIterable(coll).toArray[B]
+    else ArrayBuffer.fromIterable(iterable).toArray[B]
 
   /** Copy all elements of this collection to array `xs`, starting at `start`. */
   def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = {
     var i = start
-    val it = coll.iterator()
+    val it = iterable.iterator()
     while (it.hasNext) {
       xs(i) = it.next()
       i += 1
@@ -389,7 +392,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     var maxElem: A = null.asInstanceOf[A]
     var first = true
 
-    for (elem <- coll) {
+    for (elem <- iterable) {
       val fx = f(elem)
       if (first || cmp.gt(fx, maxF)) {
         maxElem = elem
@@ -421,7 +424,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     var minElem: A = null.asInstanceOf[A]
     var first = true
 
-    for (elem <- coll) {
+    for (elem <- iterable) {
       val fx = f(elem)
       if (first || cmp.lt(fx, minF)) {
         minElem = elem
@@ -438,7 +441,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return      a new $coll consisting of all elements of this $coll that satisfy the given
     *               predicate `pred`. Their order may not be preserved.
     */
-  def filter(pred: A => Boolean): C = fromSpecificIterable(View.Filter(coll, pred))
+  def filter(pred: A => Boolean): C = fromSpecificIterable(View.Filter(iterable, pred))
 
   /** Selects all elements of this $coll which do not satisfy a predicate.
     *
@@ -446,7 +449,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return      a new $coll consisting of all elements of this $coll that do not satisfy the given
     *               predicate `pred`. Their order may not be preserved.
     */
-  def filterNot(pred: A => Boolean): C = fromSpecificIterable(View.Filter(coll, (a: A) => !pred(a)))
+  def filterNot(pred: A => Boolean): C = fromSpecificIterable(View.Filter(iterable, (a: A) => !pred(a)))
 
   /** Creates a non-strict filter of this $coll.
     *
@@ -469,7 +472,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   class WithFilter(p: A => Boolean) {
 
-    protected[this] def filtered = View.Filter(coll, p)
+    protected[this] def filtered = View.Filter(iterable, p)
 
     /** Builds a new collection by applying a function to all elements of the
       * `filtered` outer $coll.
@@ -525,7 +528,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  which requires only a single traversal.
     */
   def partition(p: A => Boolean): (C, C) = {
-    val pn = View.Partition(coll, p)
+    val pn = View.Partition(iterable, p)
     (fromSpecificIterable(pn.first), fromSpecificIterable(pn.second))
   }
 
@@ -541,14 +544,14 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def splitAt(n: Int): (C, C) = (take(n), drop(n))
 
   /** A collection containing the first `n` elements of this collection. */
-  def take(n: Int): C = fromSpecificIterable(View.Take(coll, n))
+  def take(n: Int): C = fromSpecificIterable(View.Take(iterable, n))
 
   /** A collection containing the last `n` elements of this collection. */
   def takeRight(n: Int): C = {
     val b = newSpecificBuilder()
-    b.sizeHintBounded(n, coll)
-    val lead = coll.iterator() drop n
-    val it = coll.iterator()
+    b.sizeHintBounded(n, iterable)
+    val lead = iterable.iterator() drop n
+    val it = iterable.iterator()
     while (lead.hasNext) {
       lead.next()
       it.next()
@@ -563,7 +566,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return  the longest prefix of this $coll whose elements all satisfy
     *           the predicate `p`.
     */
-  def takeWhile(p: A => Boolean): C = fromSpecificIterable(View.TakeWhile(coll, p))
+  def takeWhile(p: A => Boolean): C = fromSpecificIterable(View.TakeWhile(iterable, p))
 
   /** Splits this $coll into a prefix/suffix pair according to a predicate.
     *
@@ -581,16 +584,16 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** The rest of the collection without its `n` first elements. For
     *  linear, immutable collections this should avoid making a copy.
     */
-  def drop(n: Int): C = fromSpecificIterable(View.Drop(coll, n))
+  def drop(n: Int): C = fromSpecificIterable(View.Drop(iterable, n))
 
   /** The rest of the collection without its `n` last elements. For
     *  linear, immutable collections this should avoid making a copy.
     */
   def dropRight(n: Int): C = {
     val b = newSpecificBuilder()
-    if (n >= 0) b.sizeHint(coll, delta = -n)
-    val lead = coll.iterator() drop n
-    val it = coll.iterator()
+    if (n >= 0) b.sizeHint(iterable, delta = -n)
+    val lead = iterable.iterator() drop n
+    val it = iterable.iterator()
     while (lead.hasNext) {
       b += it.next()
       lead.next()
@@ -605,7 +608,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return  an iterator consisting of the remaining elements
     *  @note    Reuse: $consumesAndProducesIterator
     */
-  def dropWhile(p: A => Boolean): C = fromSpecificIterable(View.DropWhile(coll, p))
+  def dropWhile(p: A => Boolean): C = fromSpecificIterable(View.DropWhile(iterable, p))
 
   /** Partitions elements in fixed size ${coll}s.
    *  @see [[scala.collection.Iterator]], method `grouped`
@@ -615,7 +618,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
    *          last will be less than size `size` if the elements don't divide evenly.
    */
   def grouped(size: Int): Iterator[C] =
-    coll.iterator().grouped(size).map(fromSpecificIterable)
+    iterable.iterator().grouped(size).map(fromSpecificIterable)
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
     *  over them (as opposed to partitioning them, as is done in `grouped`.)
@@ -641,17 +644,17 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *          if there are fewer than `size` elements remaining to be grouped.
     */
   def sliding(size: Int, step: Int): Iterator[C] =
-    coll.iterator().sliding(size, step).map(fromSpecificIterable)
+    iterable.iterator().sliding(size, step).map(fromSpecificIterable)
 
   /** The rest of the collection without its first element. */
   def tail: C = {
-    if (coll.isEmpty) throw new UnsupportedOperationException
+    if (iterable.isEmpty) throw new UnsupportedOperationException
     drop(1)
   }
 
   /** The initial part of the collection without its last element. */
   def init: C = {
-    if (coll.isEmpty) throw new UnsupportedOperationException
+    if (iterable.isEmpty) throw new UnsupportedOperationException
     dropRight(1)
   }
 
@@ -669,7 +672,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *           of this $coll.
     */
   def slice(from: Int, until: Int): C =
-    fromSpecificIterable(View.Take(View.Drop(coll, from), until - from))
+    fromSpecificIterable(View.Take(View.Drop(iterable, from), until - from))
 
   /** Partitions this $coll into a map of ${coll}s according to some discriminator function.
     *
@@ -687,7 +690,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     */
   def groupBy[K](f: A => K): immutable.Map[K, C] = {
     val m = mutable.Map.empty[K, Builder[A, C]]
-    for (elem <- coll) {
+    for (elem <- iterable) {
       val key = f(elem)
       val bldr = m.getOrElseUpdate(key, newSpecificBuilder())
       bldr += elem
@@ -722,7 +725,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @param op      the binary operator applied to the intermediate result and the element
     *  @return        collection with intermediate results
     */
-  def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = fromIterable(View.ScanLeft(coll, z, op))
+  def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = fromIterable(View.ScanLeft(iterable, z, op))
 
   /** Produces a collection containing cumulative results of applying the operator going right to left.
     *  The head of the collection is the last cumulative result.
@@ -756,13 +759,13 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return       a new $coll resulting from applying the given function
     *                `f` to each element of this $coll and collecting the results.
     */
-  def map[B](f: A => B): CC[B] = fromIterable(View.Map(coll, f))
+  def map[B](f: A => B): CC[B] = fromIterable(View.Map(iterable, f))
 
   /** Flatmap */
-  def flatMap[B](f: A => IterableOnce[B]): CC[B] = fromIterable(View.FlatMap(coll, f))
+  def flatMap[B](f: A => IterableOnce[B]): CC[B] = fromIterable(View.FlatMap(iterable, f))
 
   def flatten[B](implicit ev: A => IterableOnce[B]): CC[B] =
-    fromIterable(View.FlatMap(coll, ev))
+    fromIterable(View.FlatMap(iterable, ev))
 
   def collect[B](pf: PartialFunction[A, B]): CC[B] =
     flatMap { a =>
@@ -785,7 +788,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @return       a new collection of type `CC[B]` which contains all elements
     *                of this $coll followed by all elements of `suffix`.
     */
-  def appendAll[B >: A](suffix: Iterable[B]): CC[B] = fromIterable(View.Concat(coll, suffix))
+  def appendAll[B >: A](suffix: Iterable[B]): CC[B] = fromIterable(View.Concat(iterable, suffix))
 
   /** Alias for `appendAll` */
   @`inline` final def :++ [B >: A](suffix: Iterable[B]): CC[B] = appendAll(suffix)
@@ -820,7 +823,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *    @return       a new $coll which contains all elements of `prefix` followed
     *                  by all the elements of this $coll.
     */
-  def prependAll[B >: A](prefix: Iterable[B]): CC[B] = fromIterable(View.Concat(prefix, coll))
+  def prependAll[B >: A](prefix: Iterable[B]): CC[B] = fromIterable(View.Concat(prefix, iterable))
 
   /** Alias for `prependAll` */
   @`inline` final def ++: [B >: A](prefix: Iterable[B]): CC[B] = prependAll(prefix)
@@ -835,7 +838,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *                 corresponding elements of this $coll and `that`. The length
     *                 of the returned collection is the minimum of the lengths of this $coll and `that`.
     */
-  def zip[B](xs: Iterable[B]): CC[(A @uncheckedVariance, B)] = fromIterable(View.Zip(coll, xs))
+  def zip[B](xs: Iterable[B]): CC[(A @uncheckedVariance, B)] = fromIterable(View.Zip(iterable, xs))
   // sound bcs of VarianceNote
 
   /** Zips this $coll with its indices.
@@ -845,7 +848,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *  @example
     *    `List("a", "b", "c").zipWithIndex == List(("a", 0), ("b", 1), ("c", 2))`
     */
-  def zipWithIndex: CC[(A @uncheckedVariance, Int)] = fromIterable(View.ZipWithIndex(coll))
+  def zipWithIndex: CC[(A @uncheckedVariance, Int)] = fromIterable(View.ZipWithIndex(iterable))
 
   /** Converts this $coll of pairs into two collections of the first and second
     *  half of each pair.
@@ -867,7 +870,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *                half of each element pair of this $coll.
     */
   def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
-    val unzipped = View.Unzip(coll)
+    val unzipped = View.Unzip(iterable)
     (fromIterable(unzipped.first), fromIterable(unzipped.second))
   }
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -27,6 +27,11 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   *  the child class and the variance of the `C` parameter passed to `IterableOps`
   *  are the same. We cannot express this since we lack variance polymorphism. That's
   *  why we have to resort at some places to write `C[A @uncheckedVariance]`.
+  *
+  *  @tparam CC type constructor of the collection (e.g. `List`, `Set`). Operations returning a collection
+  *             with a different type of element `B` (e.g. `map`) return a `CC[B]`.
+  *  @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
+  *             with the same type of element (e.g. `drop`, `filter`) return a `C`.
   */
 trait IterableOps[+A, +CC[X], +C] extends Any {
 
@@ -34,6 +39,11 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     * @return This collection as an `Iterable[A]`.
     */
   protected[this] def iterable: Iterable[A]
+
+  /**
+    * @return This collection as a `C`.
+    */
+  protected[this] def coll: C
 
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
 

--- a/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/src/main/scala/strawman/collection/LinearSeq.scala
@@ -19,13 +19,13 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
 
   /** `iterator` is implemented in terms of `head` and `tail` */
   def iterator() = new Iterator[A] {
-    private[this] var current: Iterable[A] = iterable
+    private[this] var current: Iterable[A] = toIterable
     def hasNext = !current.isEmpty
     def next() = { val r = current.head; current = current.tail; r }
   }
 
   override def size: Int = {
-    var these = iterable
+    var these = toIterable
     var len = 0
     while (!these.isEmpty) {
       len += 1
@@ -51,7 +51,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
       // it's surprisingly tricky/ugly to turn this into actual types, so we
       // leave this contract implicit.
       else loop(n - 1, s.tail)
-    loop(n, iterable)
+    loop(n, toIterable)
   }
 
   /** `apply` is defined in terms of `drop`, which is in turn defined in

--- a/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/src/main/scala/strawman/collection/LinearSeq.scala
@@ -19,13 +19,13 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
 
   /** `iterator` is implemented in terms of `head` and `tail` */
   def iterator() = new Iterator[A] {
-    private[this] var current: Iterable[A] = coll
+    private[this] var current: Iterable[A] = iterable
     def hasNext = !current.isEmpty
     def next() = { val r = current.head; current = current.tail; r }
   }
 
   override def size: Int = {
-    var these = coll
+    var these = iterable
     var len = 0
     while (!these.isEmpty) {
       len += 1
@@ -51,7 +51,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
       // it's surprisingly tricky/ugly to turn this into actual types, so we
       // leave this contract implicit.
       else loop(n - 1, s.tail)
-    loop(n, coll)
+    loop(n, iterable)
   }
 
   /** `apply` is defined in terms of `drop`, which is in turn defined in

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -8,10 +8,12 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
 
 /** Base Map type */
-trait Map[K, +V] extends Iterable[(K, V)] with MapOps[K, V, Map, Map[K, V]]
+trait Map[K, +V] extends Iterable[(K, V)] with MapOps[K, V, Map, Map[K, V]] {
+  final protected[this] def coll: this.type = this
+}
 
 /** Base Map implementation type */
-trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
+trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V]
     with Equals {

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -16,7 +16,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     with PartialFunction[K, V]
     with Equals {
 
-  protected[this] def coll: Map[K, V]
+  protected[this] def iterable: Map[K, V]
 
   /** Similar to fromIterable, but returns a Map collection type */
   protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): CC[K2, V2]
@@ -72,13 +72,13 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
   /** The implementation class of the set returned by `keySet`.
     */
   protected class DefaultKeySet extends Set[K] with Serializable {
-    def contains(key: K) = MapOps.this.coll.contains(key)
+    def contains(key: K) = MapOps.this.iterable.contains(key)
     def iterator() = keysIterator()
-    override def size = coll.size
+    override def size = iterable.size
     override def foreach[U](f: K => U) = keysIterator() foreach f
     def iterableFactory: IterableFactory[Set] = Set
     def empty: Set[K] = iterableFactory.empty
-    def diff(that: Set[K]): Set[K] = fromSpecificIterable(iterableFactory.fromIterable(coll).diff(that))
+    def diff(that: Set[K]): Set[K] = fromSpecificIterable(iterableFactory.fromIterable(iterable).diff(that))
     protected[this] def fromSpecificIterable(coll: Iterable[K]): Set[K] = iterableFactory.fromIterable(coll)
     protected[this] def newSpecificBuilder(): Builder[K, Set[K]] = iterableFactory.newBuilder()
   }
@@ -100,7 +100,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @return an iterator over all keys.
     */
   def keysIterator(): Iterator[K] = new Iterator[K] {
-    val iter = coll.iterator()
+    val iter = iterable.iterator()
     def hasNext = iter.hasNext
     def next() = iter.next()._1
   }
@@ -110,7 +110,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @return an iterator over all values that are associated with some key in this map.
     */
   def valuesIterator(): Iterator[V] = new Iterator[V] {
-    val iter = coll.iterator()
+    val iter = iterable.iterator()
     def hasNext = iter.hasNext
     def next() = iter.next()._2
   }
@@ -120,14 +120,14 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
     *          the predicate `p`. The resulting map wraps the original map without copying any elements.
     */
-  def filterKeys(p: K => Boolean): View[(K, V)] = View.FilterKeys(coll, p)
+  def filterKeys(p: K => Boolean): View[(K, V)] = View.FilterKeys(iterable, p)
 
   /** Transforms this map by applying a function to every retrieved value.
     *  @param  f   the function used to transform values of this map.
     *  @return a map view which maps every key of this map
     *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
     */
-  def mapValues[W](f: V => W): View[(K, W)] = View.MapValues(coll, f)
+  def mapValues[W](f: V => W): View[(K, W)] = View.MapValues(iterable, f)
 
   /** Defines the default value computation for the map,
     *  returned when a key is not found
@@ -176,11 +176,11 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
 
   }
 
-  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFromIterable(View.Map(coll, f))
+  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFromIterable(View.Map(iterable, f))
 
-  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFromIterable(View.FlatMap(coll, f))
+  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFromIterable(View.FlatMap(iterable, f))
 
-  def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = mapFromIterable(View.Concat(coll, xs))
+  def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = mapFromIterable(View.Concat(iterable, xs))
 
   /** Alias for `concat` */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
@@ -208,7 +208,7 @@ trait MapOps[K, +V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
       false
   }
 
-  override def hashCode(): Int = Set.unorderedHash(coll, "Map".##)
+  override def hashCode(): Int = Set.unorderedHash(iterable, "Map".##)
 
 }
 

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -14,6 +14,7 @@ import scala.util.hashing.MurmurHash3
 trait Seq[+A] extends Iterable[A] with SeqOps[A, Seq, Seq[A]] {
   final protected[this] def coll: this.type = this
   final def toSeq: this.type = this
+  def iterableFactory: SeqFactory[Seq]
 }
 
 /** Base trait for Seq operations */
@@ -26,9 +27,6 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     * @return This collection as a `Seq[A]`. This equivalent to `to(Seq)` but might be faster.
     */
   def toSeq: Seq[A]
-
-  // Refine the factory member to be a `SeqFactory`
-  def iterableFactory: SeqFactory[CC]
 
   /** Selects all the elements of this $coll ignoring the duplicates.
     *

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -24,7 +24,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   with Equals {
 
   /**
-    * @return This collection as a `Seq[A]`. This equivalent to `to(Seq)` but might be faster.
+    * @return This collection as a `Seq[A]`. This is equivalent to `to(Seq)` but might be faster.
     */
   def toSeq: Seq[A]
 

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -23,9 +23,8 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   with Equals {
 
   /**
-    * @return This collection as a `Seq[A]`. Note that this method might require the creation of a
-    *         copy of this collection (e.g. `String` can not be turned into a `Seq[Char]` without
-    *         creating a new collection). Consequently you should always use `iterable` rather than `seq`.
+    * @return This collection as a `Seq[A]`. Note that this method breaks laziness when used on a `View[A]`.
+    *         You should prefer using `iterable` instead.
     */
   protected[this] def seq: Seq[A]
 
@@ -153,6 +152,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` of no such subsequence exists.
    */
+  // TODO Should be implemented in a way that preserves laziness
   def indexOfSlice[B >: A](that: Seq[B], from: Int = 0): Int =
     if (this.knownSize >= 0 && that.knownSize >= 0) {
       val l = length

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -13,7 +13,7 @@ import scala.util.hashing.MurmurHash3
 /** Base trait for sequence collections */
 trait Seq[+A] extends Iterable[A] with SeqOps[A, Seq, Seq[A]] {
   final protected[this] def coll: this.type = this
-  final protected[this] def seq: this.type = this
+  final def toSeq: this.type = this
 }
 
 /** Base trait for Seq operations */
@@ -23,10 +23,9 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   with Equals {
 
   /**
-    * @return This collection as a `Seq[A]`. Note that this method breaks laziness when used on a `View[A]`.
-    *         You should prefer using `iterable` instead.
+    * @return This collection as a `Seq[A]`. This equivalent to `to(Seq)` but might be faster.
     */
-  protected[this] def seq: Seq[A]
+  def toSeq: Seq[A]
 
   // Refine the factory member to be a `SeqFactory`
   def iterableFactory: SeqFactory[CC]
@@ -161,11 +160,11 @@ trait SeqOps[+A, +CC[X], +C] extends Any
       if (from > l) -1
       else if (tl < 1) clippedFrom
       else if (l < tl) -1
-      else SeqOps.kmpSearch(seq, clippedFrom, l, that, 0, tl, forward = true)
+      else SeqOps.kmpSearch(toSeq, clippedFrom, l, that, 0, tl, forward = true)
     }
     else {
       var i = from
-      var s: Seq[A] = seq drop i
+      var s: Seq[A] = toSeq drop i
       while (!s.isEmpty) {
         if (s startsWith that)
           return i
@@ -190,7 +189,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     if (end < 0) -1
     else if (tl < 1) clippedL
     else if (l < tl) -1
-    else SeqOps.kmpSearch(seq, 0, clippedL+tl, that, 0, tl, forward = false)
+    else SeqOps.kmpSearch(toSeq, 0, clippedL+tl, that, 0, tl, forward = false)
   }
 
   /** Tests whether this $coll contains a given sequence as a slice.
@@ -279,7 +278,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
 
     private[this] def init() = {
       val m = mutable.HashMap[A, Int]()
-      val (es, is) = (seq map (e => (e, m.getOrElseUpdate(e, m.size))) sortBy (_._2)).unzip
+      val (es, is) = (toSeq map (e => (e, m.getOrElseUpdate(e, m.size))) sortBy (_._2)).unzip
 
       (es.to(mutable.ArrayBuffer), is.toArray)
     }
@@ -340,7 +339,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
       val m = mutable.HashMap[A, Int]()
 
       // e => (e, weight(e))
-      val (es, is) = (seq map (e => (e, m.getOrElseUpdate(e, m.size))) sortBy (_._2)).unzip
+      val (es, is) = (toSeq map (e => (e, m.getOrElseUpdate(e, m.size))) sortBy (_._2)).unzip
       val cs = new Array[Int](m.size)
       is foreach (i => cs(i) += 1)
       val ns = new Array[Int](cs.length)

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -32,7 +32,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *
     * @return a new $coll consisting of all the elements of this $coll without duplicates.
     */
-  def distinct: C = fromSpecificIterable(new View.Distinct(iterable))
+  def distinct: C = fromSpecificIterable(new View.Distinct(toIterable))
 
   /** Returns new $coll with elements in reversed order.
    *
@@ -63,7 +63,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *         index `offset`, otherwise `false`.
     */
   def startsWith[B >: A](that: Seq[B], offset: Int = 0): Boolean = {
-    val i = iterable.iterator() drop offset
+    val i = toIterable.iterator() drop offset
     val j = that.iterator()
     while (j.hasNext && i.hasNext)
       if (i.next() != j.next())
@@ -78,7 +78,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
     */
   def endsWith[B >: A](that: Seq[B]): Boolean = {
-    val i = iterable.iterator().drop(length - that.length)
+    val i = toIterable.iterator().drop(length - that.length)
     val j = that.iterator()
     while (i.hasNext && j.hasNext)
       if (i.next() != j.next())
@@ -96,7 +96,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
    */
-  def padTo[B >: A](len: Int, elem: B): CC[B] = fromIterable(View.PadTo(iterable, len, elem))
+  def padTo[B >: A](len: Int, elem: B): CC[B] = fromIterable(View.PadTo(toIterable, len, elem))
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
     *
@@ -107,7 +107,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return  the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
     *           or `-1`, if none exists.
     */
-  def indexWhere(p: A => Boolean, from: Int = 0): Int = iterable.iterator().indexWhere(p, from)
+  def indexWhere(p: A => Boolean, from: Int = 0): Int = toIterable.iterator().indexWhere(p, from)
 
   /** Finds index of first occurrence of some value in this $coll after or at some start index.
     *
@@ -365,7 +365,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   def sorted[B >: A](implicit ord: Ordering[B]): C = {
     val len = this.length
     val b = newSpecificBuilder()
-    if (len == 1) b ++= iterable
+    if (len == 1) b ++= toIterable
     else if (len > 1) {
       b.sizeHint(len)
       val arr = new Array[AnyRef](len)  // Previously used ArraySeq for more compact but slower code
@@ -434,7 +434,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     * as those of `that`?
     */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean =
-    iterable.iterator().sameElements(that)
+    toIterable.iterator().sameElements(that)
 
   /** Method called from equality methods, so that user-defined subclasses can
     *  refuse to be equal to other collections of the same kind.
@@ -450,7 +450,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
       case _ => false
     }
 
-  override def hashCode(): Int = stableIterableHash(iterable)
+  override def hashCode(): Int = stableIterableHash(toIterable)
 
   // Temporary: TODO move to MurmurHash3.scala
   private def stableIterableHash(xs: Iterable[_]): Int = {

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -32,7 +32,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *
     * @return a new $coll consisting of all the elements of this $coll without duplicates.
     */
-  def distinct: C = fromSpecificIterable(new View.Distinct(coll))
+  def distinct: C = fromSpecificIterable(new View.Distinct(iterable))
 
   /** Returns new $coll with elements in reversed order.
    *
@@ -63,7 +63,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *         index `offset`, otherwise `false`.
     */
   def startsWith[B >: A](that: Seq[B], offset: Int = 0): Boolean = {
-    val i = coll.iterator() drop offset
+    val i = iterable.iterator() drop offset
     val j = that.iterator()
     while (j.hasNext && i.hasNext)
       if (i.next() != j.next())
@@ -78,7 +78,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
     */
   def endsWith[B >: A](that: Seq[B]): Boolean = {
-    val i = coll.iterator().drop(length - that.length)
+    val i = iterable.iterator().drop(length - that.length)
     val j = that.iterator()
     while (i.hasNext && j.hasNext)
       if (i.next() != j.next())
@@ -96,7 +96,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
    */
-  def padTo[B >: A](len: Int, elem: B): CC[B] = fromIterable(View.PadTo(coll, len, elem))
+  def padTo[B >: A](len: Int, elem: B): CC[B] = fromIterable(View.PadTo(iterable, len, elem))
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
     *
@@ -107,7 +107,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return  the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
     *           or `-1`, if none exists.
     */
-  def indexWhere(p: A => Boolean, from: Int = 0): Int = coll.iterator().indexWhere(p, from)
+  def indexWhere(p: A => Boolean, from: Int = 0): Int = iterable.iterator().indexWhere(p, from)
 
   /** Finds index of first occurrence of some value in this $coll after or at some start index.
     *
@@ -364,7 +364,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   def sorted[B >: A](implicit ord: Ordering[B]): C = {
     val len = this.length
     val b = newSpecificBuilder()
-    if (len == 1) b ++= coll
+    if (len == 1) b ++= iterable
     else if (len > 1) {
       b.sizeHint(len)
       val arr = new Array[AnyRef](len)  // Previously used ArraySeq for more compact but slower code
@@ -433,7 +433,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     * as those of `that`?
     */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean =
-    coll.iterator().sameElements(that)
+    iterable.iterator().sameElements(that)
 
   /** Method called from equality methods, so that user-defined subclasses can
     *  refuse to be equal to other collections of the same kind.
@@ -449,7 +449,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
       case _ => false
     }
 
-  override def hashCode(): Int = stableIterableHash(coll)
+  override def hashCode(): Int = stableIterableHash(iterable)
 
   // Temporary: TODO move to MurmurHash3.scala
   private def stableIterableHash(xs: Iterable[_]): Int = {

--- a/src/main/scala/strawman/collection/Seq.scala
+++ b/src/main/scala/strawman/collection/Seq.scala
@@ -12,8 +12,8 @@ import scala.util.hashing.MurmurHash3
 
 /** Base trait for sequence collections */
 trait Seq[+A] extends Iterable[A] with SeqOps[A, Seq, Seq[A]] {
-  protected[this] def c: this.type = this
-  protected[this] def seq: this.type = this
+  final protected[this] def coll: this.type = this
+  final protected[this] def seq: this.type = this
 }
 
 /** Base trait for Seq operations */
@@ -22,7 +22,11 @@ trait SeqOps[+A, +CC[X], +C] extends Any
   with ArrayLike[A]
   with Equals {
 
-  protected[this] def c: C
+  /**
+    * @return This collection as a `Seq[A]`. Note that this method might require the creation of a
+    *         copy of this collection (e.g. `String` can not be turned into a `Seq[Char]` without
+    *         creating a new collection). Consequently you should always use `iterable` rather than `seq`.
+    */
   protected[this] def seq: Seq[A]
 
   // Refine the factory member to be a `SeqFactory`
@@ -212,7 +216,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
     */
   def permutations: Iterator[C] =
-    if (isEmpty) Iterator(c)
+    if (isEmpty) Iterator(coll)
     else new PermutationsItr
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -8,15 +8,17 @@ import java.lang.String
 
 /** Base trait for set collections.
   */
-trait Set[A] extends Iterable[A] with SetOps[A, Set, Set[A]]
+trait Set[A] extends Iterable[A] with SetOps[A, Set, Set[A]] {
+  final protected[this] def coll: this.type = this
+}
 
 /** Base trait for set operations */
-trait SetOps[A, +CC[X], +C <: Set[A]]
+trait SetOps[A, +CC[_], +C <: Set[A]]
   extends IterableOps[A, CC, C]
      with (A => Boolean)
      with Equals {
 
-  protected[this] def iterable: C
+  protected[this] def iterable: Set[A]
 
   def contains(elem: A): Boolean
 

--- a/src/main/scala/strawman/collection/Set.scala
+++ b/src/main/scala/strawman/collection/Set.scala
@@ -16,7 +16,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
      with (A => Boolean)
      with Equals {
 
-  protected[this] def coll: C
+  protected[this] def iterable: C
 
   def contains(elem: A): Boolean
 
@@ -44,7 +44,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     */
   def subsets(len: Int): Iterator[C] = {
     if (len < 0 || len > size) Iterator.empty
-    else new SubsetsItr(coll.to(IndexedSeq), len)
+    else new SubsetsItr(iterable.to(IndexedSeq), len)
   }
 
   /** An iterator over all subsets of this set.
@@ -52,7 +52,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     *  @return     the iterator.
     */
   def subsets(): Iterator[C] = new Iterator[C] {
-    private val elms = coll.to(IndexedSeq)
+    private val elms = iterable.to(IndexedSeq)
     private var len = 0
     private var itr: Iterator[C] = Iterator.empty
 
@@ -111,12 +111,12 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
       case set: Set[A] =>
         (this eq set) ||
           (set canEqual this) &&
-            (coll.size == set.size) &&
+            (iterable.size == set.size) &&
             (this subsetOf set)
       case _ => false
     }
 
-  override def hashCode(): Int = Set.setHash(coll)
+  override def hashCode(): Int = Set.setHash(iterable)
 
   override def toString(): String = super[IterableOps].toString() // Because `Function1` overrides `toString` too
 
@@ -155,7 +155,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     *  @param that     the collection containing the elements to add.
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
-  def concat(that: collection.Iterable[A]): C = fromSpecificIterable(View.Concat(coll, that))
+  def concat(that: collection.Iterable[A]): C = fromSpecificIterable(View.Concat(iterable, that))
 
   /** Alias for `concat` */
   @`inline` final def ++ (that: collection.Iterable[A]): C = concat(that)

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -39,10 +39,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
 
   // And finally, we add new overloads taking an ordering
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](coll, f))
+    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](iterable, f))
 
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.FlatMap(coll, f))
+    sortedMapFromIterable(View.FlatMap(iterable, f))
 
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
     flatMap { (kv: (K, V)) =>
@@ -60,13 +60,13 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, C
     *  @return     a new collection of type `CC[K2, V2]` which contains all elements
     *              of this $coll followed by all elements of `xs`.
     */
-  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(coll, xs))
+  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(iterable, xs))
 
   /** Alias for `concat` */
   @`inline` final def ++ [K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
-  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(coll, xs))
+  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(iterable, xs))
   override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
   // TODO Also override mapValues
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -11,7 +11,7 @@ trait SortedMap[K, +V]
   extends Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y], +C]
+trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C]
      with SortedOps[K, C] {
 
@@ -39,10 +39,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y], +C]
 
   // And finally, we add new overloads taking an ordering
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](iterable, f))
+    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](toIterable, f))
 
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.FlatMap(iterable, f))
+    sortedMapFromIterable(View.FlatMap(toIterable, f))
 
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
     flatMap { (kv: (K, V)) =>
@@ -60,13 +60,13 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y], +C]
     *  @return     a new collection of type `CC[K2, V2]` which contains all elements
     *              of this $coll followed by all elements of `xs`.
     */
-  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(iterable, xs))
+  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(toIterable, xs))
 
   /** Alias for `concat` */
   @`inline` final def ++ [K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
-  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(iterable, xs))
+  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(toIterable, xs))
   override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
   // TODO Also override mapValues
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -11,7 +11,7 @@ trait SortedMap[K, +V]
   extends Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
+trait SortedMapOps[K, +V, +CC[X, Y] <: SortedMap[X, Y], +C]
   extends MapOps[K, V, Map, C]
      with SortedOps[K, C] {
 

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -6,7 +6,7 @@ import scala.annotation.unchecked.uncheckedVariance
 /** Base type of sorted sets */
 trait SortedSet[A] extends Set[A] with SortedSetOps[A, SortedSet, SortedSet[A]]
 
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSet[A]]
+trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 
@@ -32,14 +32,14 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSet[A]]
   }
 
   /** Map */
-  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(iterable, f))
+  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(toIterable, f))
 
   /** Flatmap */
-  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(iterable, f))
+  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(toIterable, f))
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: Iterable[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
-    sortedFromIterable(View.Zip(iterable, xs))
+    sortedFromIterable(View.Zip(toIterable, xs))
 
   def collect[B: Ordering](pf: scala.PartialFunction[A, B]): CC[B] = flatMap(a =>
     if (pf.isDefinedAt(a)) View.Single(pf(a))

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -32,14 +32,14 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSet[A]]
   }
 
   /** Map */
-  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(coll, f))
+  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(iterable, f))
 
   /** Flatmap */
-  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(coll, f))
+  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(iterable, f))
 
   /** Zip. Interesting because it requires to align to source collections. */
   def zip[B](xs: Iterable[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
-    sortedFromIterable(View.Zip(coll, xs))
+    sortedFromIterable(View.Zip(iterable, xs))
 
   def collect[B: Ordering](pf: scala.PartialFunction[A, B]): CC[B] = flatMap(a =>
     if (pf.isDefinedAt(a)) View.Single(pf(a))

--- a/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -17,14 +17,14 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   /** Optimized, push-based version of `partition`. */
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder()
-    iterable.iterator().foreach(x => (if (p(x)) l else r) += x)
+    toIterable.iterator().foreach(x => (if (p(x)) l else r) += x)
     (l.result(), r.result())
   }
 
   override def span(p: A => Boolean): (C, C) = {
     val first = newSpecificBuilder()
     val second = newSpecificBuilder()
-    val it = iterable.iterator()
+    val it = toIterable.iterator()
     var inFirst = true
     while (it.hasNext && inFirst) {
       val a = it.next()
@@ -44,7 +44,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   override def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
     val first = iterableFactory.newBuilder[A1]()
     val second = iterableFactory.newBuilder[A2]()
-    iterable.foreach { a =>
+    toIterable.foreach { a =>
       val (a1, a2) = asPair(a)
       first += a1
       second += a2

--- a/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -17,14 +17,14 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   /** Optimized, push-based version of `partition`. */
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder()
-    coll.iterator().foreach(x => (if (p(x)) l else r) += x)
+    iterable.iterator().foreach(x => (if (p(x)) l else r) += x)
     (l.result(), r.result())
   }
 
   override def span(p: A => Boolean): (C, C) = {
     val first = newSpecificBuilder()
     val second = newSpecificBuilder()
-    val it = coll.iterator()
+    val it = iterable.iterator()
     var inFirst = true
     while (it.hasNext && inFirst) {
       val a = it.next()
@@ -44,7 +44,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   override def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
     val first = iterableFactory.newBuilder[A1]()
     val second = iterableFactory.newBuilder[A2]()
-    coll.foreach { a =>
+    iterable.foreach { a =>
       val (a1, a2) = asPair(a)
       first += a1
       second += a2

--- a/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
@@ -12,7 +12,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     val builder = newSpecificBuilder()
     val seen = mutable.HashSet.empty[A]
 
-    for (x <- coll) {
+    for (x <- iterable) {
       if (!seen.contains(x)) {
         seen += x
         builder += x

--- a/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
+++ b/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
@@ -12,7 +12,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     val builder = newSpecificBuilder()
     val seen = mutable.HashSet.empty[A]
 
-    for (x <- iterable) {
+    for (x <- toIterable) {
       if (!seen.contains(x)) {
         seen += x
         builder += x

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -14,7 +14,7 @@ class StringOps(val s: String)
     with ArrayLike[Char] {
 
   protected[this] def iterable = StringView(s)
-  protected[this] def c: String = s
+  protected[this] def coll: String = s
   protected[this] def seq: Seq[Char] = iterableFactory.fromIterable(iterable)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -13,9 +13,9 @@ class StringOps(val s: String)
     with StrictOptimizedIterableOps[Char, immutable.IndexedSeq, String]
     with ArrayLike[Char] {
 
-  protected[this] def coll = StringView(s)
+  protected[this] def iterable = StringView(s)
   protected[this] def c: String = s
-  protected[this] def seq: Seq[Char] = iterableFactory.fromIterable(coll)
+  protected[this] def seq: Seq[Char] = iterableFactory.fromIterable(iterable)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder
@@ -36,7 +36,7 @@ class StringOps(val s: String)
 
   override def className = "String"
 
-  def iterator(): Iterator[Char] = coll.iterator()
+  def iterator(): Iterator[Char] = iterable.iterator()
 
   /** Overloaded version of `map` that gives back a string, where the inherited
     *  version gives back a sequence.

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -13,9 +13,9 @@ class StringOps(val s: String)
     with StrictOptimizedIterableOps[Char, immutable.IndexedSeq, String]
     with ArrayLike[Char] {
 
-  protected[this] def iterable = StringView(s)
+  def toIterable = StringView(s)
   protected[this] def coll: String = s
-  def toSeq: Seq[Char] = iterableFactory.fromIterable(iterable)
+  def toSeq: Seq[Char] = iterableFactory.fromIterable(toIterable)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder
@@ -36,7 +36,7 @@ class StringOps(val s: String)
 
   override def className = "String"
 
-  def iterator(): Iterator[Char] = iterable.iterator()
+  def iterator(): Iterator[Char] = toIterable.iterator()
 
   /** Overloaded version of `map` that gives back a string, where the inherited
     *  version gives back a sequence.

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -15,7 +15,7 @@ class StringOps(val s: String)
 
   protected[this] def iterable = StringView(s)
   protected[this] def coll: String = s
-  protected[this] def seq: Seq[Char] = iterableFactory.fromIterable(iterable)
+  def toSeq: Seq[Char] = iterableFactory.fromIterable(iterable)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder

--- a/src/main/scala/strawman/collection/StringOps.scala
+++ b/src/main/scala/strawman/collection/StringOps.scala
@@ -15,7 +15,7 @@ class StringOps(val s: String)
 
   def toIterable = StringView(s)
   protected[this] def coll: String = s
-  def toSeq: Seq[Char] = iterableFactory.fromIterable(toIterable)
+  def toSeq: Seq[Char] = fromIterable(toIterable)
 
   protected[this] def fromSpecificIterable(coll: Iterable[Char]): String = {
     val sb = new StringBuilder

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -276,7 +276,7 @@ trait ArrayLike[+A] extends Any {
 /** View defined in terms of indexing a range */
 trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, IndexedView[A]] { self =>
 
-  final protected[this] def seq: Seq[A] = to(IndexedSeq)
+  final def toSeq: Seq[A] = to(IndexedSeq)
 
   override protected[this] def fromSpecificIterable(it: Iterable[A]): IndexedView[A] =
     it match {

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -16,6 +16,8 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   protected[this] def newSpecificBuilder(): Builder[A, View[A]] =
     immutable.IndexedSeq.newBuilder().mapResult(_.view)
 
+  final protected[this] def coll: this.type = this
+
   override def toString = "View(?)"
 
   override def className = "View"

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -64,7 +64,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(iterable, xs))
+        ImmutableArray.fromIterable(View.Concat(toIterable, xs))
     }
 
   override def prependAll[B >: A](xs: collection.Iterable[B]): ImmutableArray[B] =
@@ -75,7 +75,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(elements, 0, dest, bs.length, length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(xs, iterable))
+        ImmutableArray.fromIterable(View.Concat(xs, toIterable))
     }
 
   override def zip[B](xs: collection.Iterable[B]): ImmutableArray[(A, B)] =
@@ -85,13 +85,13 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
           (apply(i), bs(i))
         }
       case _ =>
-        ImmutableArray.fromIterable(View.Zip(iterable, xs))
+        ImmutableArray.fromIterable(View.Zip(toIterable, xs))
     }
 
-  override def filter(p: A => Boolean): ImmutableArray[A] = ImmutableArray.fromIterable(View.Filter(iterable, p))
+  override def filter(p: A => Boolean): ImmutableArray[A] = ImmutableArray.fromIterable(View.Filter(toIterable, p))
 
   override def partition(p: A => Boolean): (ImmutableArray[A], ImmutableArray[A]) = {
-    val pn = View.Partition(iterable, p)
+    val pn = View.Partition(toIterable, p)
     (ImmutableArray.fromIterable(pn.first), ImmutableArray.fromIterable(pn.second))
   }
 

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -64,7 +64,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(coll, xs))
+        ImmutableArray.fromIterable(View.Concat(iterable, xs))
     }
 
   override def prependAll[B >: A](xs: collection.Iterable[B]): ImmutableArray[B] =
@@ -75,7 +75,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(elements, 0, dest, bs.length, length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(xs, coll))
+        ImmutableArray.fromIterable(View.Concat(xs, iterable))
     }
 
   override def zip[B](xs: collection.Iterable[B]): ImmutableArray[(A, B)] =
@@ -85,13 +85,13 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
           (apply(i), bs(i))
         }
       case _ =>
-        ImmutableArray.fromIterable(View.Zip(coll, xs))
+        ImmutableArray.fromIterable(View.Zip(iterable, xs))
     }
 
-  override def filter(p: A => Boolean): ImmutableArray[A] = ImmutableArray.fromIterable(View.Filter(coll, p))
+  override def filter(p: A => Boolean): ImmutableArray[A] = ImmutableArray.fromIterable(View.Filter(iterable, p))
 
   override def partition(p: A => Boolean): (ImmutableArray[A], ImmutableArray[A]) = {
-    val pn = View.Partition(coll, p)
+    val pn = View.Partition(iterable, p)
     (ImmutableArray.fromIterable(pn.first), ImmutableArray.fromIterable(pn.second))
   }
 

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -11,11 +11,11 @@ trait Map[K, +V]
      with MapOps[K, V, Map, Map[K, V]]
 
 /** Base trait of immutable Maps implementations */
-trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C <: CC[K, V]]
+trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
-  protected[this] def iterable: CC[K, V]
+  protected[this] def coll: C with CC[K, V]
 
   /** Removes a key from this map, returning a new map.
     *
@@ -34,7 +34,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C 
     *  @return a new $coll that contains all elements of the current $coll
     *  except one less occurrence of each of the elements of `elems`.
     */
-  def removeAll(keys: IterableOnce[K]): C = fromSpecificIterable(keys.iterator().foldLeft[CC[K, V]](iterable)(_ - _))
+  def removeAll(keys: IterableOnce[K]): C = keys.iterator().foldLeft[C](coll)(_ - _)
 
   /** Alias for `removeAll` */
   @`inline` final def -- (keys: IterableOnce[K]): C = removeAll(keys)
@@ -60,7 +60,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C 
   /*@`inline` final*/ def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
   override def concat [V1 >: V](that: collection.Iterable[(K, V1)]): CC[K, V1] = {
-    var result: CC[K, V1] = iterable
+    var result: CC[K, V1] = coll
     val it = that.iterator()
     while (it.hasNext) result = result + it.next()
     result

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -15,7 +15,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C 
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
-  protected[this] def coll: C
+  protected[this] def iterable: CC[K, V]
 
   /** Removes a key from this map, returning a new map.
     *
@@ -34,7 +34,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C 
     *  @return a new $coll that contains all elements of the current $coll
     *  except one less occurrence of each of the elements of `elems`.
     */
-  def removeAll(keys: IterableOnce[K]): C = fromSpecificIterable(keys.iterator().foldLeft[CC[K, V]](coll)(_ - _))
+  def removeAll(keys: IterableOnce[K]): C = fromSpecificIterable(keys.iterator().foldLeft[CC[K, V]](iterable)(_ - _))
 
   /** Alias for `removeAll` */
   @`inline` final def -- (keys: IterableOnce[K]): C = removeAll(keys)
@@ -60,7 +60,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with MapOps[X, Y, CC, CC[X, Y]], +C 
   /*@`inline` final*/ def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
   override def concat [V1 >: V](that: collection.Iterable[(K, V1)]): CC[K, V1] = {
-    var result: CC[K, V1] = coll
+    var result: CC[K, V1] = iterable
     val it = that.iterator()
     while (it.hasNext) result = result + it.next()
     result

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -36,7 +36,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
    *    @return a new $coll consisting of `value` followed
    *            by all elements of this $coll.
    */
-  def prepend[B >: A](elem: B): CC[B] = fromIterable(View.Prepend(elem, coll))
+  def prepend[B >: A](elem: B): CC[B] = fromIterable(View.Prepend(elem, iterable))
 
   /** Alias for `prepend`.
     *
@@ -71,7 +71,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
    *    @return a new $coll consisting of
    *            all elements of this $coll followed by `value`.
    */
-  def append[B >: A](elem: B): CC[B] = fromIterable(View.Append(coll, elem))
+  def append[B >: A](elem: B): CC[B] = fromIterable(View.Append(iterable, elem))
 
   /** Alias for `append`
     *
@@ -91,7 +91,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
     *
     *    @return a copy of this $coll with the element at position `index` replaced by `elem`.
     */
-  def updated[B >: A](index: Int, elem: B): CC[B] = fromIterable(View.Updated(coll, index, elem))
+  def updated[B >: A](index: Int, elem: B): CC[B] = fromIterable(View.Updated(iterable, index, elem))
 
   /** Produces a new $coll where a slice of elements in this $coll is replaced by another sequence.
     *
@@ -107,7 +107,8 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
     *                   except that `replaced` elements starting from `from` are replaced
     *                   by all the elements of `other`.
     */
-  def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] = fromIterable(new View.Patched(coll, from, other, replaced))
+  def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] =
+    fromIterable(new View.Patched(iterable, from, other, replaced))
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -36,7 +36,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
    *    @return a new $coll consisting of `value` followed
    *            by all elements of this $coll.
    */
-  def prepend[B >: A](elem: B): CC[B] = fromIterable(View.Prepend(elem, iterable))
+  def prepend[B >: A](elem: B): CC[B] = fromIterable(View.Prepend(elem, toIterable))
 
   /** Alias for `prepend`.
     *
@@ -71,7 +71,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
    *    @return a new $coll consisting of
    *            all elements of this $coll followed by `value`.
    */
-  def append[B >: A](elem: B): CC[B] = fromIterable(View.Append(iterable, elem))
+  def append[B >: A](elem: B): CC[B] = fromIterable(View.Append(toIterable, elem))
 
   /** Alias for `append`
     *
@@ -91,7 +91,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
     *
     *    @return a copy of this $coll with the element at position `index` replaced by `elem`.
     */
-  def updated[B >: A](index: Int, elem: B): CC[B] = fromIterable(View.Updated(iterable, index, elem))
+  def updated[B >: A](index: Int, elem: B): CC[B] = fromIterable(View.Updated(toIterable, index, elem))
 
   /** Produces a new $coll where a slice of elements in this $coll is replaced by another sequence.
     *
@@ -108,7 +108,7 @@ trait SeqOps[+A, +CC[_], +C] extends collection.SeqOps[A, CC, C] {
     *                   by all the elements of `other`.
     */
   def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] =
-    fromIterable(new View.Patched(iterable, from, other, replaced))
+    fromIterable(new View.Patched(toIterable, from, other, replaced))
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -11,8 +11,6 @@ trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[
 trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   extends collection.SetOps[A, CC, C] {
 
-  protected[this] def iterable: C
-
   /** Creates a new set with an additional element, unless the element is
     *  already present.
     *
@@ -37,7 +35,7 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   @`inline` final def - (elem: A): C = excl(elem)
 
   override def concat(that: collection.Iterable[A]): C = {
-    var result: C = iterable
+    var result: C = coll
     val it = that.iterator()
     while (it.hasNext) result = result + it.next()
     result

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -8,7 +8,7 @@ import scala.{Any, `inline`}
 trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]]
 
 /** Base trait for immutable set operations */
-trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
+trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {
 
   /** Creates a new set with an additional element, unless the element is
@@ -42,7 +42,7 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   }
 
   def diff(that: collection.Set[A]): C =
-    iterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
+    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -11,7 +11,7 @@ trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[
 trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   extends collection.SetOps[A, CC, C] {
 
-  protected[this] def coll: C
+  protected[this] def iterable: C
 
   /** Creates a new set with an additional element, unless the element is
     *  already present.
@@ -37,14 +37,14 @@ trait SetOps[A, +CC[X], +C <: Set[A] with SetOps[A, Set, C]]
   @`inline` final def - (elem: A): C = excl(elem)
 
   override def concat(that: collection.Iterable[A]): C = {
-    var result: C = coll
+    var result: C = iterable
     val it = that.iterator()
     while (it.hasNext) result = result + it.next()
     result
   }
 
   def diff(that: collection.Set[A]): C =
-    coll.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
+    iterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
 }
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -13,7 +13,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
   extends MapOps[K, V, Map, C]
      with collection.SortedMapOps[K, V, CC, C] {
 
-    protected[this] def coll: C
+    protected[this] def iterable: CC[K, V]
 
     protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
       Map.fromIterable(it)
@@ -23,7 +23,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
     override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
     override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
-        var result: CC[K, V2] = coll
+        var result: CC[K, V2] = iterable
         val it = xs.iterator()
         while (it.hasNext) result = result + it.next()
         result

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -9,11 +9,11 @@ trait SortedMap[K, +V]
      with collection.SortedMap[K, V]
      with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: CC[K, V]]
+trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C]
      with collection.SortedMapOps[K, V, CC, C] {
 
-    protected[this] def iterable: CC[K, V]
+    protected[this] def coll: C with CC[K, V]
 
     protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
       Map.fromIterable(it)
@@ -23,7 +23,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, 
     override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
     override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
-        var result: CC[K, V2] = iterable
+        var result: CC[K, V2] = coll
         val it = xs.iterator()
         while (it.hasNext) result = result + it.next()
         result

--- a/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -2,18 +2,13 @@ package strawman
 package collection
 package immutable
 
-import strawman.collection.mutable.Builder
-import scala.Ordering
-
 /** Base trait for sorted sets */
 trait SortedSet[A]
   extends Set[A]
      with collection.SortedSet[A]
      with SortedSetOps[A, SortedSet, SortedSet[A]]
 
-trait SortedSetOps[A,
-                   +CC[X] <: SortedSet[X] with SortedSetOps[X, CC, _],
-                   +C <: SortedSet[A] with SortedSetOps[A, SortedSet, C]]
+trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C]
 

--- a/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
@@ -17,7 +17,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size + 1)
     }
     b += elem
-    b ++= coll
+    b ++= iterable
     b.result()
   }
 
@@ -26,7 +26,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
     if (knownSize >= 0) {
       b.sizeHint(size + 1)
     }
-    b ++= coll
+    b ++= iterable
     b += elem
     b.result()
   }
@@ -38,7 +38,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size)
     }
     var i = 0
-    val it = coll.iterator()
+    val it = iterable.iterator()
     while (i < index && it.hasNext) {
       b += it.next()
       i += 1
@@ -53,7 +53,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] = {
     val b = iterableFactory.newBuilder[B]()
     var i = 0
-    val it = coll.iterator()
+    val it = iterable.iterator()
     while (i < from && it.hasNext) {
       b += it.next()
       i += 1

--- a/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
@@ -17,7 +17,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size + 1)
     }
     b += elem
-    b ++= iterable
+    b ++= toIterable
     b.result()
   }
 
@@ -26,7 +26,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
     if (knownSize >= 0) {
       b.sizeHint(size + 1)
     }
-    b ++= iterable
+    b ++= toIterable
     b += elem
     b.result()
   }
@@ -38,7 +38,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size)
     }
     var i = 0
-    val it = iterable.iterator()
+    val it = toIterable.iterator()
     while (i < index && it.hasNext) {
       b += it.next()
       i += 1
@@ -53,7 +53,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] = {
     val b = iterableFactory.newBuilder[B]()
     var i = 0
-    val it = iterable.iterator()
+    val it = toIterable.iterator()
     while (i < from && it.hasNext) {
       b += it.next()
       i += 1

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -18,7 +18,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     with collection.MapOps[K, V, CC, C]
     with Shrinkable[K] {
 
-  protected[this] def coll: Map[K, V]
+  protected[this] def iterable: Map[K, V]
 
   def iterableFactory = Iterable
 
@@ -45,7 +45,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @param key    The key to update
     *  @param value  The new value
     */
-  def update(key: K, value: V): Unit = { coll += ((key, value)) }
+  def update(key: K, value: V): Unit = { iterable += ((key, value)) }
 
   /** If given key is already in this map, returns associated value.
    *
@@ -67,7 +67,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
       case None => val d = op; this(key) = d; d
     }
 
-  override def clone(): C = empty ++= coll
+  override def clone(): C = empty ++= iterable
 
   def mapInPlace(f: ((K, V)) => (K, V)): this.type = {
     val toAdd = Map[K, V]()
@@ -79,8 +79,8 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
         toRemove -= elem._1
       }
     }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) iterable -= elem
+    for (elem <- toAdd) iterable += elem
     this
   }
 
@@ -93,8 +93,8 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
           toAdd += mapped
           toRemove -= elem._1
         }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) iterable -= elem
+    for (elem <- toAdd) iterable += elem
     this
   }
 
@@ -103,7 +103,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     for (elem <- this)
       if (!p(elem)) toRemove += elem._1
     for (elem <- toRemove)
-      coll -= elem
+      iterable -= elem
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/src/main/scala/strawman/collection/mutable/Map.scala
@@ -13,12 +13,10 @@ trait Map[K, V]
     with MapOps[K, V, Map, Map[K, V]]
 
 /** Base trait of mutable Maps implementations */
-trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
+trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C]
     with Shrinkable[K] {
-
-  protected[this] def iterable: Map[K, V]
 
   def iterableFactory = Iterable
 
@@ -45,7 +43,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     *  @param key    The key to update
     *  @param value  The new value
     */
-  def update(key: K, value: V): Unit = { iterable += ((key, value)) }
+  def update(key: K, value: V): Unit = { coll += ((key, value)) }
 
   /** If given key is already in this map, returns associated value.
    *
@@ -67,7 +65,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
       case None => val d = op; this(key) = d; d
     }
 
-  override def clone(): C = empty ++= iterable
+  override def clone(): C = empty ++= toIterable
 
   def mapInPlace(f: ((K, V)) => (K, V)): this.type = {
     val toAdd = Map[K, V]()
@@ -79,8 +77,8 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
         toRemove -= elem._1
       }
     }
-    for (elem <- toRemove) iterable -= elem
-    for (elem <- toAdd) iterable += elem
+    for (elem <- toRemove) coll -= elem
+    for (elem <- toAdd) coll += elem
     this
   }
 
@@ -93,8 +91,8 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
           toAdd += mapped
           toRemove -= elem._1
         }
-    for (elem <- toRemove) iterable -= elem
-    for (elem <- toAdd) iterable += elem
+    for (elem <- toRemove) coll -= elem
+    for (elem <- toAdd) coll += elem
     this
   }
 
@@ -103,7 +101,7 @@ trait MapOps[K, V, +CC[X, Y] <: Map[X, Y], +C <: Map[K, V]]
     for (elem <- this)
       if (!p(elem)) toRemove += elem._1
     for (elem <- toRemove)
-      iterable -= elem
+      coll -= elem
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -26,8 +26,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
         toRemove -= elem
       }
     }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) iterable -= elem
+    for (elem <- toAdd) iterable += elem
     this
   }
 
@@ -39,17 +39,17 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
 
   def insert(elem: A): Boolean =
     !contains(elem) && {
-      coll += elem; true
+      iterable += elem; true
     }
 
   def remove(elem: A): Option[A] = {
     val res = get(elem)
-    coll -= elem
+    iterable -= elem
     res
   }
 
   def diff(that: collection.Set[A]): C =
-    coll.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
+    iterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
 
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     val toAdd = Set[A]()
@@ -60,8 +60,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
           toAdd += mapped
           toRemove -= elem
         }
-    for (elem <- toRemove) coll -= elem
-    for (elem <- toAdd) coll += elem
+    for (elem <- toRemove) iterable -= elem
+    for (elem <- toAdd) iterable += elem
     this
   }
 
@@ -70,11 +70,11 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     for (elem <- this)
       if (!p(elem)) toRemove += elem
     for (elem <- toRemove)
-      coll -= elem
+      iterable -= elem
     this
   }
 
-  override def clone(): C = empty ++= coll
+  override def clone(): C = empty ++= iterable
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -11,7 +11,7 @@ trait Set[A]
     with collection.Set[A]
     with SetOps[A, Set, Set[A]]
 
-trait SetOps[A, +CC[X], +C <: Set[A]]
+trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
     with collection.SetOps[A, CC, C]
     with Shrinkable[A] {
@@ -49,7 +49,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
   }
 
   def diff(that: collection.Set[A]): C =
-    iterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
+    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
 
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     val toAdd = Set[A]()
@@ -74,7 +74,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     this
   }
 
-  override def clone(): C = empty ++= iterable
+  override def clone(): C = empty ++= toIterable
 
 }
 

--- a/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/src/main/scala/strawman/collection/mutable/Set.scala
@@ -26,8 +26,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
         toRemove -= elem
       }
     }
-    for (elem <- toRemove) iterable -= elem
-    for (elem <- toAdd) iterable += elem
+    for (elem <- toRemove) coll -= elem
+    for (elem <- toAdd) coll += elem
     this
   }
 
@@ -39,12 +39,12 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
 
   def insert(elem: A): Boolean =
     !contains(elem) && {
-      iterable += elem; true
+      coll += elem; true
     }
 
   def remove(elem: A): Option[A] = {
     val res = get(elem)
-    iterable -= elem
+    coll -= elem
     res
   }
 
@@ -60,8 +60,8 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
           toAdd += mapped
           toRemove -= elem
         }
-    for (elem <- toRemove) iterable -= elem
-    for (elem <- toAdd) iterable += elem
+    for (elem <- toRemove) coll -= elem
+    for (elem <- toAdd) coll += elem
     this
   }
 
@@ -70,7 +70,7 @@ trait SetOps[A, +CC[X], +C <: Set[A]]
     for (elem <- this)
       if (!p(elem)) toRemove += elem
     for (elem <- toRemove)
-      iterable -= elem
+      coll -= elem
     this
   }
 

--- a/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -9,7 +9,7 @@ trait SortedMap[K, V]
     with Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
 
-trait SortedMapOps[K, V, +CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMap[K, V]]
+trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends collection.SortedMapOps[K, V, CC, C]
     with MapOps[K, V, Map, C] {
 

--- a/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -12,7 +12,7 @@ trait SortedSet[A]
     with collection.SortedSet[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
 
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSet[A]]
+trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
     with collection.SortedSetOps[A, CC, C]
 


### PR DESCRIPTION
This PR extracts the changes performed in #173 that are unrelated with `withFilter`, and polishes them.

For more details, see [this comment](https://github.com/scala/collection-strawman/pull/173#discussion_r129514133):

> I add [a `coll: C`] member to `IterableOps[A, CC[_], C]`. Why is it useful? In this PR it’s needed by `WithFilter`, which uses a `BuildFrom` instance to build the result of `map` and `flatMap`, and `BuildFrom` needs an initial collection `C` to create a builder.
> 
> Note, that this member was previously already existing in `SeqOps`. It was needed because `SeqOps` is extended by (at least) `StringOps` and `List`, and to implement methods of `SeqOps` we sometimes needed a `C` (ie. `String` or `List[A]`) value and sometimes an `Iterable[A]` (ie. `StringView` or `List[A]`) value. So, with just one member (`coll`) we couldn’t get both a `String` and an `Iterable[Char]`, that’s why we needed two members: `coll: Iterable[A]` and `c: C`.

For me, these changes solve #134 and #78 with the benefit of not introducing a new intermediate layer (interfaces with no implementations) in the hierarchy.