### PR TITLE
#163 Fix incorrect benchmarks charts

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class HashSetBenchmark {
 
-  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: HashSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class ScalaHashSetBenchmark {
 
-  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.collection.immutable.HashSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class ScalaTreeSetBenchmark {
 
-  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: scala.collection.immutable.TreeSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -16,7 +16,7 @@ import scala.Predef.intWrapper
 @State(Scope.Benchmark)
 class TreeSetBenchmark {
 
-  @Param(scala.Array(/*"0", */"1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "73121", "7312102"))
   var size: Int = _
 
   var xs: TreeSet[Long] = _

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
@@ -18,7 +18,7 @@ import scala.Predef.{intWrapper, longArrayOps}
 @State(Scope.Benchmark)
 class ScalaArrayBenchmark {
 
-  @Param(scala.Array(/*"0", */"1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "31980"/*, "73121", "120000"*/))
+  @Param(scala.Array("0", "1"/*, "2", "3", "4", "7"*/, "8"/*, "15", "16"*/, "17"/*, "39"*/, "282", "4096", "31980"/*, "73121", "120000"*/))
   var size: Int = _
 
   var xs: scala.Array[Long] = _

--- a/project/Bencharts.scala
+++ b/project/Bencharts.scala
@@ -3,7 +3,7 @@ package strawman.collection
 import javax.imageio.ImageIO
 
 import org.jfree.chart.JFreeChart
-import org.jfree.chart.axis.{LogAxis, NumberAxis}
+import org.jfree.chart.axis.{LogAxis, LogarithmicAxis, NumberAxis}
 import org.jfree.chart.plot.XYPlot
 import org.jfree.chart.renderer.xy.XYErrorRenderer
 import org.jfree.data.xy.{YIntervalSeries, YIntervalSeriesCollection}
@@ -50,9 +50,8 @@ object Bencharts {
               ySeries
             }
 
-        val xAxis = new LogAxis("Size")
-        xAxis.setBase(2)
-        xAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits())
+        val xAxis = new LogarithmicAxis("Size")
+        xAxis.setAllowNegativesFlag(true)
         val yAxis = new LogAxis(yAxisTitle)
 
         val col = new YIntervalSeriesCollection()

--- a/project/Bencharts.scala
+++ b/project/Bencharts.scala
@@ -52,7 +52,8 @@ object Bencharts {
 
         val xAxis = new LogarithmicAxis("Size")
         xAxis.setAllowNegativesFlag(true)
-        val yAxis = new LogAxis(yAxisTitle)
+        val yAxis = new LogarithmicAxis(yAxisTitle)
+        yAxis.setAllowNegativesFlag(true)
 
         val col = new YIntervalSeriesCollection()
         val renderer = new XYErrorRenderer


### PR DESCRIPTION
The issue in #163 is that potentially zero values are being plotted in a logarithmic axis (the logarithm of zero is undefined/infinity). The `org.jfree.chart.axis.LogAxis` class does not seem to allow zero/negative values (see impl. of `setSmallestValue`) or accepts them silently and the result is a messed up chart like the one below:

![concat_current2](https://user-images.githubusercontent.com/1107367/29896688-ebff6fe4-8dd5-11e7-9d59-1046bc3709d6.png)



I have thought of a few options to solve this:

1. **remove zeroes:** I don't think we want this as zero is a valid input size for the benchmarks
2. **replace zeroes with a very small positive number (cheating):** the chart is still messed up if the number is too small.
3. **use a linear axis instead:** this one would plot the zeroes. However, if there is a large range of input values (as is the case for HashSetBenchmark) the ones at the beginning would be squeezed (as they are more condensed) and the higher values would be too distant leaving huge gaps in between:
![concat_numberaxis](https://user-images.githubusercontent.com/1107367/29896758-330e95a4-8dd6-11e7-95ee-80884009abb7.png)

4. **use `LogarithmicAxis`:** this class is similar to `LogAxis` but can allow zero/negative values. I think the result looks pretty good. The only con is that the default base is 10 (the current charts use base 2 in the x-axis) and the api does not let it be changed.

![concat_logarithmicaxis](https://user-images.githubusercontent.com/1107367/29897535-3a615d84-8dd9-11e7-91bf-748987986595.png)
_(p.s.: the execution times for the last 2 sizes are not real. I got OOM errors when running the benchmarks through sbt and did not find out how to set -Xms/-Xmx flags for JMH)_

The last option seemed to be the most appropriate and is the one implemented for this PR. Please let me know if it looks good enough or if there's any other alternative I should consider.

(Note: I did sign the CLA already)