### PR TITLE
Use custom start/step in 'zipWithIndex'

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -841,11 +841,14 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** Zips this $coll with its indices.
     *
     *  @return        A new collection of type `That` containing pairs consisting of all elements of this
-    *                 $coll paired with their index. Indices start at `0`.
+    *                 $coll paired with their index. Indices start at `start` and are increased by `step`.
     *  @example
     *    `List("a", "b", "c").zipWithIndex == List(("a", 0), ("b", 1), ("c", 2))`
     */
-  def zipWithIndex: CC[(A @uncheckedVariance, Int)] = fromIterable(View.ZipWithIndex(toIterable))
+  def zipWithIndex(start: Int = 0, step: Int = 0): CC[(A @uncheckedVariance, Int)] = fromIterable(View.ZipWithIndex(toIterable, start, step))
+
+  /** Alias for default zipWithIndex. As a separate method, to support old syntax */
+  @`inline` def zipWithIndex: CC[(A @uncheckedVariance, Int)] = zipWithIndex(start = 0, step = 1)
 
   /** Converts this $coll of pairs into two collections of the first and second
     *  half of each pair.

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -620,12 +620,12 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     *                 corresponding elements of this iterator and their indices.
     *  @note          Reuse: $consumesAndProducesIterator
     */
-  def zipWithIndex: Iterator[(A, Int)] = new Iterator[(A, Int)] {
-    var idx = 0
+  def zipWithIndex(start: Int = 0, step: Int = 1): Iterator[(A, Int)] = new Iterator[(A, Int)] {
+    var idx = start
     def hasNext = self.hasNext
     def next() = {
       val ret = (self.next(), idx)
-      idx += 1
+      idx += step
       ret
     }
   }

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -222,8 +222,8 @@ object View extends IterableFactory[View] {
     def iterator(): Iterator[A] = underlying.iterator().patch(from, other.iterator(), replaced)
   }
 
-  case class ZipWithIndex[A](underlying: Iterable[A]) extends View[(A, Int)] {
-    def iterator(): Iterator[(A, Int)] = underlying.iterator().zipWithIndex
+  case class ZipWithIndex[A](underlying: Iterable[A], start: Int = 0, step: Int = 1) extends View[(A, Int)] {
+    def iterator(): Iterator[(A, Int)] = underlying.iterator().zipWithIndex(start, step)
     override def knownSize: Int = underlying.knownSize
   }
 

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -176,8 +176,9 @@ sealed abstract class LazyList[+A]
     if (this.isEmpty || xs.isEmpty) LazyList.empty
     else LazyList.cons((this.head, xs.head), this.tail.zip(xs.tail))
 
-  override final def zipWithIndex: LazyList[(A, Int)] = this.zip(LazyList.from(0))
+  override final def zipWithIndex(start: Int = 0, step: Int = 1): LazyList[(A, Int)] = this.zip(LazyList.from(start, step))
 
+  override final def zipWithIndex: LazyList[(A, Int)] = zipWithIndex(start = 0, step = 1)
 }
 
 object LazyList extends SeqFactory[LazyList] {

--- a/src/test/scala/strawman/collection/test/ZipWithIndex.scala
+++ b/src/test/scala/strawman/collection/test/ZipWithIndex.scala
@@ -1,0 +1,32 @@
+package strawman
+package collection
+package test
+
+import immutable.{LazyList, List, Range, Vector}
+
+import scala.{Array, Int, Unit}
+import scala.Predef.{ArrowAssoc, assert}
+import org.junit.Test
+
+class ZipWithIndex {
+
+  @Test
+  def originalZipWithIndex(): Unit = {
+    assert(List(1, 2, 3).zipWithIndex == List((1, 0), (2, 1), (3, 2)))
+    assert(List(1, 2, 3).view.zipWithIndex.toArray sameElements Array[(Int, Int)]((1, 0), (2, 1), (3, 2)))
+    assert(LazyList(1, 2, 3).zipWithIndex.toArray sameElements Array[(Int, Int)]((1, 0), (2, 1), (3, 2)))
+    assert(Vector(1, 2, 3).zipWithIndex == Vector((1, 0), (2, 1), (3, 2)))
+    assert(Array(1, 2, 3).zipWithIndex sameElements Array[(Int, Int)]((1, 0), (2, 1), (3, 2)))
+    assert(Range(1, 4).zipWithIndex.toArray sameElements Array[(Int, Int)]((1, 0), (2, 1), (3, 2)))
+  }
+
+  @Test
+  def zipWithIndexStartStep(): Unit = {
+    assert(List(1, 2, 3).zipWithIndex(42, -1) == List((1, 42), (2, 41), (3, 40)))
+    assert(List(1, 2, 3).view.zipWithIndex(42, -1).toArray sameElements Array[(Int, Int)]((1, 42), (2, 41), (3, 40)))
+    assert(LazyList(1, 2, 3).zipWithIndex(42, -1).toArray sameElements Array[(Int, Int)]((1, 42), (2, 41), (3, 40)))
+    assert(Vector(1, 2, 3).zipWithIndex(42, -1) == Vector((1, 42), (2, 41), (3, 40)))
+    assert(Array(1, 2, 3).zipWithIndex(42, -1) sameElements Array[(Int, Int)]((1, 42), (2, 41), (3, 40)))
+    assert(Range(1, 4).zipWithIndex(42, -1).toArray sameElements Array[(Int, Int)]((1, 42), (2, 41), (3, 40)))
+  }
+}


### PR DESCRIPTION
Motivation -- sometimes I want to use other than 0 start index in `zipWithIndex`. Some alternatives -- implicit class or manual addition, like `for ((x, _i) <- list.zipWithIndex; i = _i + start) ...`. However, probably would be useful to have this functionality built in stdlib, to simplify user code.

Example:
```
scala> List(1, 2, 3).zipWithIndex(start = 42, step = -1)
res0: strawman.collection.immutable.List[(Int, Int)] = List((1,42), (2,41), (3,40))
```

Goals:
1. Already existing syntax `list.zipWithIndex ...` must be preserved, so no user code should be changed.
2. New method must use the same name, so it looks like `list.zipWithIndex(42, 1) ...`.
3. `list.zipWithIndex() ...` must behave exactly the same as `list.zipWithIndex ...`.

To achieve first goal, I had to create explicit overloaded `zipWithIndex` method. That slightly complicates collection's code. Alternative is to provide scalafix rule that replaces `list.zipWithIndex` with `list.zipWithIndex()`. Not sure what's better, decided to start without scalafix.

Any comments and suggestions are welcome.