### PR TITLE
add fill benchmarks

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -292,4 +292,10 @@ class ListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  def fill(bh: Blackhole): Unit = {
+    val result = List.fill(size)(())
+    bh.consume(result)
+  }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -292,4 +292,10 @@ class ScalaListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  def fill(bh: Blackhole): Unit = {
+    val result = List.fill(size)(())
+    bh.consume(result)
+  }
 }


### PR DESCRIPTION
The new List.fill is slower, but not horribly so until the collection size becomes large. I ran the benchmarks with -Xms12G. You can see that ListBenchmark.fill has a severe problem for the largest size. I believe it's due to memory pressure, but I'm not sure.

```
[info] # Run complete. Total time: 00:12:44
[info]
[info] Benchmark                 (size)  Mode  Cnt           Score            Error  Units
[info] ListBenchmark.fill             0  avgt   10          81.033 ±          6.180  ns/op
[info] ListBenchmark.fill             1  avgt   10         103.044 ±          8.414  ns/op
[info] ListBenchmark.fill             2  avgt   10         120.165 ±          4.002  ns/op
[info] ListBenchmark.fill             3  avgt   10         148.985 ±          9.002  ns/op
[info] ListBenchmark.fill             4  avgt   10         162.349 ±         12.988  ns/op
[info] ListBenchmark.fill             7  avgt   10         226.644 ±         17.605  ns/op
[info] ListBenchmark.fill             8  avgt   10         301.029 ±         26.030  ns/op
[info] ListBenchmark.fill            15  avgt   10         507.449 ±         36.583  ns/op
[info] ListBenchmark.fill            16  avgt   10         543.501 ±         67.147  ns/op
[info] ListBenchmark.fill            17  avgt   10         537.010 ±         37.800  ns/op
[info] ListBenchmark.fill            39  avgt   10        1214.240 ±        109.495  ns/op
[info] ListBenchmark.fill           282  avgt   10        3338.817 ±        298.093  ns/op
[info] ListBenchmark.fill          4096  avgt   10       42777.832 ±       2031.041  ns/op
[info] ListBenchmark.fill        131070  avgt   10     1579473.944 ±     554707.054  ns/op
[info] ListBenchmark.fill       7312102  avgt   10  1016141204.700 ± 3015303989.604  ns/op
[info] ScalaListBenchmark.fill        0  avgt   10          71.739 ±          3.370  ns/op
[info] ScalaListBenchmark.fill        1  avgt   10          80.742 ±          3.684  ns/op
[info] ScalaListBenchmark.fill        2  avgt   10          97.603 ±          7.710  ns/op
[info] ScalaListBenchmark.fill        3  avgt   10         104.818 ±          6.974  ns/op
[info] ScalaListBenchmark.fill        4  avgt   10         112.337 ±          5.858  ns/op
[info] ScalaListBenchmark.fill        7  avgt   10         133.601 ±          5.867  ns/op
[info] ScalaListBenchmark.fill        8  avgt   10         138.069 ±          9.337  ns/op
[info] ScalaListBenchmark.fill       15  avgt   10         215.898 ±         12.223  ns/op
[info] ScalaListBenchmark.fill       16  avgt   10         222.923 ±         12.883  ns/op
[info] ScalaListBenchmark.fill       17  avgt   10         228.236 ±         10.389  ns/op
[info] ScalaListBenchmark.fill       39  avgt   10         479.336 ±         39.121  ns/op
[info] ScalaListBenchmark.fill      282  avgt   10        2464.617 ±         90.019  ns/op
[info] ScalaListBenchmark.fill     4096  avgt   10      135445.705 ±     193731.295  ns/op
[info] ScalaListBenchmark.fill   131070  avgt   10     1351558.899 ±     317645.062  ns/op
[info] ScalaListBenchmark.fill  7312102  avgt   10    72150762.767 ±    8988583.569  ns/op
```