### PR TITLE
Make factory methods take an IterableOnce instead of an Iterable

### DIFF
--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -49,7 +49,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
 
   protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.from(it)
 
-  def iterableFactory: IterableFactory[CC]
+  def iterableFactory: IterableFactoryLike[CC]
 
   /**
     * @return a strict builder for the same collection type.

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -47,7 +47,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
 
   protected[this] def fromSpecificIterable(coll: Iterable[A]): C
 
-  protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.fromIterable(it)
+  protected[this] def fromIterable[E](it: Iterable[E]): CC[E] = iterableFactory.from(it)
 
   def iterableFactory: IterableFactory[CC]
 
@@ -264,12 +264,12 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
     *      xs.to(ArrayBuffer)
     *      xs.to(BitSet) // for xs: Iterable[Int]
     */
-  def to[C1](f: CanBuild[A, C1]): C1 = f.fromSpecificIterable(toIterable)
+  def to[C1](f: CanBuild[A, C1]): C1 = f.fromSpecific(toIterable)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =
     if (knownSize >= 0) copyToArray(new Array[B](knownSize), 0)
-    else ArrayBuffer.fromIterable(toIterable).toArray[B]
+    else ArrayBuffer.from(toIterable).toArray[B]
 
   /** Copy all elements of this collection to array `xs`, starting at `start`. */
   def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = {
@@ -484,9 +484,9 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
 
     protected[this] def filtered = View.Filter(toIterable, p, isFlipped = false)
 
-    def map[B](f: A => B): CC[B] = iterableFactory.fromIterable(View.Map(filtered, f))
+    def map[B](f: A => B): CC[B] = iterableFactory.from(View.Map(filtered, f))
 
-    def flatMap[B](f: A => IterableOnce[B]): CC[B] = iterableFactory.fromIterable(View.FlatMap(filtered, f))
+    def flatMap[B](f: A => IterableOnce[B]): CC[B] = iterableFactory.from(View.FlatMap(filtered, f))
 
     def foreach[U](f: A => U): Unit = filtered.foreach(f)
 

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -255,7 +255,7 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   def size: Int = if (knownSize >= 0) knownSize else toIterable.iterator().length
 
   /** A view representing the elements of this collection. */
-  def view: View[A] = View.fromIterator(toIterable.iterator())
+  def view: View[A] = View.fromIteratorProvider(() => toIterable.iterator())
 
   /** Given a collection factory `fi`, convert this collection to the appropriate
     * representation for the current element type `A`. Example uses:

--- a/src/main/scala/strawman/collection/IterableOnce.scala
+++ b/src/main/scala/strawman/collection/IterableOnce.scala
@@ -1,9 +1,11 @@
 package strawman
 package collection
 
-import scala.Any
+import scala.{Any, Int}
 
 trait IterableOnce[+A] extends Any {
   /** Iterator can be used only once */
   def iterator(): Iterator[A]
+
+  def knownSize: Int
 }

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -734,6 +734,14 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     b
   }
 
+  /** Converts this Iterator into another collection.
+    *  @return a new collection containing all elements of this Iterator.
+    *  @tparam C The collection type to build.
+    *  @param canBuild Collection factory to use. The factory may or may
+    *                  not eagerly consume this iterator.
+    */
+  def to[C](canBuild: CanBuild[A, C]): C = canBuild.fromSpecific(self)
+
 }
 
 object Iterator {

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -21,6 +21,8 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
   def next(): A
   def iterator() = this
 
+  final def knownSize: Int = -1
+
   /** Tests whether this iterator is empty.
     *
     *  @return   `true` if hasNext is false, `false` otherwise.

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -97,7 +97,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     *
     *  @return the values of this map as an iterable.
     */
-  def values: Iterable[V] = View.fromIterator(valuesIterator())
+  def values: Iterable[V] = View.fromIteratorProvider(() => valuesIterator())
 
   /** Creates an iterator for all keys.
     *

--- a/src/main/scala/strawman/collection/Map.scala
+++ b/src/main/scala/strawman/collection/Map.scala
@@ -172,9 +172,9 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   /** Specializes `WithFilter` for Map collection types */
   class MapWithFilter(p: ((K, V)) => Boolean) extends WithFilter(p) {
 
-    def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFactory.fromIterable(View.Map(filtered, f))
+    def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFactory.from(View.Map(filtered, f))
 
-    def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFactory.fromIterable(View.FlatMap(filtered, f))
+    def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFactory.from(View.FlatMap(filtered, f))
 
     override def withFilter(q: ((K, V)) => Boolean): MapWithFilter = new MapWithFilter(kv => p(kv) && q(kv))
 

--- a/src/main/scala/strawman/collection/SortedMap.scala
+++ b/src/main/scala/strawman/collection/SortedMap.scala
@@ -52,10 +52,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   class SortedMapWithFilter(p: ((K, V)) => Boolean) extends MapWithFilter(p) {
 
     def map[K2 : Ordering, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] =
-      sortedMapFactory.sortedFromIterable(View.Map(filtered, f))
+      sortedMapFactory.from(View.Map(filtered, f))
 
     def flatMap[K2 : Ordering, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] =
-      sortedMapFactory.sortedFromIterable(View.FlatMap(filtered, f))
+      sortedMapFactory.from(View.FlatMap(filtered, f))
 
     override def withFilter(q: ((K, V)) => Boolean): SortedMapWithFilter = new SortedMapWithFilter(kv => p(kv) && q(kv))
 

--- a/src/main/scala/strawman/collection/SortedSet.scala
+++ b/src/main/scala/strawman/collection/SortedSet.scala
@@ -23,9 +23,9 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     */
   class SortedWithFilter(p: A => Boolean) extends WithFilter(p) {
 
-    def map[B : Ordering](f: A => B): CC[B] = sortedIterableFactory.sortedFromIterable(View.Map(filtered, f))
+    def map[B : Ordering](f: A => B): CC[B] = sortedIterableFactory.from(View.Map(filtered, f))
 
-    def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedIterableFactory.sortedFromIterable(View.FlatMap(filtered, f))
+    def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedIterableFactory.from(View.FlatMap(filtered, f))
 
     override def withFilter(q: A => Boolean): SortedWithFilter = new SortedWithFilter(a => p(a) && q(a))
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -26,14 +26,14 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
 /** This object reifies operations on views as case classes */
 object View extends IterableFactory[View] {
 
-  def fromIterator[A](it: => Iterator[A]): View[A] = new View[A] {
-    def iterator() = it
+  def fromIteratorProvider[A](it: () => Iterator[A]): View[A] = new View[A] {
+    def iterator() = it()
   }
 
   /** Avoid copying if source collection is already a view. */
   def from[E](it: IterableOnce[E]): View[E] = it match {
     case it: View[E]     => it
-    case it: Iterable[E] => View.fromIterator(it.iterator())
+    case it: Iterable[E] => View.fromIteratorProvider(() => it.iterator())
     case _ => scala.sys.error("One should not build a View from an IterableOnce instance")
   }
 

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -23,8 +23,16 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   override def className = "View"
 }
 
-/** This object reifies operations on views as case classes */
-object View extends IterableFactory[View] {
+/** This object reifies operations on views as case classes
+  *
+  * @define $Coll View
+  * @define $coll view
+  */
+object View extends IterableFactoryLike[View] {
+
+  // Views are just forwarders to a source collection’s iterator. Consequently, they have to be
+  // build from an `Iterable` source in order to be themselves `Iterable`
+  type Source[A] = Iterable[A]
 
   /**
     * @return A `View[A]` whose underlying iterator is provided by the `it` parameter-less function.
@@ -46,11 +54,9 @@ object View extends IterableFactory[View] {
     *
     * @tparam E View element type
     */
-  @throws[IllegalArgumentException]
-  def from[E](it: IterableOnce[E]): View[E] = it match {
+  def from[E](it: Iterable[E]): View[E] = it match {
     case it: View[E]     => it
-    case it: Iterable[E] => View.fromIteratorProvider(() => it.iterator())
-    case _ => throw new IllegalArgumentException("One should not build a View from an IterableOnce instance")
+    case _               => View.fromIteratorProvider(() => it.iterator())
   }
 
   def empty[A]: View[A] = Empty

--- a/src/main/scala/strawman/collection/View.scala
+++ b/src/main/scala/strawman/collection/View.scala
@@ -31,14 +31,15 @@ object View extends IterableFactory[View] {
   }
 
   /** Avoid copying if source collection is already a view. */
-  def fromIterable[E](it: Iterable[E]): View[E] = it match {
-    case it: View[E] => it
-    case _ => View.fromIterator(it.iterator())
+  def from[E](it: IterableOnce[E]): View[E] = it match {
+    case it: View[E]     => it
+    case it: Iterable[E] => View.fromIterator(it.iterator())
+    case _ => scala.sys.error("One should not build a View from an IterableOnce instance")
   }
 
   def empty[A]: View[A] = Empty
 
-  def newBuilder[A](): Builder[A, View[A]] = ArrayBuffer.newBuilder[A]().mapResult(fromIterable)
+  def newBuilder[A](): Builder[A, View[A]] = ArrayBuffer.newBuilder[A]().mapResult(from)
 
   override def apply[A](xs: A*): View[A] = Elems(xs: _*)
 

--- a/src/main/scala/strawman/collection/concurrent/TrieMap.scala
+++ b/src/main/scala/strawman/collection/concurrent/TrieMap.scala
@@ -665,8 +665,8 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   def this() = this(Hashing.default, Equiv.universal)
 
   def mapFactory: MapFactory[TrieMap] = TrieMap
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TrieMap[K,V] = TrieMap.fromIterable(coll)
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): TrieMap[K2,V2] = TrieMap.fromIterable(it)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TrieMap[K,V] = TrieMap.from(coll)
+  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): TrieMap[K2,V2] = TrieMap.from(it)
   protected[this] def newSpecificBuilder(): Builder[(K, V), TrieMap[K,V]] = TrieMap.newBuilder[K, V]()
 
   /* internal methods */
@@ -988,7 +988,7 @@ object TrieMap extends MapFactory[TrieMap] {
 
   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
 
-  def fromIterable[K, V](it: Iterable[(K, V)]) = new TrieMap[K, V]() ++= it
+  def from[K, V](it: IterableOnce[(K, V)]) = new TrieMap[K, V]() ++= it
 
   def newBuilder[K, V]() = new GrowableBuilder(empty[K, V])
 
@@ -1082,7 +1082,7 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
     // this one needs to be evaluated
     if (this.subiter == null) it.subiter = null
     else {
-      val lst = immutable.List.fromIterable(View.fromIterator(this.subiter))
+      val lst = this.subiter.to(immutable.List)
       this.subiter = lst.iterator()
       it.subiter = lst.iterator()
     }

--- a/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -30,8 +30,8 @@ sealed abstract class BitSet
   def iterableFactory = Set
   def sortedIterableFactory = SortedSet
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecificIterable(coll)
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.sortedFromIterable(it)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecific(coll)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.from(it)
   protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
@@ -62,10 +62,10 @@ sealed abstract class BitSet
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
-  def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet =
+  def fromSpecific(it: strawman.collection.IterableOnce[Int]): BitSet =
     it match {
       case bs: BitSet => bs
-      case _          => empty.++(it)
+      case _          => (newBuilder() ++= it).result()
     }
 
   def empty: BitSet = new BitSet1(0L)

--- a/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -39,10 +39,10 @@ sealed trait HashMap[K, +V]
   def iterableFactory = List
   def mapFactory = HashMap
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.fromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
 
   protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] =
-    HashMap.fromIterable(it)
+    HashMap.from(it)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
 
@@ -108,10 +108,10 @@ object HashMap extends MapFactory[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = EmptyHashMap.asInstanceOf[HashMap[K, V]]
 
-  def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] =
+  def from[K, V](it: collection.IterableOnce[(K, V)]): HashMap[K, V] =
     it match {
       case hm: HashMap[K, V] => hm
-      case _ => empty ++ it
+      case _ => (newBuilder[K, V]() ++= it).result()
     }
 
   def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] =

--- a/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -59,10 +59,10 @@ sealed abstract class HashSet[A]
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[A](it: collection.Iterable[A]): HashSet[A] =
+  def from[A](it: collection.IterableOnce[A]): HashSet[A] =
     it match {
       case hs: HashSet[A] => hs
-      case _ => empty ++ it
+      case _ => (newBuilder[A]() ++= it).result()
     }
 
   def empty[A]: HashSet[A] = EmptyHashSet.asInstanceOf[HashSet[A]]

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -62,7 +62,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(bs.elements, 0, dest, length, bs.length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(toIterable, xs))
+        fromIterable(View.Concat(toIterable, xs))
     }
 
   override def prependAll[B >: A](xs: collection.Iterable[B]): ImmutableArray[B] =
@@ -73,7 +73,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
         java.lang.System.arraycopy(elements, 0, dest, bs.length, length)
         new ImmutableArray(dest)
       case _ =>
-        ImmutableArray.fromIterable(View.Concat(xs, toIterable))
+        fromIterable(View.Concat(xs, toIterable))
     }
 
   override def zip[B](xs: collection.Iterable[B]): ImmutableArray[(A, B)] =
@@ -83,12 +83,12 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
           (apply(i), bs(i))
         }
       case _ =>
-        ImmutableArray.fromIterable(View.Zip(toIterable, xs))
+        fromIterable(View.Zip(toIterable, xs))
     }
 
   override def partition(p: A => Boolean): (ImmutableArray[A], ImmutableArray[A]) = {
     val pn = View.Partition(toIterable, p)
-    (ImmutableArray.fromIterable(pn.first), ImmutableArray.fromIterable(pn.second))
+    (fromIterable(pn.first), fromIterable(pn.second))
   }
 
   override def take(n: Int): ImmutableArray[A] = ImmutableArray.tabulate(n)(apply)
@@ -119,8 +119,8 @@ object ImmutableArray extends SeqFactory[ImmutableArray] {
   def fromArrayBuffer[A](arr: ArrayBuffer[A]): ImmutableArray[A] =
     new ImmutableArray[A](arr.asInstanceOf[ArrayBuffer[Any]].toArray)
 
-  def fromIterable[A](it: strawman.collection.Iterable[A]): ImmutableArray[A] =
-    if (it.knownSize > -1) {
+  def from[A](it: strawman.collection.IterableOnce[A]): ImmutableArray[A] =
+    /*if (it.knownSize > -1) {
       val n = it.knownSize
       val elements = scala.Array.ofDim[Any](n)
       val iterator = it.iterator()
@@ -130,7 +130,7 @@ object ImmutableArray extends SeqFactory[ImmutableArray] {
         i = i + 1
       }
       new ImmutableArray(elements)
-    } else fromArrayBuffer(ArrayBuffer.fromIterable(it))
+    } else*/ fromArrayBuffer(ArrayBuffer.from(it))
 
   def newBuilder[A](): Builder[A, ImmutableArray[A]] =
     ArrayBuffer.newBuilder[A]().mapResult(fromArrayBuffer)

--- a/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -120,7 +120,7 @@ object ImmutableArray extends SeqFactory[ImmutableArray] {
     new ImmutableArray[A](arr.asInstanceOf[ArrayBuffer[Any]].toArray)
 
   def from[A](it: strawman.collection.IterableOnce[A]): ImmutableArray[A] =
-    /*if (it.knownSize > -1) {
+    if (it.knownSize > -1) {
       val n = it.knownSize
       val elements = scala.Array.ofDim[Any](n)
       val iterator = it.iterator()
@@ -130,7 +130,7 @@ object ImmutableArray extends SeqFactory[ImmutableArray] {
         i = i + 1
       }
       new ImmutableArray(elements)
-    } else*/ fromArrayBuffer(ArrayBuffer.from(it))
+    } else fromArrayBuffer(ArrayBuffer.from(it))
 
   def newBuilder[A](): Builder[A, ImmutableArray[A]] =
     ArrayBuffer.newBuilder[A]().mapResult(fromArrayBuffer)

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -238,7 +238,7 @@ object LazyList extends SeqFactory[LazyList] {
     def unapply[A](s: LazyList[A]): Evaluated[A] = s.force
   }
 
-  def fromIterable[A](coll: collection.Iterable[A]): LazyList[A] = coll match {
+  def from[A](coll: collection.IterableOnce[A]): LazyList[A] = coll match {
     case coll: LazyList[A] => coll
     case _ => fromIterator(coll.iterator())
   }
@@ -305,7 +305,7 @@ object LazyList extends SeqFactory[LazyList] {
     loop(init)
   }
 
-  def newBuilder[A](): Builder[A, LazyList[A]] = ArrayBuffer.newBuilder[A]().mapResult(fromIterable)
+  def newBuilder[A](): Builder[A, LazyList[A]] = ArrayBuffer.newBuilder[A]().mapResult(array => from(array))
 
   private[immutable] def filteredTail[A](lazyList: LazyList[A], p: A => Boolean, isFlipped: Boolean) = {
     cons(lazyList.head, lazyList.tail.filterImpl(p, isFlipped))

--- a/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -243,6 +243,14 @@ object LazyList extends SeqFactory[LazyList] {
     case _ => fromIterator(coll.iterator())
   }
 
+  /**
+    * @return A `LazyList[A]` that gets its elements from the given `Iterator`.
+    *
+    * @param it Source iterator
+    * @tparam A type of elements
+    */
+  // Note that the resulting `LazyList` will be effectively iterable more than once because
+  // `LazyList` memoizes its elements
   def fromIterator[A](it: Iterator[A]): LazyList[A] =
     if (it.hasNext) {
       // Be sure that `it.next()` is called even when the `head`

--- a/src/main/scala/strawman/collection/immutable/List.scala
+++ b/src/main/scala/strawman/collection/immutable/List.scala
@@ -350,9 +350,9 @@ case object Nil extends List[Nothing] {
 
 object List extends SeqFactory[List] {
 
-  def fromIterable[B](coll: collection.Iterable[B]): List[B] = coll match {
+  def from[B](coll: collection.IterableOnce[B]): List[B] = coll match {
     case coll: List[B] => coll
-    case _ => ListBuffer.fromIterable(coll).toList
+    case _ => ListBuffer.from(coll).toList
   }
 
   def newBuilder[A](): Builder[A, List[A]] =

--- a/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -52,9 +52,9 @@ sealed class ListMap[K, +V]
   def iterableFactory = List
   def mapFactory = ListMap
 
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ListMap[K2,V2] = ListMap.fromIterable(it)
+  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ListMap[K2,V2] = ListMap.from(it)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ListMap[K, V] = ListMap.fromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ListMap[K, V] = ListMap.from(coll)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), ListMap[K, V]] = ListMap.newBuilder()
 
@@ -162,10 +162,10 @@ object ListMap extends MapFactory[ListMap] {
   @SerialVersionUID(-8256686706655863282L)
   private object EmptyListMap extends ListMap[Any, Nothing]
 
-  def fromIterable[K, V](it: collection.Iterable[(K, V)]): ListMap[K, V] =
+  def from[K, V](it: collection.IterableOnce[(K, V)]): ListMap[K, V] =
     it match {
       case lm: ListMap[K, V] => lm
-      case _ => empty ++ it
+      case _ => (newBuilder[K, V]() ++= it).result()
     }
 
   def newBuilder[K, V](): Builder[(K, V), ListMap[K, V]] =

--- a/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -115,10 +115,10 @@ sealed class ListSet[A]
   */
 object ListSet extends IterableFactory[ListSet] {
 
-  def fromIterable[E](it: strawman.collection.Iterable[E]): ListSet[E] =
+  def from[E](it: strawman.collection.IterableOnce[E]): ListSet[E] =
     it match {
       case ls: ListSet[E] => ls
-      case _ => empty ++ it
+      case _ => (newBuilder[E]() ++= it).result()
     }
 
   @SerialVersionUID(5010379588739277132L)

--- a/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/src/main/scala/strawman/collection/immutable/Map.scala
@@ -86,10 +86,10 @@ object Map extends MapFactory[Map] {
 
   def empty[K, V]: Map[K, V] = EmptyMap.asInstanceOf[Map[K, V]]
 
-  def fromIterable[K, V](it: collection.Iterable[(K, V)]): Map[K, V] =
+  def from[K, V](it: collection.IterableOnce[(K, V)]): Map[K, V] =
     it match {
       case m: Map[K, V] => m
-      case _ => empty ++ it
+      case _ => (newBuilder[K, V]() ++= it).result()
     }
 
   def newBuilder[K, V](): Builder[(K, V), Map[K, V]] = HashMap.newBuilder()
@@ -98,8 +98,8 @@ object Map extends MapFactory[Map] {
     def iterableFactory: IterableFactory[Iterable] = Iterable
     def mapFactory: MapFactory[Map] = Map
     def empty: Map[K, V] = mapFactory.empty
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): Map[K, V] = mapFactory.fromIterable(coll)
-    protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = mapFactory.fromIterable(it)
+    protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): Map[K, V] = mapFactory.from(coll)
+    protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = mapFactory.from(it)
     protected[this] def newSpecificBuilder(): Builder[(K, V), Map[K, V]] = mapFactory.newBuilder()
   }
 

--- a/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/src/main/scala/strawman/collection/immutable/Set.scala
@@ -52,13 +52,13 @@ object Set extends IterableFactory[Set] {
 
   def empty[A]: Set[A] = EmptySet.asInstanceOf[Set[A]]
 
-  def fromIterable[E](it: collection.Iterable[E]): Set[E] =
+  def from[E](it: collection.IterableOnce[E]): Set[E] =
     it match {
       // We want `SortedSet` (and subclasses, such as `BitSet`) to
       // rebuild themselves to avoid element type widening issues
-      case _: SortedSet[E] => empty ++ it
+      case _: SortedSet[E] => (newBuilder[E]() ++= it).result()
       case s: Set[E]       => s
-      case _               => empty ++ it
+      case _               => (newBuilder[E]() ++= it).result()
     }
 
   def newBuilder[A](): Builder[A, Set[A]] = HashSet.newBuilder()
@@ -67,7 +67,7 @@ object Set extends IterableFactory[Set] {
   trait SmallSet[A] extends Set[A] {
     def iterableFactory: IterableFactory[Set] = Set
     def empty: Set[A] = iterableFactory.empty
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): Set[A] = iterableFactory.fromIterable(coll)
+    protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): Set[A] = iterableFactory.from(coll)
     protected[this] def newSpecificBuilder(): Builder[A, Set[A]] = iterableFactory.newBuilder()
   }
 

--- a/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -23,8 +23,8 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
     protected class ImmutableKeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
       def iterableFactory: IterableFactory[Set] = Set
       def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
-      protected[this] def sortedFromIterable[B: Ordering](it: collection.Iterable[B]): SortedSet[B] = sortedIterableFactory.sortedFromIterable(it)
-      protected[this] def fromSpecificIterable(coll: collection.Iterable[K]): SortedSet[K] = sortedIterableFactory.sortedFromIterable(coll)
+      protected[this] def sortedFromIterable[B: Ordering](it: collection.Iterable[B]): SortedSet[B] = sortedIterableFactory.from(it)
+      protected[this] def fromSpecificIterable(coll: collection.Iterable[K]): SortedSet[K] = sortedIterableFactory.from(coll)
       protected[this] def newSpecificBuilder(): Builder[K, SortedSet[K]] = sortedIterableFactory.newBuilder()
       def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
         val map = self.rangeImpl(from, until)
@@ -36,7 +36,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
     }
 
     protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
-      Map.fromIterable(it)
+      Map.from(it)
 
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]

--- a/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -41,10 +41,10 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   def sortedMapFactory = TreeMap
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    TreeMap.sortedFromIterable(coll)
+    TreeMap.from(coll)
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
-    TreeMap.sortedFromIterable(it)
+    TreeMap.from(it)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
@@ -134,10 +134,10 @@ object TreeMap extends SortedMapFactory[TreeMap] {
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap()
 
-  def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
+  def from[K : Ordering, V](it: collection.IterableOnce[(K, V)]): TreeMap[K, V] =
     it match {
       case tm: TreeMap[K, V] => tm
-      case _ => empty[K, V] ++ it
+      case _ => (newBuilder[K, V]() ++= it).result()
     }
 
   def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] =

--- a/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -39,10 +39,10 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
   def sortedIterableFactory = TreeSet
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.sortedFromIterable(coll)
+    TreeSet.from(coll)
 
   protected[this] def sortedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.sortedFromIterable(coll)
+    TreeSet.from(coll)
 
   protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
 
@@ -137,10 +137,10 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def empty[A: Ordering]: TreeSet[A] = new TreeSet[A]
 
-  def sortedFromIterable[E: Ordering](it: strawman.collection.Iterable[E]): TreeSet[E] =
+  def from[E: Ordering](it: strawman.collection.IterableOnce[E]): TreeSet[E] =
     it match {
       case ts: TreeSet[E] => ts
-      case _ => empty[E] ++ it
+      case _ => (newBuilder[E]() ++= it).result()
     }
 
   def newBuilder[A : Ordering](): Builder[A, TreeSet[A]] =

--- a/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -14,7 +14,7 @@ object Vector extends SeqFactory[Vector] {
 
   def empty[A]: Vector[A] = NIL
 
-  def fromIterable[E](it: collection.Iterable[E]): Vector[E] =
+  def from[E](it: collection.IterableOnce[E]): Vector[E] =
     it match {
       case v: Vector[E] => v
       case _            => (newBuilder() ++= it).result()

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -107,7 +107,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
             }
         }
       case _ =>
-        insertAll(idx, ArrayBuffer.fromIterable(View.fromIterator(elems.iterator())))
+        insertAll(idx, ArrayBuffer.from(elems))
     }
   }
 
@@ -135,14 +135,14 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 object ArrayBuffer extends SeqFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
-  def fromIterable[B](coll: collection.Iterable[B]): ArrayBuffer[B] =
-    if (coll.knownSize >= 0) {
+  def from[B](coll: collection.IterableOnce[B]): ArrayBuffer[B] =
+    /*if (coll.knownSize >= 0) {
       val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()
       for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
       new ArrayBuffer[B](array, array.length)
     }
-    else new ArrayBuffer[B] ++= coll
+    else*/ new ArrayBuffer[B] ++= coll
 
   def newBuilder[A](): Builder[A, ArrayBuffer[A]] =
     new GrowableBuilder[A, ArrayBuffer[A]](empty) {

--- a/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -136,13 +136,13 @@ object ArrayBuffer extends SeqFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
   def from[B](coll: collection.IterableOnce[B]): ArrayBuffer[B] =
-    /*if (coll.knownSize >= 0) {
+    if (coll.knownSize >= 0) {
       val array = new Array[AnyRef](coll.knownSize)
       val it = coll.iterator()
       for (i <- 0 until array.length) array(i) = it.next().asInstanceOf[AnyRef]
       new ArrayBuffer[B](array, array.length)
     }
-    else*/ new ArrayBuffer[B] ++= coll
+    else new ArrayBuffer[B] ++= coll
 
   def newBuilder[A](): Builder[A, ArrayBuffer[A]] =
     new GrowableBuilder[A, ArrayBuffer[A]](empty) {

--- a/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -41,10 +41,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
   def sortedIterableFactory = SortedSet
 
   protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): collection.mutable.SortedSet[B] =
-    collection.mutable.SortedSet.sortedFromIterable(it)
+    collection.mutable.SortedSet.from(it)
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
-    BitSet.fromSpecificIterable(coll)
+    BitSet.fromSpecific(coll)
 
   protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
 
@@ -153,7 +153,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
-  def fromSpecificIterable(it: strawman.collection.Iterable[Int]): BitSet = Growable.fromIterable(empty, it)
+  def fromSpecific(it: strawman.collection.IterableOnce[Int]): BitSet = Growable.from(empty, it)
 
   def empty: BitSet = new BitSet()
 

--- a/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -70,6 +70,6 @@ object Growable {
     * @tparam A Element type
     * @return The filled instance
     */
-  def fromIterable[A](empty: Growable[A], it: collection.Iterable[A]): empty.type = empty ++= it
+  def from[A](empty: Growable[A], it: collection.IterableOnce[A]): empty.type = empty ++= it
 
 }

--- a/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -40,8 +40,8 @@ final class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, D
 
   def this() = this(null)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.fromIterable(coll)
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] = HashMap.fromIterable(it)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
+  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] = HashMap.from(it)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] =  HashMap.newBuilder()
 
@@ -118,7 +118,7 @@ object HashMap extends MapFactory[HashMap] {
 
   def empty[K, V]: HashMap[K, V] = new HashMap[K, V]
 
-  def fromIterable[K, V](it: collection.Iterable[(K, V)]): HashMap[K, V] = Growable.fromIterable(empty[K, V], it)
+  def from[K, V](it: collection.IterableOnce[(K, V)]): HashMap[K, V] = Growable.from(empty[K, V], it)
 
   def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] = new GrowableBuilder(HashMap.empty[K, V])
 

--- a/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -77,7 +77,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
 object HashSet extends IterableFactory[HashSet] {
 
-  def fromIterable[B](it: strawman.collection.Iterable[B]): HashSet[B] = Growable.fromIterable(empty[B], it)
+  def from[B](it: strawman.collection.IterableOnce[B]): HashSet[B] = Growable.from(empty[B], it)
 
   def empty[A]: HashSet[A] = new HashSet[A]
 

--- a/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -38,7 +38,7 @@ class ListBuffer[A]
   protected[this] def newSpecificBuilder(): Builder[A, ListBuffer[A]] = ListBuffer.newBuilder()
 
   private def copyElems(): Unit = {
-    val buf = ListBuffer.fromIterable(this)
+    val buf = ListBuffer.from(this)
     first = buf.first
     last0 = buf.last0
     aliased = false
@@ -246,7 +246,7 @@ class ListBuffer[A]
 
 object ListBuffer extends SeqFactory[ListBuffer] {
 
-  def fromIterable[A](coll: collection.Iterable[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
+  def from[A](coll: collection.IterableOnce[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
 
   def newBuilder[A](): Builder[A, ListBuffer[A]] = new GrowableBuilder(empty[A])
 

--- a/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -13,6 +13,6 @@ trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], 
   extends collection.SortedMapOps[K, V, CC, C]
     with MapOps[K, V, Map, C] {
 
-  def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = Map.fromIterable(it)
+  def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = Map.from(it)
 
 }

--- a/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -38,9 +38,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(ord)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.sortedFromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.from(coll)
 
-  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.sortedFromIterable(it)
+  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.from(it)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
@@ -180,8 +180,8 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   */
 object TreeMap extends SortedMapFactory[TreeMap] {
 
-  def sortedFromIterable[K : Ordering, V](it: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    Growable.fromIterable(empty[K, V], it)
+  def from[K : Ordering, V](it: collection.IterableOnce[(K, V)]): TreeMap[K, V] =
+    Growable.from(empty[K, V], it)
 
   def empty[K : Ordering, V]: TreeMap[K, V] = new TreeMap[K, V]()
 

--- a/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -40,9 +40,9 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def iterator(): collection.Iterator[A] = RB.keysIterator(tree)
 
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.sortedFromIterable(it)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.from(it)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.sortedFromIterable(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.from(coll)
 
   protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
 
@@ -184,7 +184,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def empty[A : Ordering]: TreeSet[A] = new TreeSet[A]()
 
-  def sortedFromIterable[E : Ordering](it: collection.Iterable[E]): TreeSet[E] = Growable.fromIterable(empty[E], it)
+  def from[E : Ordering](it: collection.IterableOnce[E]): TreeSet[E] = Growable.from(empty[E], it)
 
   def newBuilder[A: Ordering](): Builder[A, TreeSet[A]] = new GrowableBuilder(empty[A])
 

--- a/test/junit/src/test/scala/strawman/CollectTest.scala
+++ b/test/junit/src/test/scala/strawman/CollectTest.scala
@@ -53,11 +53,11 @@ class CollectTest {
 
   @Ignore @Test
   def testIteratorCollect: Unit =
-    testing(???)(List.fromIterable(View.fromIterator(Iterator(1, 2) collect { case x if f(x) && x < 2 => x})))
+    testing(???)(Iterator(1, 2) collect { case x if f(x) && x < 2 => x} to List)
 
   @Ignore @Test
   def testListViewCollect: Unit =
-    testing(???)(List.fromIterable(View.fromIterator(Iterator(1, 2) collect { case x if f(x) && x < 2 => x})))
+    testing(???)(Iterator(1, 2) collect { case x if f(x) && x < 2 => x} to List)
 
   @Ignore @Test
   def testFutureCollect: Unit = {

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -156,7 +156,7 @@ class IteratorTest {
   // was java.lang.UnsupportedOperationException: tail of empty list
   @Test def iterateIsSufficientlyLazy(): Unit = {
     //Iterator.iterate((1 to 5).toList)(_.tail).takeWhile(_.nonEmpty).toList  // suffices
-    View.fromIterator(Iterator.iterate((1 to 5).toList)(_.tail).takeWhile(_.nonEmpty).map(_.head)).to(List)
+    Iterator.iterate((1 to 5).toList)(_.tail).takeWhile(_.nonEmpty).map(_.head).to(List)
   }
   // scala/bug#3516
   @Test def lazyListIsLazy(): Unit = {
@@ -167,9 +167,8 @@ class IteratorTest {
     val s1 = LazyList.fromIterator(mkIterator)
     val s2 = LazyList.fromIterator(mkInfinite)
     // back and forth without slipping into nontermination.
-    // TODO Uncomment and adapt with LazyList
-//    results += (Stream from 1).toIterator.drop(10).toStream.drop(10).toIterator.next()
-    assertSameElements(List.empty, results)
+    results += LazyList.from(1).iterator().drop(10).to(LazyList).drop(10).iterator().next()
+    assertSameElements(List(21), results)
   }
 
   // scala/bug#8552

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -72,10 +72,10 @@ class IteratorTest {
       //closures.foldLeft(Iterator.empty: Iterator[Int])((res, f) => res ++ f())
       List.fill(size)(() => Iterator(1)).foldLeft(Iterator.empty: Iterator[Int])((res, f) => res ++ f())
     }
-    assertEquals(100,    View.fromIterator(mk(100)).sum)
-    assertEquals(1000,   View.fromIterator(mk(1000)).sum)
-    assertEquals(10000,  View.fromIterator(mk(10000)).sum)
-    assertEquals(100000, View.fromIterator(mk(100000)).sum)
+    assertEquals(100,    View.fromIteratorProvider(() => mk(100)).sum)
+    assertEquals(1000,   View.fromIteratorProvider(() => mk(1000)).sum)
+    assertEquals(10000,  View.fromIteratorProvider(() => mk(10000)).sum)
+    assertEquals(100000, View.fromIteratorProvider(() => mk(100000)).sum)
   }
 
   @Test def from(): Unit = {

--- a/test/junit/src/test/scala/strawman/collection/concurrent/TrieMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/concurrent/TrieMapTest.scala
@@ -12,8 +12,8 @@ class TrieMapTest {
     val m = TrieMap[String, String]()
     val values = f(m)
     m.put("k", "v")
-    Assert.assertEquals(Nil, List.fromIterable(View.fromIterator(values.iterator())))
-    Assert.assertEquals(result2, List.fromIterable(View.fromIterator(f(m).iterator())))
+    Assert.assertEquals(Nil, values.iterator().to(List))
+    Assert.assertEquals(result2, f(m).iterator().to(List))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/immutable/ListMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ListMapTest.scala
@@ -44,6 +44,6 @@ class ListMapTest {
   @Test
   def hasCorrectIterator(): Unit = {
     val m = ListMap(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4)
-    assertEquals(List(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4), List.fromIterable(View.fromIterator(m.iterator())))
+    assertEquals(List(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4), m.iterator().to(List))
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/ListSetTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ListSetTest.scala
@@ -49,6 +49,6 @@ class ListSetTest {
   @Test
   def hasCorrectIterator(): Unit = {
     val s = ListSet(1, 2, 3, 5, 4)
-    assertEquals(List(1, 2, 3, 5, 4), List.fromIterable(View.fromIterator(s.iterator())))
+    assertEquals(List(1, 2, 3, 5, 4), s.iterator().to(List))
   }
 }


### PR DESCRIPTION
Fixes #199.

Changes the signature of factory methods from:

~~~ scala
def fromIterable[A](it: Iterable[A]): CC[A]
~~~

to:

~~~ scala
def from[A](it: IterableOnce[A]): CC[A]
~~~

This makes it simpler to build a collection from an `Iterator`, for instance.

Since this change doesn’t work for `View` (they have to be built from an `Iterable`, not an `IterableOnce`), the source type is still fixed to `Iterable`. To achieve that I introduced an `IterableFactoryLike`, which generalizes `IterableFactory` by making the type of the source collection abstract. This type is then refined to be `IterableOnce` in `IterableFactory` and `Iterable` in `View` companion. I wish I had thought of a better name than `IterableFactoryLike`. Any suggestion?

I also changed the signature of `View.fromIterator[A](it: => Iterator[A]): View[A]` to `View.fromIteratorProvider[A](it: () => Iterator[A]): View[A]` to make it clearer that one should not pass a “provider” that returns the same `Iterator` (because the resulting `View` would be effectively iterable only once, in such a case).