### PR TITLE
Separate BuildFrom and CanBuild.

### DIFF
--- a/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/src/main/scala/strawman/collection/BuildFrom.scala
@@ -1,0 +1,50 @@
+package strawman.collection
+
+import scala.{Any, Ordering}
+
+import strawman.collection.mutable.Builder
+
+/** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
+  * Implicit instances of `BuildFrom` are available for all collection types.
+  *
+  * @tparam From Type of source collection
+  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+  */
+trait BuildFrom[-From, -A, +C] extends Any {
+  def fromSpecificIterable(from: From)(it: Iterable[A]): C
+
+  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+    * Building collections with `fromSpecificIterable` is preferred because it can be lazy for lazy collections. */
+  def newBuilder(from: From): Builder[A, C]
+}
+
+object BuildFrom extends BuildFromLowPriority {
+  /** Build the source collection type from a MapOps */
+  implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _], K0, V0, K, V]: BuildFrom[CC[K0, V0], (K, V), CC[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
+    //TODO: Reuse a prototype instance
+    def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = from.mapFactory.newBuilder[K, V]()
+    def fromSpecificIterable(from: CC[K0, V0])(it: Iterable[(K, V)]): CC[K, V] = from.mapFactory.from(it)
+  }
+
+  /** Build the source collection type from a SortedMapOps */
+  implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0], (K, V), CC[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
+    def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = from.sortedMapFactory.newBuilder[K, V]()
+    def fromSpecificIterable(from: CC[K0, V0])(it: Iterable[(K, V)]): CC[K, V] = from.sortedMapFactory.from(it)
+  }
+
+  /** Build the source collection type from an Iterable with SortedOps */
+  implicit def buildFromSortedSetOps[CC[X] <: SortedSet[X] with SortedSetOps[X, CC, _], A0, A : Ordering]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
+    def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.sortedIterableFactory.newBuilder[A]()
+    def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.sortedIterableFactory.from(it)
+  }
+}
+
+trait BuildFromLowPriority {
+  /** Build the source collection type from an IterableOps */
+  implicit def buildFromIterableOps[CC[X] <: Iterable[X] with IterableOps[X, CC, _], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
+    //TODO: Reuse a prototype instance
+    def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.iterableFactory.newBuilder[A]()
+    def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.iterableFactory.from(it)
+  }
+}

--- a/src/main/scala/strawman/collection/Factory.scala
+++ b/src/main/scala/strawman/collection/Factory.scala
@@ -105,7 +105,7 @@ trait IterableFactoryLike[+CC[_]] {
   *
   * @tparam CC Collection type constructor (e.g. `List`)
   */
-trait IterableFactory[+CC[_]] extends IterableFactoryLike[CC] {
+trait IterableFactory[+CC[_]] extends IterableFactoryLike[CC] { factory =>
 
   // Since most collection factories can build a target collection instance by performing only one
   // traversal of a source collection, the type of this source collection can be refined to be
@@ -113,6 +113,16 @@ trait IterableFactory[+CC[_]] extends IterableFactoryLike[CC] {
   type Source[A] = IterableOnce[A]
 
   implicit def iterableFactory[A]: Factory[A, CC[A]] = IterableFactory.toFactory(this)
+
+  /**
+    * @return a `BuildFrom` instance that ignores the factory of the source collection.
+    * @tparam A Type of elements
+    */
+  def toBuildFrom[A]: BuildFrom[Any, A, CC[A]] =
+    new BuildFrom[Any, A, CC[A]] {
+      def fromSpecificIterable(from: Any)(it: Iterable[A]) = factory.from(it)
+      def newBuilder(from: Any) = factory.newBuilder()
+    }
 
 }
 
@@ -130,12 +140,6 @@ object IterableFactory {
     new Factory[A, CC[A]] {
       def fromSpecific(it: IterableOnce[A]): CC[A] = factory.from[A](it)
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
-    }
-
-  implicit def toBuildFrom[A, CC[_]](factory: IterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
-    new BuildFrom[Any, A, CC[A]] {
-      def fromSpecificIterable(from: Any)(it: Iterable[A]) = factory.from(it)
-      def newBuilder(from: Any) = factory.newBuilder()
     }
 
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
@@ -269,7 +273,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 }
 
 /** Factory methods for collections of kind `* −> * -> *` */
-trait MapFactory[+CC[_, _]] {
+trait MapFactory[+CC[_, _]] { factory =>
 
   def empty[K, V]: CC[K, V]
 
@@ -280,6 +284,17 @@ trait MapFactory[+CC[_, _]] {
   def newBuilder[K, V](): Builder[(K, V), CC[K, V]]
 
   implicit def mapFactory[K, V]: Factory[(K, V), CC[K, V]] = MapFactory.toFactory(this)
+
+  /**
+    * @return a `BuildFrom` instance that ignores the factory of the source collection
+    * @tparam K Type of keys
+    * @tparam V Type of values
+    */
+  def toBuildFrom[K, V]: BuildFrom[Any, (K, V), CC[K, V]] =
+    new BuildFrom[Any, (K, V), CC[K, V]] {
+      def fromSpecificIterable(from: Any)(it: Iterable[(K, V)]) = factory.from(it)
+      def newBuilder(from: Any) = factory.newBuilder[K, V]()
+    }
 
 }
 
@@ -300,21 +315,16 @@ object MapFactory {
       def newBuilder(): Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]()
     }
 
-  implicit def toBuildFrom[K, V, CC[_, _]](factory: MapFactory[CC]): BuildFrom[Any, (K, V), CC[K, V]] =
-    new BuildFrom[Any, (K, V), CC[K, V]] {
-      def fromSpecificIterable(from: Any)(it: Iterable[(K, V)]) = factory.from(it)
-      def newBuilder(from: Any) = factory.newBuilder[K, V]()
-    }
 
-  class Delegate[C[_, _]](delegate: MapFactory[C]) extends MapFactory[C] {
-    def from[K, V](it: IterableOnce[(K, V)]): C[K, V] = delegate.from(it)
-    def empty[K, V]: C[K, V] = delegate.empty
-    def newBuilder[K, V](): Builder[(K, V), C[K, V]] = delegate.newBuilder()
+  class Delegate[CC[_, _]](delegate: MapFactory[CC]) extends MapFactory[CC] {
+    def from[K, V](it: IterableOnce[(K, V)]): CC[K, V] = delegate.from(it)
+    def empty[K, V]: CC[K, V] = delegate.empty
+    def newBuilder[K, V](): Builder[(K, V), CC[K, V]] = delegate.newBuilder()
   }
 }
 
 /** Base trait for companion objects of collections that require an implicit evidence */
-trait SortedIterableFactory[+CC[_]] {
+trait SortedIterableFactory[+CC[_]] { factory =>
 
   def from[E : Ordering](it: IterableOnce[E]): CC[E]
 
@@ -327,6 +337,16 @@ trait SortedIterableFactory[+CC[_]] {
   def newBuilder[A : Ordering](): Builder[A, CC[A]]
 
   implicit def sortedIterableFactory[A : Ordering]: Factory[A, CC[A]] = SortedIterableFactory.toFactory(this)
+
+  /**
+    * @return A `BuildFrom` instance that ignores the factory of the source collection.
+    * @tparam A Type of elements
+    */
+  def toBuildFrom[A: Ordering]: BuildFrom[Any, A, CC[A]] =
+    new BuildFrom[Any, A, CC[A]] {
+      def fromSpecificIterable(from: Any)(it: Iterable[A]): CC[A] = factory.from[A](it)
+      def newBuilder(from: Any): Builder[A, CC[A]] = factory.newBuilder[A]()
+    }
 
 }
 
@@ -346,12 +366,6 @@ object SortedIterableFactory {
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
 
-  implicit def toBuildFrom[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
-    new BuildFrom[Any, A, CC[A]] {
-      def fromSpecificIterable(from: Any)(it: Iterable[A]): CC[A] = factory.from[A](it)
-      def newBuilder(from: Any): Builder[A, CC[A]] = factory.newBuilder[A]()
-    }
-
   class Delegate[CC[_]](delegate: SortedIterableFactory[CC]) extends SortedIterableFactory[CC] {
     def empty[A : Ordering]: CC[A] = delegate.empty
     def from[E : Ordering](it: IterableOnce[E]): CC[E] = delegate.from(it)
@@ -360,7 +374,7 @@ object SortedIterableFactory {
 }
 
 /** Factory methods for collections of kind `* −> * -> *` which require an implicit evidence value for the key type */
-trait SortedMapFactory[+CC[_, _]] {
+trait SortedMapFactory[+CC[_, _]] { factory =>
 
   def empty[K : Ordering, V]: CC[K, V]
 
@@ -371,6 +385,17 @@ trait SortedMapFactory[+CC[_, _]] {
   def newBuilder[K : Ordering, V](): Builder[(K, V), CC[K, V]]
 
   implicit def sortedMapFactory[K : Ordering, V]: Factory[(K, V), CC[K, V]] = SortedMapFactory.toFactory(this)
+
+  /**
+    * @return a `BuildFrom` instance that ignores the factory of the source collection.
+    * @tparam K Type of keys
+    * @tparam V Type of values
+    */
+  def toBuildFrom[K : Ordering, V]: BuildFrom[Any, (K, V), CC[K, V]] =
+    new BuildFrom[Any, (K, V), CC[K, V]] {
+      def fromSpecificIterable(from: Any)(it: Iterable[(K, V)]) = factory.from(it)
+      def newBuilder(from: Any) = factory.newBuilder[K, V]()
+    }
 
 }
 
@@ -391,12 +416,6 @@ object SortedMapFactory {
     new Factory[(K, V), CC[K, V]] {
       def fromSpecific(it: IterableOnce[(K, V)]): CC[K, V] = factory.from[K, V](it)
       def newBuilder(): Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]()
-    }
-
-  implicit def toBuildFrom[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]): BuildFrom[Any, (K, V), CC[K, V]] =
-    new BuildFrom[Any, (K, V), CC[K, V]] {
-      def fromSpecificIterable(from: Any)(it: Iterable[(K, V)]) = factory.from(it)
-      def newBuilder(from: Any) = factory.newBuilder[K, V]()
     }
 
   class Delegate[CC[_, _]](delegate: SortedMapFactory[CC]) extends SortedMapFactory[CC] {

--- a/src/main/scala/strawman/collection/Factory.scala
+++ b/src/main/scala/strawman/collection/Factory.scala
@@ -10,60 +10,26 @@ import scala.{Any, Int, Integral, Nothing, Ordering}
 import scala.Predef.implicitly
 import scala.annotation.unchecked.uncheckedVariance
 
-
-/** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
-  * Implicit instances of `BuildFrom` are available for all collection types.
-  *
-  * @tparam From Type of source collection
-  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
-  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-  */
-trait BuildFrom[-From, -A, +C] extends Any {
-  def fromSpecificIterable(from: From)(it: Iterable[A]): C
-
-  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-    * Building collections with `fromSpecificIterable` is preferred because it can be lazy for lazy collections. */
-  def newBuilder(from: From): Builder[A, C]
-}
-
-object BuildFrom extends BuildFromLowPriority {
-  /** Build the source collection type from a MapOps */
-  implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _], K0, V0, K, V]: BuildFrom[CC[K0, V0], (K, V), CC[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
-    //TODO: Reuse a prototype instance
-    def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = from.mapFactory.newBuilder[K, V]()
-    def fromSpecificIterable(from: CC[K0, V0])(it: Iterable[(K, V)]): CC[K, V] = from.mapFactory.from(it)
-  }
-
-  /** Build the source collection type from a SortedMapOps */
-  implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0], (K, V), CC[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
-    def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = from.sortedMapFactory.newBuilder[K, V]()
-    def fromSpecificIterable(from: CC[K0, V0])(it: Iterable[(K, V)]): CC[K, V] = from.sortedMapFactory.from(it)
-  }
-
-  /** Build the source collection type from an Iterable with SortedOps */
-  implicit def buildFromSortedSetOps[CC[X] <: SortedSet[X] with SortedSetOps[X, CC, _], A0, A : Ordering]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
-    def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.sortedIterableFactory.newBuilder[A]()
-    def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.sortedIterableFactory.from(it)
-  }
-}
-
-trait BuildFromLowPriority {
-  /** Build the source collection type from an IterableOps */
-  implicit def buildFromIterableOps[CC[X] <: Iterable[X] with IterableOps[X, CC, _], A0, A]: BuildFrom[CC[A0], A, CC[A]] =
-    new BuildFrom[CC[A0], A, CC[A]] {
-      //TODO: Reuse a prototype instance
-      def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.iterableFactory.newBuilder[A]()
-      def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.iterableFactory.from(it)
-    }
-}
-
 /**
-  * Builds a collection of type `C` from elements of type `A`
+  * A factory that builds a collection of type `C` with elements of type `A`.
+  *
+  * This is a general form of any factory ([[IterableFactory]],
+  * [[SortedIterableFactory]], [[MapFactory]] and [[SortedMapFactory]]) whose
+  * element type is fixed.
+  *
   * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
   */
-trait CanBuild[-A, +C] extends Any {
+trait Factory[-A, +C] extends Any {
+
+  /**
+    * @return A collection of type `C` containing the same elements
+    *         as the source collection `it`.
+    * @param it Source collection
+    */
   def fromSpecific(it: IterableOnce[A]): C
+
+  /** A strict builder that eventually produces a `C` */
   def newBuilder(): Builder[A, C]
 }
 
@@ -146,14 +112,22 @@ trait IterableFactory[+CC[_]] extends IterableFactoryLike[CC] {
   // just `IterableOnce`
   type Source[A] = IterableOnce[A]
 
-  implicit def canBuildIterable[A]: CanBuild[A, CC[A]] = IterableFactory.toCanBuild(this)
+  implicit def iterableFactory[A]: Factory[A, CC[A]] = IterableFactory.toFactory(this)
 
 }
 
 object IterableFactory {
 
-  implicit def toCanBuild[A, CC[_]](factory: IterableFactory[CC]): CanBuild[A, CC[A]] =
-    new CanBuild[A, CC[A]] {
+  /**
+    * Fixes the element type of `factory` to `A`
+    * @param factory The factory to fix the element type
+    * @tparam A Type of elements
+    * @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
+    * @return A [[Factory]] that uses the given `factory` to build a collection of elements
+    *         of type `A`
+    */
+  implicit def toFactory[A, CC[_]](factory: IterableFactory[CC]): Factory[A, CC[A]] =
+    new Factory[A, CC[A]] {
       def fromSpecific(it: IterableOnce[A]): CC[A] = factory.from[A](it)
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
@@ -287,7 +261,7 @@ object SeqFactory {
   }
 }
 
-trait SpecificIterableFactory[-A, +C] extends CanBuild[A, C] {
+trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   def empty: C
   def apply(xs: A*): C = fromSpecific(View.Elems(xs: _*))
   def fill(n: Int)(elem: => A): C = fromSpecific(View.Fill(n)(elem))
@@ -296,16 +270,32 @@ trait SpecificIterableFactory[-A, +C] extends CanBuild[A, C] {
 
 /** Factory methods for collections of kind `* −> * -> *` */
 trait MapFactory[+CC[_, _]] {
+
   def empty[K, V]: CC[K, V]
+
   def from[K, V](it: IterableOnce[(K, V)]): CC[K, V]
+
   def apply[K, V](elems: (K, V)*): CC[K, V] = from(elems.toStrawman)
+
   def newBuilder[K, V](): Builder[(K, V), CC[K, V]]
-  implicit def canBuildMap[K, V]: CanBuild[(K, V), CC[K, V]] = MapFactory.toCanBuild(this)
+
+  implicit def mapFactory[K, V]: Factory[(K, V), CC[K, V]] = MapFactory.toFactory(this)
+
 }
 
 object MapFactory {
-  implicit def toCanBuild[K, V, CC[_, _]](factory: MapFactory[CC]): CanBuild[(K, V), CC[K, V]] =
-    new CanBuild[(K, V), CC[K, V]] {
+
+  /**
+    * Fixes the key and value types of `factory` to `K` and `V`, respectively
+    * @param factory The factory to fix the key and value types
+    * @tparam K Type of keys
+    * @tparam V Type of values
+    * @tparam CC Collection type constructor of the factory (e.g. `Map`, `HashMap`, etc.)
+    * @return A [[Factory]] that uses the given `factory` to build a map with keys of type `K`
+    *         and values of type `V`
+    */
+  implicit def toFactory[K, V, CC[_, _]](factory: MapFactory[CC]): Factory[(K, V), CC[K, V]] =
+    new Factory[(K, V), CC[K, V]] {
       def fromSpecific(it: IterableOnce[(K, V)]): CC[K, V] = factory.from[K, V](it)
       def newBuilder(): Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]()
     }
@@ -325,17 +315,33 @@ object MapFactory {
 
 /** Base trait for companion objects of collections that require an implicit evidence */
 trait SortedIterableFactory[+CC[_]] {
+
   def from[E : Ordering](it: IterableOnce[E]): CC[E]
+
   def empty[A : Ordering]: CC[A]
+
   def apply[A : Ordering](xs: A*): CC[A] = from(View.Elems(xs: _*))
+
   def fill[A : Ordering](n: Int)(elem: => A): CC[A] = from(View.Fill(n)(elem))
+
   def newBuilder[A : Ordering](): Builder[A, CC[A]]
-  implicit def canBuildSortedIterable[A : Ordering]: CanBuild[A, CC[A]] = SortedIterableFactory.toCanBuild(this)
+
+  implicit def sortedIterableFactory[A : Ordering]: Factory[A, CC[A]] = SortedIterableFactory.toFactory(this)
+
 }
 
 object SortedIterableFactory {
-  implicit def toCanBuild[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): CanBuild[A, CC[A]] =
-    new CanBuild[A, CC[A]] {
+
+  /**
+    * Fixes the element type of `factory` to `A`
+    * @param factory The factory to fix the element type
+    * @tparam A Type of elements
+    * @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)
+    * @return A [[Factory]] that uses the given `factory` to build a collection of elements
+    *         of type `A`
+    */
+  implicit def toFactory[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): Factory[A, CC[A]] =
+    new Factory[A, CC[A]] {
       def fromSpecific(it: IterableOnce[A]): CC[A] = factory.from[A](it)
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
@@ -355,16 +361,34 @@ object SortedIterableFactory {
 
 /** Factory methods for collections of kind `* −> * -> *` which require an implicit evidence value for the key type */
 trait SortedMapFactory[+CC[_, _]] {
+
   def empty[K : Ordering, V]: CC[K, V]
+
   def from[K : Ordering, V](it: IterableOnce[(K, V)]): CC[K, V]
+
   def apply[K : Ordering, V](elems: (K, V)*): CC[K, V] = from(elems.toStrawman)
+
   def newBuilder[K : Ordering, V](): Builder[(K, V), CC[K, V]]
-  implicit def canBuildSortedMap[K : Ordering, V]: CanBuild[(K, V), CC[K, V]] = SortedMapFactory.toCanBuild(this)
+
+  implicit def sortedMapFactory[K : Ordering, V]: Factory[(K, V), CC[K, V]] = SortedMapFactory.toFactory(this)
+
 }
 
 object SortedMapFactory {
-  implicit def toCanBuild[K : Ordering, V, CC[X, Y]](factory: SortedMapFactory[CC]): CanBuild[(K, V), CC[K, V]] =
-    new CanBuild[(K, V), CC[K, V]] {
+
+  /**
+    * Implicit conversion that fixes the key and value types of `factory` to `K` and `V`,
+    * respectively.
+    *
+    * @param factory The factory to fix the key and value types
+    * @tparam K Type of keys
+    * @tparam V Type of values
+    * @tparam CC Collection type constructor of the factory (e.g. `TreeMap`)
+    * @return A [[Factory]] that uses the given `factory` to build a map with keys of
+    *         type `K` and values of type `V`
+    */
+  implicit def toFactory[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]): Factory[(K, V), CC[K, V]] =
+    new Factory[(K, V), CC[K, V]] {
       def fromSpecific(it: IterableOnce[(K, V)]): CC[K, V] = factory.from[K, V](it)
       def newBuilder(): Builder[(K, V), CC[K, V]] = factory.newBuilder[K, V]()
     }

--- a/src/main/scala/strawman/collection/Iterable.scala
+++ b/src/main/scala/strawman/collection/Iterable.scala
@@ -257,14 +257,14 @@ trait IterableOps[+A, +CC[X], +C] extends Any {
   /** A view representing the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => toIterable.iterator())
 
-  /** Given a collection factory `fi`, convert this collection to the appropriate
+  /** Given a collection factory `factory`, convert this collection to the appropriate
     * representation for the current element type `A`. Example uses:
     *
     *      xs.to(List)
     *      xs.to(ArrayBuffer)
     *      xs.to(BitSet) // for xs: Iterable[Int]
     */
-  def to[C1](f: CanBuild[A, C1]): C1 = f.fromSpecific(toIterable)
+  def to[C1](factory: Factory[A, C1]): C1 = factory.fromSpecific(toIterable)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =

--- a/src/main/scala/strawman/collection/Iterator.scala
+++ b/src/main/scala/strawman/collection/Iterator.scala
@@ -752,10 +752,10 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
   /** Converts this Iterator into another collection.
     *  @return a new collection containing all elements of this Iterator.
     *  @tparam C The collection type to build.
-    *  @param canBuild Collection factory to use. The factory may or may
+    *  @param factory Collection factory to use. The factory may or may
     *                  not eagerly consume this iterator.
     */
-  def to[C](canBuild: CanBuild[A, C]): C = canBuild.fromSpecific(self)
+  def to[C](factory: Factory[A, C]): C = factory.fromSpecific(self)
 
 }
 

--- a/src/test/scala/strawman/collection/test/GenericTest.scala
+++ b/src/test/scala/strawman/collection/test/GenericTest.scala
@@ -30,9 +30,9 @@ object Parse {
     }
   }
 
-  def parseCollection[A, C](implicit parseA: Parse[A], cb: CanBuild[A, C]): Parse[C] = { (s: String) =>
+  def parseCollection[A, C](implicit parseA: Parse[A], factory: Factory[A, C]): Parse[C] = { (s: String) =>
     val parts = s.split("\\|")
-    parts.foldLeft[Option[Builder[A, C]]](Some(cb.newBuilder())) { (maybeBuilder, s) =>
+    parts.foldLeft[Option[Builder[A, C]]](Some(factory.newBuilder())) { (maybeBuilder, s) =>
       (maybeBuilder, parseA.parse(s)) match {
         case (Some(builder), Some(a)) =>
           Some(builder += a)

--- a/src/test/scala/strawman/collection/test/TraverseTest.scala
+++ b/src/test/scala/strawman/collection/test/TraverseTest.scala
@@ -74,7 +74,7 @@ class TraverseTest {
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:
     val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
-    val o4 = optionSequence2(xs4)(immutable.TreeMap) // same syntax as in `.to`
+    val o4 = optionSequence2(xs4)(immutable.TreeMap.toBuildFrom)
     val o4t: Option[immutable.TreeMap[Int, String]] = o4
   }
 
@@ -90,7 +90,7 @@ class TraverseTest {
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:
     val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
-    val o4 = optionSequence3(xs4)(immutable.TreeMap) // same syntax as in `.to`
+    val o4 = optionSequence3(xs4)(immutable.TreeMap.toBuildFrom)
     val o4t: Option[immutable.TreeMap[Int, String]] = o4
   }
 

--- a/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
@@ -1,0 +1,29 @@
+package strawman.collection
+
+import strawman.collection.mutable.ArrayBuffer
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class FactoriesTest {
+
+  val seq: Seq[Int] = ArrayBuffer(1, 2, 3)
+
+  @Test def buildFromUsesSourceCollectionFactory(): Unit = {
+
+    def cloneCollection[A, C](xs: Iterable[A])(implicit bf: BuildFrom[xs.type, A, C]): C =
+      bf.fromSpecificIterable(xs)(xs)
+
+    Assert.assertEquals("ArrayBuffer", cloneCollection(seq).className)
+  }
+
+  @Test def canBuildIgnoresSourceCollectionFactory(): Unit = {
+
+    def cloneElements[A, C](xs: Iterable[A])(cb: CanBuild[A, C]): C =
+      cb.fromSpecific(xs)
+
+    Assert.assertEquals("List", cloneElements(seq)(Seq).className)
+  }
+
+}

--- a/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
@@ -18,9 +18,9 @@ class FactoriesTest {
     Assert.assertEquals("ArrayBuffer", cloneCollection(seq).className)
   }
 
-  @Test def canBuildIgnoresSourceCollectionFactory(): Unit = {
+  @Test def factoryIgnoresSourceCollectionFactory(): Unit = {
 
-    def cloneElements[A, C](xs: Iterable[A])(cb: CanBuild[A, C]): C =
+    def cloneElements[A, C](xs: Iterable[A])(cb: Factory[A, C]): C =
       cb.fromSpecific(xs)
 
     Assert.assertEquals("List", cloneElements(seq)(Seq).className)


### PR DESCRIPTION
Fixes #198

These changes re-introduce the `BuildFrom` behaviour as it was before #168: the dynamic factory of the source collection is reused to build the target collection.

The PR contains several commits. The [first one](https://github.com/scala/collection-strawman/pull/249/commits/b7195c5704c75f3c5ed26627b3d608e9adbb23b5) contains the essence of the fix and the second one only performs renamings (`CanBuild` is renamed to `Factory`, and `BuildFrom` is moved to a separate file). I suggest to review the first commit before looking at the rest.

Last, I also pushed an alternative implementation [here](https://github.com/julienrf/collection-strawman/commit/d2cfa497fbab6612eceb7b4a32ab089f58fd8227) that makes the conversion between factories and `BuildFrom` instances explicit. I explained the rationale for this change in the commit message. Let me know what you think. [Edit: actually I merged the commit mentioned above in the current branch]