### PR TITLE
Optimize List#updated

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -8,7 +8,7 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
 import mutable.{Builder, ListBuffer, ReusableBuilder}
 
-import scala.{Any, AnyRef, Boolean, Function1, Int, NoSuchElementException, Nothing, PartialFunction, SerialVersionUID, Serializable, Unit, UnsupportedOperationException, `inline`, transient}
+import scala.{Any, AnyRef, Boolean, Function1, IndexOutOfBoundsException, Int, NoSuchElementException, Nothing, PartialFunction, SerialVersionUID, Serializable, Unit, UnsupportedOperationException, `inline`, transient}
 
 
 /** A class for immutable linked lists representing ordered collections
@@ -204,6 +204,22 @@ sealed trait List[+A]
       these = these.tail
     }
     (b.toList, these)
+  }
+
+  override def updated[B >: A](index: Int, elem: B): List[B] = {
+    var i = 0
+    var current = this
+    var prefix = ListBuffer.empty[B]
+    while (i < index && current.nonEmpty) {
+      i += 1
+      prefix += current.head
+      current = current.tail
+    }
+    if (i == index && current.nonEmpty) {
+      prefix.prependToList(elem :: current.tail)
+    } else {
+      throw new IndexOutOfBoundsException(index.toString)
+    }
   }
 
   final override def map[B](f: A => B): List[B] = {

--- a/test/junit/src/test/scala/strawman/collection/immutable/ListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ListTest.scala
@@ -48,4 +48,23 @@ class ListTest {
     // real assertion
     Assert.assertTrue(emptyIterators.exists(_._2.get.isEmpty))
   }
+
+  @Test
+  def updated(): Unit = {
+    val xs = 1 :: 2 :: Nil
+    Assert.assertEquals(0 :: 2 :: Nil, xs.updated(index = 0, elem = 0))
+    Assert.assertEquals(1 :: 0 :: Nil, xs.updated(index = 1, elem = 0))
+    try {
+      xs.updated(index = -1, 0)
+      Assert.fail("No exception thrown")
+    } catch {
+      case e: IndexOutOfBoundsException => ()
+    }
+    try {
+      xs.updated(index = 2, 0)
+      Assert.fail("No exception thrown")
+    } catch {
+      case e: IndexOutOfBoundsException => ()
+    }
+  }
 }


### PR DESCRIPTION
Don’t recompute the shared tail.

Fixes #256 

Benchmark on call to `updated` with random indices, for various sizes of lists (lower is better):

![transform_updaterandom](https://user-images.githubusercontent.com/332812/31078175-66cb652e-a781-11e7-9b25-192779a18208.png)

The `ListUpdatedBenchmark` line (in blue) contains the specialized implementation.