### PR TITLE
Add NonEmpty collection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ The following operations are provided:
 - `Seq#intersperse`
 - `Map#zipByKeyWith`
 
+The following collections are provided:
+
+- `NonEmpty`
+
 ## Roadmap
 
 1. September 2017: release targeting Scala 2.13 and Dotty.

--- a/collections-contrib/src/main/scala/strawman/collection/NonEmpty.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/NonEmpty.scala
@@ -1,0 +1,90 @@
+package strawman
+package collection
+
+import collection.immutable.List
+
+/**
+  * A wrapper around a collection that is guaranteed to have at least one element.
+  *
+  * A `NonEmpty` instance is implicitly enriched with the same operations as the
+  * wrapped collection and also has its own operations that preserve non-emptiness.
+  *
+  * @param coll Wrapped collection
+  * @tparam A Type of elements (e.g. `Int`, `String`)
+  * @tparam C Type of collection (e.g. `List[Int]`, `Map[Int, Boolean]`)
+  */
+final class NonEmpty[+A, C <: Iterable[A]] private (val coll: C)
+  extends AnyVal {
+
+  def map[B, C2 <: Iterable[B]](f: A => B)(implicit bf: BuildFrom[C, B, C2]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(coll.toIterable.map(f)))
+
+  def flatMap[B, C2 <: Iterable[B]](f: A => IterableOnce[B])(implicit bf: BuildFrom[C, B, C2]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(coll.toIterable.flatMap(f)))
+
+  def concat[B >: A, C2 <: Iterable[B]](that: Iterable[B])(implicit bf: BuildFrom[C, B, C2]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(coll.toIterable ++ that))
+
+  @`inline` def ++ [B >: A, C2 <: Iterable[B]](that: Iterable[B])(implicit bf: BuildFrom[C, B, C2]): NonEmpty[B, C2] =
+    concat(that)
+
+  def zip[A0 >: A, B, C2 <: Iterable[(A0, B)]](that: NonEmpty[B, _ <: Iterable[B]])(implicit bf: BuildFrom[C, (A0, B), C2]): NonEmpty[(A0, B), C2] =
+    new NonEmpty[(A0, B), C2](bf.fromSpecificIterable(coll)(coll.zip(that.coll)))
+
+  def zipWithIndex[A0 >: A, C2 <: Iterable[(A0, Int)]](implicit bf: BuildFrom[C, (A0, Int), C2]): NonEmpty[(A0, Int), C2] =
+    new NonEmpty[(A0, Int), C2](bf.fromSpecificIterable(coll)(coll.zipWithIndex))
+
+  def prepended[B >: A, C2 <: Seq[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< Seq[B]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(elem +: coll))
+
+  @`inline` def +: [B >: A, C2 <: Seq[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< Seq[B]): NonEmpty[B, C2] =
+    prepended(elem)
+
+  @`inline` def :: [B >: A, C2 <: List[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< List[B]): NonEmpty[B, C2] =
+    prepended(elem)
+
+  def appended[B >: A, C2 <: Iterable[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< Seq[B]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(coll :+ elem))
+
+  @`inline` def :+ [B >: A, C2 <: Iterable[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< Seq[B]): NonEmpty[B, C2] =
+    appended(elem)
+
+  def incl[B >: A, C2 <: immutable.Set[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< immutable.Set[B]): NonEmpty[B, C2] =
+    new NonEmpty[B, C2](bf.fromSpecificIterable(coll)(coll.incl(elem).toIterable))
+
+  @`inline` def + [B >: A, C2 <: immutable.Set[B]](elem: B)(implicit bf: BuildFrom[C, B, C2], ev: C <:< immutable.Set[B]): NonEmpty[B, C2] =
+    incl(elem)
+
+  def updated[K, V, C2 <: immutable.Map[K, V]](key: K, value: V)(implicit bf: BuildFrom[C, (K, V), C2], ev: C <:< immutable.Map[K, V]): NonEmpty[(K, V), C2] =
+    new NonEmpty[(K, V), C2](bf.fromSpecificIterable(coll)(coll.updated(key, value)))
+
+  @`inline` def + [K, V, C2 <: immutable.Map[K, V]](kv: (K, V))(implicit bf: BuildFrom[C, (K, V), C2], ev: C <:< immutable.Map[K, V]): NonEmpty[(K, V), C2] =
+    updated(kv._1, kv._2)
+
+}
+
+object NonEmpty {
+
+  import scala.language.implicitConversions
+
+  implicit def toCollection[A, C <: Iterable[A]](nonEmpty: NonEmpty[A, C]): C =
+    nonEmpty.coll
+
+  def fromIterable[A, C <: Iterable[A]](it: C): Option[NonEmpty[A, C]] =
+    if (it.isEmpty) None
+    else Some(new NonEmpty[A, C](it))
+
+  /**
+    * Create a `NonEmpty` instance that contains `elem` and all the elements of `coll` (which
+    * might be empty).
+    *
+    * If the wrapped collection is a sequence, then `elem` is prepended to `coll`.
+    *
+    * @param bf Builder for the wrapped collection
+    * @tparam A Type of the elements
+    * @tparam C Type of the wrapped collection
+    */
+  def apply[A, C <: Iterable[A]](elem: A, coll: C)(implicit bf: BuildFrom[C, A, C]): NonEmpty[A, C] =
+    new NonEmpty[A, C](bf.fromSpecificIterable(coll)(View.Prepend(elem, coll.toIterable)))
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/NonEmptyTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/NonEmptyTest.scala
@@ -8,7 +8,7 @@ class NonEmptyTest {
   @Test
   def nonEmptiness(): Unit = {
     val xs = List(1, 2, 3)
-    val nel = NonEmpty(0, xs)
+    val nel = NonEmpty.cons(0, xs)
 
     Assert.assertEquals(4, nel.size)
     // This partial method is now guaranteed to be total!
@@ -18,9 +18,6 @@ class NonEmptyTest {
     // we apply structure preserving operations or when we grow the collection
     val nel2 = nel.map(x => x.toString)
     val nel2T: NonEmpty[String, List[String]] = nel2
-
-    val nel3 = nel.flatMap(x => Set(x, x * x))
-    val nel3T: NonEmpty[Int, List[Int]] = nel3
 
     val nel4 = nel ++ Nil
     val nel4T: NonEmpty[Int, List[Int]] = nel4
@@ -42,14 +39,14 @@ class NonEmptyTest {
 
     // Also works with different “kinds” of collections
     val ys = immutable.SortedSet(1, 2, 3)
-    val nes = NonEmpty(4, ys)
+    val nes = NonEmpty.cons(4, ys)
     val nesT: NonEmpty[Int, immutable.SortedSet[Int]] = nes
 
     val nes2 = nes + 0
     val nes2T: NonEmpty[Int, immutable.SortedSet[Int]] = nes2
 
     val zs = immutable.SortedMap(1 -> "a", 2 -> "b")
-    val nem = NonEmpty(3 -> "c", zs)
+    val nem = NonEmpty.cons(3 -> "c", zs)
     val nemT: NonEmpty[(Int, String), immutable.SortedMap[Int, String]] = nem
 
     val nem2 = nem + (4 -> "d")
@@ -59,6 +56,29 @@ class NonEmptyTest {
     // available in `NonEmpty`
     Assert.assertEquals(Set(1, 3, 4), nes - 2)
     Assert.assertEquals(2, nel.indexOf(2))
+  }
+
+  @Test
+  def factory(): Unit = {
+    val nel = NonEmpty[List[Int]](1, 2, 3)
+    val nelT: NonEmpty[Int, List[Int]] = nel
+    Assert.assertEquals(1 :: 2 :: 3 :: Nil, nel.coll)
+
+    val nem = NonEmpty[Map[Int, Boolean]](1 -> true, 2 -> true, 3 -> false)
+    val nemT: NonEmpty[(Int, Boolean), Map[Int, Boolean]] = nem
+    Assert.assertEquals(Map(1 -> true, 2 -> true, 3 -> false), nem.coll)
+
+    val nebs = NonEmpty[immutable.BitSet](1, 2, 3)
+    val nebsT: NonEmpty[Int, immutable.BitSet] = nebs
+    Assert.assertEquals(immutable.BitSet(1, 2, 3), nebs.coll)
+
+    val ness = NonEmpty[immutable.TreeSet[Int]](1, 2, 3)
+    val nessT: NonEmpty[Int, immutable.TreeSet[Int]] = ness
+    Assert.assertEquals(immutable.TreeSet(1, 2, 3), ness.coll)
+
+    val nesm = NonEmpty[immutable.SortedMap[Int, Boolean]](1 -> true, 2 -> true, 3 -> false)
+    val nesmT: NonEmpty[(Int, Boolean), immutable.SortedMap[Int, Boolean]] = nesm
+    Assert.assertEquals(immutable.SortedMap(1 -> true, 2 -> true, 3 -> false), nesm.coll)
   }
 
 }

--- a/collections-contrib/src/test/scala/strawman/collection/NonEmptyTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/NonEmptyTest.scala
@@ -1,0 +1,64 @@
+package strawman.collection
+
+import strawman.collection.immutable.{List, Nil}
+import org.junit.{Assert, Test}
+
+class NonEmptyTest {
+
+  @Test
+  def nonEmptiness(): Unit = {
+    val xs = List(1, 2, 3)
+    val nel = NonEmpty(0, xs)
+
+    Assert.assertEquals(4, nel.size)
+    // This partial method is now guaranteed to be total!
+    Assert.assertEquals(0, nel.min)
+
+    // The following tests just check that non emptiness is preserved when
+    // we apply structure preserving operations or when we grow the collection
+    val nel2 = nel.map(x => x.toString)
+    val nel2T: NonEmpty[String, List[String]] = nel2
+
+    val nel3 = nel.flatMap(x => Set(x, x * x))
+    val nel3T: NonEmpty[Int, List[Int]] = nel3
+
+    val nel4 = nel ++ Nil
+    val nel4T: NonEmpty[Int, List[Int]] = nel4
+
+    val nel5 = -1 +: nel
+    val nel5T: NonEmpty[Int, List[Int]] = nel5
+
+    val nel6 = nel :+ 1
+    val nel6T: NonEmpty[Int, List[Int]] = nel6
+
+    val nel7 = nel.zipWithIndex
+    val nel7T: NonEmpty[(Int, Int), List[(Int, Int)]] = nel7
+
+    val nel8 = nel.zip(nel)
+    val nel8T: NonEmpty[(Int, Int), List[(Int, Int)]] = nel8
+
+    val nel9 = -1 :: nel
+    val nel9T: NonEmpty[Int, List[Int]] = nel9
+
+    // Also works with different “kinds” of collections
+    val ys = immutable.SortedSet(1, 2, 3)
+    val nes = NonEmpty(4, ys)
+    val nesT: NonEmpty[Int, immutable.SortedSet[Int]] = nes
+
+    val nes2 = nes + 0
+    val nes2T: NonEmpty[Int, immutable.SortedSet[Int]] = nes2
+
+    val zs = immutable.SortedMap(1 -> "a", 2 -> "b")
+    val nem = NonEmpty(3 -> "c", zs)
+    val nemT: NonEmpty[(Int, String), immutable.SortedMap[Int, String]] = nem
+
+    val nem2 = nem + (4 -> "d")
+    val nem2T: NonEmpty[(Int, String), immutable.SortedMap[Int, String]] = nem2
+
+    // Operations specific to the wrapped collection are
+    // available in `NonEmpty`
+    Assert.assertEquals(Set(1, 3, 4), nes - 2)
+    Assert.assertEquals(2, nel.indexOf(2))
+  }
+
+}

--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -270,6 +270,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   def apply(xs: A*): C = fromSpecific(View.Elems(xs: _*))
   def fill(n: Int)(elem: => A): C = fromSpecific(View.Fill(n)(elem))
   def newBuilder(): Builder[A, C]
+  implicit def specificIterableFactory: Factory[A, C] = this
 }
 
 /** Factory methods for collections of kind `* −> * -> *` */


### PR DESCRIPTION
Fixes #98.

The approach taken here is similar to @tarao’s approach here: https://github.com/tarao/nonempty-scala

I added a `NonEmpty` wrapper around a collection and make sure that the only way to build an instance of such a wrapper is to provide at least one element.

I provide an implicit conversion from `NonEmpty` to the wrapped instance, making it possible to use all the operations of the specific collection directly on the `NonEmpty` instance, as if it was effectively an instance of that specific collection.

Operations that preserve non-emptiness (e.g. `map`, `++`) are defined directly on `NonEmpty` to return another `NonEmpty` instance.

Current limitations:
 - doesn’t work with `String` or `Array`,
 - doesn’t work with `View` (but that would be easily doable at the cost of slightly more cryptic method signatures).