### PR TITLE
Move equality implementations into collection classes

### DIFF
--- a/collections/src/main/scala/strawman/collection/Set.scala
+++ b/collections/src/main/scala/strawman/collection/Set.scala
@@ -8,15 +8,33 @@ import java.lang.String
 
 /** Base trait for set collections.
   */
-trait Set[A] extends Iterable[A] with SetOps[A, Set, Set[A]] {
+trait Set[A]
+  extends Iterable[A]
+    with SetOps[A, Set, Set[A]]
+    with Equals {
+
   final protected[this] def coll: this.type = this
+
+  def canEqual(that: Any) = true
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case set: Set[A] =>
+        (this eq set) ||
+          (set canEqual this) &&
+            (toIterable.size == set.size) &&
+            (this subsetOf set)
+      case _ => false
+    }
+
+  override def hashCode(): Int = Set.setHash(toIterable)
+
 }
 
 /** Base trait for set operations */
 trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
-     with (A => Boolean)
-     with Equals {
+     with (A => Boolean) {
 
   def contains(elem: A): Boolean
 
@@ -103,20 +121,6 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
       result
     }
   }
-
-  def canEqual(that: Any) = true
-
-  override def equals(that: Any): Boolean =
-    that match {
-      case set: Set[A] =>
-        (this eq set) ||
-          (set canEqual this) &&
-            (toIterable.size == set.size) &&
-            (this subsetOf set)
-      case _ => false
-    }
-
-  override def hashCode(): Int = Set.setHash(toIterable)
 
   override def toString(): String = super[IterableOps].toString() // Because `Function1` overrides `toString` too
 

--- a/collections/src/test/scala/strawman/collection/test/Test.scala
+++ b/collections/src/test/scala/strawman/collection/test/Test.scala
@@ -466,22 +466,6 @@ class StrawmanTest {
     assert(lazeCountS==lazeCountL)
   }
 
-  def equality(): Unit = {
-    val list: Iterable[Int] = List(1, 2, 3)
-    val lazyList: Iterable[Int] = LazyList(1, 2, 3)
-    val buffer = ArrayBuffer(1, 2, 3)
-    val range = Range.inclusive(1, 3)
-    assert(list == lazyList)
-    assert(list.## == lazyList.##)
-    assert(list == (buffer: Iterable[Int]))
-    assert(list.## == buffer.##)
-    assert(list == (range: Iterable[Int]))
-    assert(list.## == range.##)
-    buffer += 4
-    assert(list != (buffer: Iterable[Int]))
-    assert(list.## != buffer.##)
-  }
-
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
     iterableOps(xs)
     val xs1 = xs.map((x: Int) => x.toString) // TODO Remove type annotation when https://github.com/scala/scala/pull/5708 is published
@@ -590,7 +574,6 @@ class StrawmanTest {
     immutableSeqOps(intsArr)
     immutableArrayOps(intsArr)
     lazyListOps(intsLzy)
-    equality()
     distinct()
     linearSeqSize()
   }

--- a/test/junit/src/test/scala/strawman/collection/EqualityTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/EqualityTest.scala
@@ -1,0 +1,42 @@
+package strawman.collection
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.immutable.{LazyList, List, Range}
+import strawman.collection.mutable.ArrayBuffer
+
+@RunWith(classOf[JUnit4])
+class EqualityTest {
+
+  @Test
+  def equality(): Unit = {
+    val list: Iterable[Int] = List(1, 2, 3)
+    val lazyList: Iterable[Int] = LazyList(1, 2, 3)
+    val buffer = ArrayBuffer(1, 2, 3)
+    val range = Range.inclusive(1, 3)
+    Assert.assertTrue(list == lazyList)
+    Assert.assertTrue(list.## == lazyList.##)
+    Assert.assertTrue(list == (buffer: Iterable[Int]))
+    Assert.assertTrue(list.## == buffer.##)
+    Assert.assertTrue(list == (range: Iterable[Int]))
+    Assert.assertTrue(list.## == range.##)
+    buffer += 4
+    Assert.assertTrue(list != (buffer: Iterable[Int]))
+    Assert.assertTrue(list.## != buffer.##)
+  }
+
+  @Test
+  def viewsComparisonDoesntConsumeElements(): Unit = {
+    val xs = List(1, 2, 3)
+    var n = 0
+    val xsView = xs.view.map { x => n += 1; x }
+    Assert.assertTrue(xs != xsView)
+    Assert.assertTrue(xsView != xs)
+    Assert.assertTrue(xs.## != xsView.##)
+    Assert.assertEquals(0, n) // The view hasn’t been evaluated
+    Assert.assertTrue(xs sameElements xsView) // sameElements does evaluate the view elements
+    Assert.assertEquals(3, n)
+  }
+
+}


### PR DESCRIPTION
They were previously in the collection Ops class but it doesn’t
make sense to have them there because the Ops classes can be
inherited by Views, which must always use reference
equality and hashcode.