### PR TITLE
Add mutable.MultiMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import org.scalajs.sbtplugin.cross.CrossProject
 
 // Convenient setting that allows writing `set scalaVersion := dotty.value` in sbt shell to switch from Scala to Dotty
 val dotty = settingKey[String]("dotty version")
-dotty in ThisBuild := "0.3.0-RC2"
+dotty in ThisBuild := "0.4.0-bin-20171005-4aa13b0-NIGHTLY"
 
 val commonSettings = Seq(
   organization := "ch.epfl.scala",

--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -14,7 +14,7 @@ trait Map[K, +V] extends Iterable[(K, V)] with MapOps[K, V, Map, Map[K, V]] {
 }
 
 /** Base Map implementation type */
-trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V]
     with Equals {

--- a/collections/src/main/scala/strawman/collection/mutable/MultiMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/MultiMap.scala
@@ -1,0 +1,124 @@
+package strawman
+package collection.mutable
+
+import scala.{Any, Boolean, None, Option, Some, Unit}
+import strawman.collection.{BuildFrom, Factory, IterableOnce, MapFactory, View}
+
+/** A class for mutable maps with multiple values assigned to a key.
+ *
+ *  @example {{{
+ *  import collection.mutable.MultiMap
+ *
+ *  // to create a `MultiMap` the easiest way is to use the default `MultiMap` factory
+ *  val mm = MultiMap.empty[Int, String]
+ *
+ *  // to add key-value pairs to a multimap you can use `+=`
+ *  mm += 1 -> "a"
+ *  mm += 2 -> "b"
+ *  mm += 1 -> "c"
+ *
+ *  // mm now contains `Map(2 -> Set(b), 1 -> Set(c, a))`
+ *
+ *  // to check if the multimap contains a value there is method
+ *  // `entryExists`, which allows to traverse the including set
+ *  mm.entryExists(1, _ == "a") == true
+ *  mm.entryExists(1, _ == "b") == false
+ *  mm.entryExists(2, _ == "b") == true
+ *
+ *  // to remove a previous added value you can use `-=`
+ *  mm -= 1 -> "a"
+ *  mm.entryExists(1, _ == "a") == false
+ *  }}}
+ *
+ *  @define coll multimap
+ *  @define Coll `MultiMap`
+ */
+class MultiMap[K, V] private (
+  underlying: Map[K, Set[V]],
+  bf: BuildFrom[Any, (K, Set[V]), Map[K, Set[V]]],
+  setFactory: Factory[V, Set[V]]
+) extends collection.Map[K, Set[V]]
+    with collection.IterableOps[(K, Set[V]), collection.Iterable, MultiMap[K, V]]
+    with Growable[(K, V)]
+    with Shrinkable[(K, V)] {
+
+  // Note: primary constructors can not use path dependent types, that’s why I’m defining this secondary constructor
+  def this(underlying: Map[K, Set[V]], setFactory: Factory[V, Set[V]])(implicit bf: BuildFrom[underlying.type, (K, Set[V]), Map[K, Set[V]]]) =
+    this(underlying, bf.asInstanceOf[BuildFrom[Any, (K, Set[V]), Map[K, Set[V]]]], setFactory)
+
+  def iterator(): collection.Iterator[(K, Set[V])] = underlying.iterator()
+
+  def toMutableMap: Map[K, Set[V]] = underlying
+
+  def mapFactory = underlying.mapFactory
+  def iterableFactory = collection.Iterable
+  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]) = mapFactory.from(it)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, Set[V])]) =
+    new MultiMap(bf.fromSpecificIterable(underlying)(coll), bf, setFactory)
+  protected[this] def newSpecificBuilder() =
+    bf.newBuilder(underlying).mapResult(fromSpecificIterable)
+
+  def empty = new MultiMap(underlying.empty, bf, setFactory)
+
+  def get(key: K): Option[Set[V]] = underlying.get(key)
+
+  /** Adds the specified entry.  If the key
+    * already has a binding to equal to `value`, nothing is changed;
+    * otherwise a new binding is added for that `key`.
+    *
+    *  @param elem   The entry to add
+    *  @return       A reference to this multimap.
+    */
+  def add(elem: (K, V)): this.type = {
+    val (key, value) = elem
+    underlying.get(key) match {
+      case None     => underlying.put(key, setFactory.fromSpecific(View.Single(value)))
+      case Some(vs) => vs += value
+    }
+    this
+  }
+
+  def clear(): Unit = underlying.clear()
+
+  /** Removes the binding if it exists, otherwise this
+    *  operation doesn't have any effect.
+    *
+    *  If this was the last value assigned to the specified key, the
+    *  set assigned to that key will be removed as well.
+    *
+    *  @param elem    The entry to remove.
+    *  @return        A reference to this multimap.
+    */
+  def subtract(elem: (K, V)): this.type = {
+    val (key, value) = elem
+    underlying.get(key).foreach { vs =>
+      vs -= value
+      if (vs.isEmpty) underlying.remove(key)
+    }
+    this
+  }
+
+  /** Checks if there exists a binding to `key` such that it satisfies the predicate `p`.
+    *
+    *  @param key   The key for which the predicate is checked.
+    *  @param p     The predicate which a value assigned to the key must satisfy.
+    *  @return      A boolean if such a binding exists
+    */
+  def entryExists(key: K, p: V => Boolean): Boolean =
+    underlying.get(key).exists(_.exists(p))
+
+  // TODO Define equality
+
+}
+
+class MultiMapFactory(mapFactory: MapFactory[Map]) extends MapFactory[MultiMap] {
+
+  def empty[K, V] = new MultiMap[K, V](mapFactory.empty, Set)
+
+  def from[K, V](it: IterableOnce[(K, V)]) = Growable.from(empty[K, V], it)
+
+  def newBuilder[K, V](): Builder[(K, V), MultiMap[K, V]] = new GrowableBuilder(empty[K, V])
+
+}
+
+object MultiMap extends MultiMapFactory(mapFactory = Map)

--- a/test/junit/src/test/scala/strawman/collection/mutable/MultiMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/MultiMapTest.scala
@@ -1,0 +1,56 @@
+package strawman
+package collection.mutable
+
+import strawman.collection.Iterator
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MultiMapTest {
+
+  @Test
+  def multiMap(): Unit = {
+    val mm = MultiMap.empty[Int, String]
+
+    mm += 1 -> "a"
+    mm += 2 -> "b"
+    mm += 1 -> "c"
+
+    val m = Map(2 -> Set("b"), 1 -> Set("c", "a"))
+    Assert.assertEquals(m, mm)
+    Assert.assertEquals(mm, m)
+    Assert.assertEquals(m.##, mm.##)
+
+    Assert.assertTrue(mm.entryExists(1, _ == "a"))
+    Assert.assertFalse(mm.entryExists(1, _ == "b"))
+    Assert.assertTrue(mm.entryExists(2, _ == "b"))
+
+    mm -= 1 -> "a"
+    Assert.assertFalse(mm.entryExists(1, _ == "a"))
+    Assert.assertTrue(mm.entryExists(1, _ == "c"))
+
+    mm -= 2 -> "b"
+    Assert.assertFalse(mm.contains(2))
+
+  }
+
+  @Test
+  def sortedMultiMap(): Unit = {
+    val mm = new MultiMap[Int, String](TreeMap.empty, TreeSet)
+
+    mm += 1 -> "a"
+    mm += 2 -> "b"
+    mm += 1 -> "c"
+    mm += 3 -> "d"
+    mm += 1 -> "e"
+
+    Assert.assertTrue(mm.keysIterator().sameElements(Iterator(1, 2, 3)))
+    Assert.assertTrue(mm.apply(1).iterator().sameElements(Iterator("a", "c", "e")))
+
+    // “Sortedness” is preserved by transformation operations
+    Assert.assertEquals(mm.toMutableMap.className, mm.takeRight(3).toMutableMap.className)
+  }
+
+}


### PR DESCRIPTION
This is an experiment to add a `mutable.MultiMap` collection type. That collection type does already exist in the current collections. I tried to implement it differently.

In the current collections, `MultiMap[K, V]` is simply a trait that you can mix in any `Map[K, Set[V]]` implementation. This trait adds new methods to the underlying `Map`, notably `addBinding(key: K, value: V)` and `removeBinding(key: K, value: V)`. When you use such a `MultiMap` you have to take care of using these new methods to add or remove entries because `+=` and `-=` methods inherited from `Map` still have the `Map` semantics (which is good, BTW!): adding an entry replaces the previous entry, if any, whereas `addBinding` adds the new value to the pre-existing `Set[V]`, if any.

I wanted to find a design where users could still use the usual `+=` and `-=` operators to add or remove elements to a `MultiMap`. As a consequence, I can not inherit from `mutable.Map[K, Set[V]]` because the signature of `+=` would be `def += (key: K, value: Set[V])` instead of the desired `def += (key: K, value: V)`. Therefore, this `MultiMap` implementation only inherit from the generic `collection.Map[K, Set[V]]`.

As you can see in the tests, the API is probably more straightforward.

However, one limitation of this PR is that transformation operations such as `map` or `++` will return a `collection.Map` instead of a `MultiMap`. We could add overloads for those methods:

~~~ scala
def map[V2](f: ((K, V)) => (K, V2)): MultiMap[K, V2]
// etc.
~~~

But I’m not even sure the type system will be able to disambiguate calls with the `map` method inherited from `Map`:

~~~ scala
def map[V2](f: ((K, Set[V])) => (K, V2)): Map[K, V2]
~~~

I think this limitation already exists in the current collections (since I think there is no `CanBuildFrom` instance that builds a `MultiMap` when the type of values is a `Set[V]`).