### PR TITLE
Add mutable.MultiSet collection and updateWith operation on mutable Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ The following operations are provided:
 - `Map`
     - `zipByKey` / `join` / `zipByKeyWith`
     - `mergeByKey` / `fullOuterJoin` / `mergeByKeyWith` / `leftOuterJoin` / `rightOuterJoin`
+- `mutable.Map`
+    - `updateWith`
+
+The following collections are provided:
+
+- `mutable.MultiSet`
 
 ## Roadmap
 

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/MutableMapDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/MutableMapDecorator.scala
@@ -1,0 +1,43 @@
+package strawman
+package collection
+package decorators
+
+class MutableMapDecorator[K, V](`this`: mutable.Map[K, V]) {
+
+  /**
+    * Updates an existing binding or create a new one according to the
+    * result of the application of `f`.
+    *
+    * This operation retrieves the current binding for `key` and passes
+    * it to the partial function `f`. If `f` is not defined, nothing
+    * is changed on the underlying Map. If `f` returns `Some(v)`, the
+    * binding is updated with the new value `v`. If `f` returns `None`,
+    * the binding is removed.
+    *
+    * For example, to update an existing binding:
+    *
+    * {{{
+    *   updateWith("foo") { case Some(previous) => Some(previous * 2) }
+    * }}}
+    *
+    * @return The current value associated with `key`, or `None` if the
+    *         there is no such binding or if it has been removed
+    */
+  def updateWith(key: K)(f: PartialFunction[Option[V], Option[V]]): Option[V] = {
+    val pf = f.lift
+    val previousValue = `this`.get(key)
+    pf(previousValue) match {
+      case None => previousValue
+      case Some(result) =>
+        result match {
+          case None =>
+            `this` -= key
+            None
+          case Some(v) =>
+            `this`(key) = v
+            Some(v)
+        }
+    }
+  }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -13,4 +13,7 @@ package object decorators {
   implicit def MapDecorator[K, V](map: Map[K, V]): MapDecorator[K, V] { val `this`: map.type } =
     new MapDecorator[K, V] { val `this`: map.type = map }
 
+  implicit def MutableMapDecorator[K, V](map: mutable.Map[K, V]): MutableMapDecorator[K, V] =
+    new MutableMapDecorator[K, V](map)
+
 }

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
@@ -1,0 +1,98 @@
+package strawman
+package collection.mutable
+
+import strawman.collection.{IterableFactory, IterableOnce, MapFactory}
+import strawman.collection.decorators._
+
+/**
+  * A class for mutable sets with the ability to count the occurrences of their elements.
+  *
+  * @example {{{
+  *   import collection.mutable.MultiSet
+  *   val ms = MultiSet.empty[String]
+  *
+  *   ms += "foo"
+  *   ms += "bar"
+  *   ms += "foo"
+  *
+  *   assert(ms.get("foo") == 2)
+  *   assert(ms.get("bar") == 1)
+  * }}}
+  *
+  * @param elems Underlying elements
+  * @param newBuilder Factory for building a `Map` of the same type as `elems`
+  * @tparam A Type of elements
+  * @define coll multiset
+  * @define Coll MultiSet
+  */
+class MultiSet[A](private val elems: Map[A, Int], newBuilder: () => Builder[(A, Int), Map[A, Int]])
+  extends collection.Iterable[(A, Int)]
+    with collection.IterableOps[(A, Int), collection.Iterable, MultiSet[A]]
+    with Growable[A]
+    with Shrinkable[A]
+    with Equals {
+
+  def this(elems: Map[A, Int]) = this(elems, () => elems.mapFactory.newBuilder())
+
+  protected[this] def coll: MultiSet[A] = this
+
+  def iterableFactory: IterableFactory[collection.Iterable] = collection.Iterable
+
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(A, Int)]): MultiSet[A] =
+    new MultiSet[A](coll.to(elems.mapFactory))
+
+  protected[this] def newSpecificBuilder(): Builder[(A, Int), MultiSet[A]] =
+    newBuilder().mapResult(fromSpecificIterable)
+
+  def iterator(): strawman.collection.Iterator[(A, Int)] = elems.iterator()
+
+  def add(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case None    => Some(1)
+      case Some(n) => Some(n + 1)
+    }
+    this
+  }
+
+  def subtract(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case Some(n) => if (n > 1) Some(n - 1) else None
+    }
+    this
+  }
+
+  def clear(): Unit = elems.clear()
+
+  def canEqual(that: Any) = true
+
+  override def equals(that: Any): Boolean = that match {
+    case that: MultiSet[A] => this.elems == that.elems
+    case _ => false
+  }
+
+  override def hashCode(): Int = strawman.collection.Set.unorderedHash(this, "MultiSet".##)
+
+  /**
+    * @return The number of occurrences of `elem` in this `MultiSet`
+    */
+  def get(elem: A): Int = elems.getOrElse(elem, 0)
+
+  def toMutableMap: Map[A, Int] = elems
+
+}
+
+class MultiSetFactory(mapFactory: MapFactory[Map]) extends IterableFactory[MultiSet] {
+
+  def from[A](source: IterableOnce[A]) = Growable.from(empty[A], source)
+
+  def empty[A] = new MultiSet(mapFactory.empty[A, Int])
+
+  def newBuilder[A]() = new GrowableBuilder(empty[A])
+
+}
+
+/**
+  * The default MultiSet factory uses the default `mutable.Map` to store
+  * its elements.
+  */
+object MultiSet extends MultiSetFactory(mapFactory = Map)

--- a/collections-contrib/src/test/scala/strawman/collection/mutable/MultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/mutable/MultiSetTest.scala
@@ -1,0 +1,40 @@
+package strawman
+package collection
+package mutable
+
+import org.junit.{Assert, Test}
+
+class MultiSetTest {
+
+  @Test
+  def multiSet(): Unit = {
+    val ms = MultiSet.empty[String]
+    ms += "foo"
+    ms += "bar"
+    ms += "foo"
+    Assert.assertEquals(2, ms.get("foo"))
+    Assert.assertEquals(1, ms.get("bar"))
+    Assert.assertEquals(0, ms.get("baz"))
+    val ss = for ((elem, n) <- ms) yield elem * n
+    Assert.assertEquals(Set("foofoo", "bar"), ss.to(Set))
+    ms -= "foo"
+    ms -= "bar"
+    Assert.assertEquals(1, ms.get("foo"))
+    Assert.assertEquals(0, ms.get("bar"))
+
+    val ms2 = MultiSet("foo")
+    Assert.assertTrue(ms == ms2)
+    Assert.assertTrue(ms2 == ms)
+    Assert.assertEquals(ms.##, ms2.##)
+  }
+
+  @Test
+  def sortedMultiSet(): Unit = {
+    val ms = new MultiSet[String](TreeMap.empty, () => TreeMap.newBuilder[String, Int]())
+    ms += "foo"
+    ms += "bar"
+    ms += "foo"
+    Assert.assertTrue(ms.iterator().sameElements(Iterator("bar" -> 1, "foo" -> 2)))
+  }
+
+}


### PR DESCRIPTION
Fixes #133 and fixes #251 (cc @alexknvl).

In `collections-contrib`, decorate `mutable.Map` collections with a new operation, `updateWith`, similar to `java.util.Map#compute`: it creates a new binding or updates or removes an existing binding. I felt like we don’t need an equivalent for `computeIfAbsent` because we already have `getOrElseUpdate`, which does exactly the same thing. The case of `computeIfPresent` is also supported by `updateWith(key) { case Some(value) => … }`.

Add a `mutable.MultiSet` collection, whose implementation internally uses a mutable Map and the aforementioned `updateWith` method.