### PR TITLE
Add updateWith/updatedWith methods to Map collections

### DIFF
--- a/collections-contrib/src/main/scala/strawman/collection/decorators/ImmutableMapDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/ImmutableMapDecorator.scala
@@ -1,0 +1,20 @@
+package strawman
+package collection
+package decorators
+
+class ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.MapOps[X, Y, CC, CC[X, Y]]](`this`: CC[K, V]) {
+
+  def updatedWith(key: K)(f: PartialFunction[Option[V], Option[V]]): CC[K, V] = {
+    val pf = f.lift
+    val previousValue = `this`.get(key)
+    pf(previousValue) match {
+      case None => `this`
+      case Some(result) =>
+        result match {
+          case None => `this` - key
+          case Some(v) => `this` + (key -> v)
+        }
+    }
+  }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/MutableMapDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/MutableMapDecorator.scala
@@ -1,0 +1,43 @@
+package strawman
+package collection
+package decorators
+
+class MutableMapDecorator[K, V](`this`: mutable.Map[K, V]) {
+
+  /**
+    * Updates an existing binding or create a new one according to the
+    * result of the application of `f`.
+    *
+    * This operation retrieves the current binding for `key` and passes
+    * it to the partial function `f`. If `f` is not defined, nothing
+    * is changed on the underlying Map. If `f` returns `Some(v)`, the
+    * binding is updated with the new value `v`. If `f` returns `None`,
+    * the binding is removed.
+    *
+    * For example, to update an existing binding:
+    *
+    * {{{
+    *   updateWith("foo") { case Some(previous) => Some(previous * 2) }
+    * }}}
+    *
+    * @return The current value associated with `key`, or `None` if the
+    *         there is no such binding or if it has been removed
+    */
+  def updateWith(key: K)(f: PartialFunction[Option[V], Option[V]]): Option[V] = {
+    val pf = f.lift
+    val previousValue = `this`.get(key)
+    pf(previousValue) match {
+      case None => previousValue
+      case Some(result) =>
+        result match {
+          case None =>
+            `this` -= key
+            None
+          case Some(v) =>
+            `this`(key) = v
+            Some(v)
+        }
+    }
+  }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -13,4 +13,7 @@ package object decorators {
   implicit def MapDecorator[K, V](map: Map[K, V]): MapDecorator[K, V] { val `this`: map.type } =
     new MapDecorator[K, V] { val `this`: map.type = map }
 
+  implicit def MutableMapDecorator[K, V](map: mutable.Map[K, V]): MutableMapDecorator[K, V] =
+    new MutableMapDecorator[K, V](map)
+
 }

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -13,6 +13,9 @@ package object decorators {
   implicit def MapDecorator[K, V](map: Map[K, V]): MapDecorator[K, V] { val `this`: map.type } =
     new MapDecorator[K, V] { val `this`: map.type = map }
 
+  implicit def ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.MapOps[X, Y, CC, CC[X, Y]]](map: CC[K, V]): ImmutableMapDecorator[K, V, CC] =
+    new ImmutableMapDecorator[K, V, CC](map)
+
   implicit def MutableMapDecorator[K, V](map: mutable.Map[K, V]): MutableMapDecorator[K, V] =
     new MutableMapDecorator[K, V](map)
 

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/ImmutableMapDecoratorTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/ImmutableMapDecoratorTest.scala
@@ -1,0 +1,30 @@
+package strawman
+package collection
+package decorators
+
+import org.junit.{Assert, Test}
+
+class ImmutableMapDecoratorTest {
+
+  @Test
+  def updatedWith(): Unit = {
+    var ms = new MultiSet[String](immutable.Map.empty)
+    ms -= "foo"
+    Assert.assertEquals(Map.empty, ms.elems)
+    ms += "foo"
+    ms += "bar"
+    ms += "foo"
+    Assert.assertEquals(Map("foo" -> 2, "bar" -> 1), ms.elems)
+    ms -= "foo"
+    ms -= "bar"
+    Assert.assertEquals(Map("foo" -> 1), ms.elems)
+  }
+
+  class MultiSet[A](val elems: immutable.Map[A, Int]) {
+    def + (elem: A): MultiSet[A] =
+      new MultiSet(elems.updatedWith(elem) { case Some(n) => Some(n + 1) case None => Some(1) })
+    def - (elem: A): MultiSet[A] =
+      new MultiSet(elems.updatedWith(elem) { case Some(n) => if (n > 1) Some(n - 1) else None })
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/MutableMapDecoratorTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/MutableMapDecoratorTest.scala
@@ -1,0 +1,35 @@
+package strawman
+package collection
+package decorators
+
+import org.junit.{Assert, Test}
+
+class MutableMapDecoratorTest {
+
+  @Test
+  def updateWith(): Unit = {
+    val ms = new MultiSet[String]
+    ms -= "foo"
+    Assert.assertEquals(Map.empty, ms.elems)
+    ms += "foo"
+    ms += "bar"
+    ms += "foo"
+    Assert.assertEquals(Map("foo" -> 2, "bar" -> 1), ms.elems)
+    ms -= "foo"
+    ms -= "bar"
+    Assert.assertEquals(Map("foo" -> 1), ms.elems)
+  }
+
+  class MultiSet[A] {
+    val elems = mutable.Map.empty[A, Int]
+    def += (elem: A): this.type = {
+      elems.updateWith(elem) { case Some(n) => Some(n + 1) case None => Some(1) }
+      this
+    }
+    def -= (elem: A): this.type = {
+      elems.updateWith(elem) { case Some(n) => if (n > 1) Some(n - 1) else None }
+      this
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #251. Adds an `updateWith` method to mutable Maps and an `updatedWith` method to immutable Maps.