### PR TITLE
Add MultiMap branch. Add mutable.MultiMap and immutable.MultiMap leaves.

### DIFF
--- a/collections-contrib/src/main/scala/strawman/collection/MultiMap.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/MultiMap.scala
@@ -1,0 +1,79 @@
+package strawman
+package collection
+
+trait MultiMap[K, V]
+  extends Iterable[(K, Set[V])]
+    with MultiMapOps[K, V, MultiMap, MultiMap[K, V]]
+    with Equals {
+
+  final protected[this] def coll: this.type = this
+
+  def canEqual(that: Any): Boolean = true
+
+  override def equals(o: Any): Boolean = o match {
+    case that: MultiMap[K, _] =>
+      (this eq that) ||
+        (that canEqual this) &&
+          (this.size == that.size) && {
+          try {
+            this forall { case (k, vs) => that.get(k) == vs }
+          } catch {
+            case _: ClassCastException => false
+          }
+        }
+    case _ => false
+  }
+
+  override def hashCode(): Int = collection.Set.unorderedHash(toIterable, "MultiMap".##)
+
+}
+
+trait MultiMapOps[K, V, +CC[X, Y] <: MultiMap[X, Y], +C]
+  extends IterableOps[(K, Set[V]), Iterable, C] {
+
+  def iterableFactory: IterableFactory[Iterable] = Iterable
+
+  def toIterableByValue: Iterable[(K, V)]
+  def multiMapFactory: MapFactory[CC]
+  protected[this] def multiMapFromIterable[K2, V2](coll: Iterable[(K2, Set[V2])]): CC[K2, V2]
+  protected[this] def multiMapFromIterableByValue[K2, V2](coll: Iterable[(K2, V2)]): CC[K2, V2]
+
+  def mapByValue[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] =
+    multiMapFromIterableByValue(View.Map(toIterableByValue, f))
+
+  def map[K2, V2](f: ((K, Set[V])) => (K2, Set[V2])): CC[K2, V2] =
+    multiMapFromIterable(View.Map(toIterable, f))
+
+  def flatMapByValue[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] =
+    multiMapFromIterableByValue(View.FlatMap(toIterableByValue, f))
+
+  def flatMap[K2, V2](f: ((K, Set[V])) => IterableOnce[(K2, collection.Set[V2])]): CC[K2, V2] =
+    multiMapFromIterable(View.FlatMap(toIterable, f))
+
+  def concatByValue(that: Iterable[(K, V)]): CC[K, V] =
+    multiMapFromIterableByValue(View.Concat(toIterableByValue, that))
+
+  def concat(that: Iterable[(K, Set[V])]): CC[K, V] =
+    multiMapFromIterable(View.Concat(toIterable, that))
+
+  @`inline` final def ++ (that: Iterable[(K, Set[V])]): CC[K, V] = concat(that)
+
+  def get(key: K): Set[V]
+
+  def contains(key: K): Boolean = get(key).nonEmpty
+
+  def keySet: Set[K]
+
+  def values: Iterable[V]
+
+  def iterator(): Iterator[(K, Set[V])]
+
+  def iteratorByValue(): Iterator[(K, V)]
+
+  def foreachValue[U](f: ((K, V)) => U): Unit = iteratorByValue().foreach(f)
+
+  def entryExists(key: K, p: V => Boolean): Boolean = get(key).exists(p)
+
+}
+
+object MultiMap extends MapFactory.Delegate[MultiMap](mutable.MultiMap)

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/MultiMap.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/MultiMap.scala
@@ -1,0 +1,70 @@
+package strawman
+package collection
+package immutable
+
+import collection.mutable.{ ImmutableBuilder, Builder }
+
+class MultiMap[K, V](underlying: Map[K, Set[V]])
+  extends collection.MultiMap[K, V]
+    with collection.MultiMapOps[K, V, MultiMap, MultiMap[K, V]] {
+
+  def toIterableByValue = underlying.view.flatMap { case (k, vs) => vs.map(k -> _) }
+  def multiMapFactory = MultiMap
+  protected[this] def multiMapFromIterable[K2, V2](coll: collection.Iterable[(K2, collection.Set[V2])]) =
+    new MultiMap(underlying.mapFactory.from(coll.view.map { case (k, vs) => (k, vs.to(Set)) }))
+  protected[this] def multiMapFromIterableByValue[K2, V2](coll: collection.Iterable[(K2, V2)]) = multiMapFactory.from(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, collection.Set[V])]) = multiMapFromIterable(coll)
+  protected[this] def newSpecificBuilder() =
+    Map.newBuilder[K, collection.Set[V]]()
+      .mapResult(m => new MultiMap(m.map { case (k, vs) => (k, vs.to(Set)) }))
+
+  def get(key: K): collection.Set[V] = underlying.getOrElse(key, Set.empty)
+
+  def keySet: collection.Set[K] = underlying.keySet
+
+  def values: collection.Iterable[V] = underlying.values.flatten
+
+  def iterator(): Iterator[(K, collection.Set[V])] = underlying.iterator()
+
+  def iteratorByValue(): Iterator[(K, V)] = toIterableByValue.iterator()
+
+  def remove(key: K, value: V): MultiMap[K, V] =
+    underlying.get(key) match {
+      case None => this
+      case Some(vs) =>
+        if (vs.contains(value)) {
+          val updatedVs = vs - value
+          if (updatedVs.isEmpty) new MultiMap(underlying - key)
+          else new MultiMap(underlying + (key -> updatedVs))
+        } else this
+    }
+
+  @`inline` final def - (kv: (K, V)): MultiMap[K, V] = remove(kv._1, kv._2)
+
+  def add(key: K, value: V): MultiMap[K, V] =
+    underlying.get(key) match {
+      case Some(vs) => new MultiMap(underlying + (key -> (vs + value)))
+      case None     => new MultiMap(underlying + (key -> Set(value)))
+    }
+
+  @`inline` final def + (kv: (K, V)): MultiMap[K, V] = add(kv._1, kv._2)
+
+  def empty: MultiMap[K, V] = new MultiMap[K, V](underlying.mapFactory.empty)
+
+}
+
+object MultiMap extends MapFactory[MultiMap] {
+
+  def empty[K, V] = new MultiMap(Map.empty)
+
+  def from[K, V](it: IterableOnce[(K, V)]) = it match {
+    case mm: MultiMap[K, V] => mm
+    case _ => (newBuilder[K, V]() ++= it).result()
+  }
+
+  def newBuilder[K, V](): Builder[(K, V), MultiMap[K, V]] =
+    new ImmutableBuilder[(K, V), MultiMap[K, V]](empty) {
+      def add(elem: (K, V)): this.type = { elems = elems.add(elem._1, elem._2); this }
+    }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/MultiMap.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/MultiMap.scala
@@ -1,0 +1,65 @@
+package strawman
+package collection
+package mutable
+
+class MultiMap[K, V](underlying: Map[K, Set[V]])
+  extends collection.MultiMap[K, V]
+    with collection.MultiMapOps[K, V, MultiMap, MultiMap[K, V]]
+    with Growable[(K, V)]
+    with Shrinkable[(K, V)] {
+
+  def toIterableByValue: collection.Iterable[(K, V)] =
+    underlying.view.flatMap { case (k, vs) => vs.map(k -> _) }
+  def multiMapFactory: MapFactory[MultiMap] = MultiMap
+  protected[this] def multiMapFromIterable[K2, V2](coll: collection.Iterable[(K2, collection.Set[V2])]): MultiMap[K2, V2] =
+    new MultiMap(underlying.mapFactory.from(coll.view.map { case (k, vs) => (k, vs.to(Set)) }))
+  protected[this] def multiMapFromIterableByValue[K2, V2](coll: collection.Iterable[(K2, V2)]): MultiMap[K2, V2] = multiMapFactory.from(coll)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, collection.Set[V])]): MultiMap[K, V] = multiMapFromIterable(coll)
+  protected[this] def newSpecificBuilder(): Builder[(K, collection.Set[V]), MultiMap[K, V]] =
+    Map.newBuilder[K, collection.Set[V]]()
+      .mapResult(m => new MultiMap(m.map { case (k, vs) => (k, vs.to(Set)) }))
+
+  def get(key: K): collection.Set[V] = underlying.getOrElse(key, Set.empty)
+
+  def keySet: collection.Set[K] = underlying.keySet
+
+  def values: collection.Iterable[V] = underlying.values.flatten
+
+  def iterator(): Iterator[(K, collection.Set[V])] = underlying.iterator()
+
+  def iteratorByValue(): Iterator[(K, V)] = toIterableByValue.iterator()
+
+  def subtract(elem: (K, V)): this.type = {
+    val (key, value) = elem
+    underlying.get(key).foreach { vs =>
+      vs -= value
+      if (vs.isEmpty) underlying -= key
+    }
+    this
+  }
+
+  def add(elem: (K, V)): this.type = {
+    val (key, value) = elem
+    underlying.get(key) match {
+      case None     => underlying += key -> Set(value)
+      case Some(vs) => vs += value
+    }
+    this
+  }
+
+  def clear(): Unit = underlying.clear()
+
+}
+
+object MultiMap extends MapFactory[MultiMap] {
+
+  def empty[K, V] = new MultiMap[K, V](Map.empty)
+
+  def from[K, V](it: IterableOnce[(K, V)]) = it match {
+    case mm: MultiMap[K, V] => mm
+    case _ => Growable.from(empty[K, V], it)
+  }
+
+  def newBuilder[K, V]() = new GrowableBuilder[(K, V), MultiMap[K, V]](empty)
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/MultiMapTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/MultiMapTest.scala
@@ -1,0 +1,28 @@
+package strawman.collection
+
+import org.junit.{Assert, Test}
+
+class MultiMapTest {
+
+  @Test
+  def equality(): Unit = {
+    val mm1 = MultiMap(1 -> "a", 2 -> "b", 1 -> "c")
+    val mm2 = MultiMap(1 -> "a", 2 -> "b", 1 -> "c")
+
+    Assert.assertEquals(mm2, mm1)
+    Assert.assertEquals(mm1, mm2)
+    Assert.assertEquals(mm1.##, mm2.##)
+  }
+
+  @Test
+  def byValue(): Unit = {
+    Assert.assertEquals(
+      MultiMap(1 -> "b"),
+      MultiMap(1 -> "a").concat(MultiMap(1 -> "b"))
+    )
+    Assert.assertEquals(
+      MultiMap(1 -> "a", 1 -> "b"),
+      MultiMap(1 -> "a").concatByValue(MultiMap(1 -> "b").toIterableByValue)
+    )
+  }
+}

--- a/collections-contrib/src/test/scala/strawman/collection/immutable/MultiMapTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/immutable/MultiMapTest.scala
@@ -1,0 +1,35 @@
+package strawman
+package collection.immutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MultiMapTest {
+
+  @Test
+  def multiMap(): Unit = {
+    val mm = MultiMap(1 -> "aa", 2 -> "b", 1 -> "c")
+
+    val m = Map(2 -> Set("b"), 1 -> Set("c", "aa"))
+    Assert.assertEquals(m, mm.to(Map))
+    Assert.assertEquals(mm.to(Map), m)
+
+    Assert.assertTrue(mm.entryExists(1, _ == "aa"))
+    Assert.assertFalse(mm.entryExists(1, _ == "b"))
+    Assert.assertTrue(mm.entryExists(2, _ == "b"))
+
+    val mm2 = mm.mapByValue { case (k, v) => (k + v.length, v ++ v) }
+    Assert.assertEquals(Map(2 -> Set("cc"), 3 -> Set("aaaa", "bb")), mm2.to(Map))
+
+    val mm3 = mm - (1 -> "a")
+    Assert.assertFalse(mm3.entryExists(1, _ == "a"))
+    Assert.assertTrue(mm3.entryExists(1, _ == "c"))
+
+    val mm4 = mm3 - (2 -> "b")
+    Assert.assertFalse(mm4.contains(2))
+
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/mutable/MultiMapTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/mutable/MultiMapTest.scala
@@ -1,0 +1,39 @@
+package strawman
+package collection.mutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MultiMapTest {
+
+  @Test
+  def multiMap(): Unit = {
+    val mm = MultiMap.empty[Int, String]
+
+    mm += 1 -> "aa"
+    mm += 2 -> "b"
+    mm += 1 -> "c"
+
+    val m = Map(2 -> Set("b"), 1 -> Set("c", "aa"))
+    Assert.assertEquals(m, mm.to(Map))
+    Assert.assertEquals(mm.to(Map), m)
+
+    Assert.assertTrue(mm.entryExists(1, _ == "aa"))
+    Assert.assertFalse(mm.entryExists(1, _ == "b"))
+    Assert.assertTrue(mm.entryExists(2, _ == "b"))
+
+    val mm2 = mm.mapByValue { case (k, v) => (k + v.length, v ++ v) }
+    Assert.assertEquals(Map(2 -> Set("cc"), 3 -> Set("aaaa", "bb")), mm2.to(Map))
+
+    mm -= 1 -> "a"
+    Assert.assertFalse(mm.entryExists(1, _ == "a"))
+    Assert.assertTrue(mm.entryExists(1, _ == "c"))
+
+    mm -= 2 -> "b"
+    Assert.assertFalse(mm.contains(2))
+
+  }
+
+}

--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -24,13 +24,7 @@ trait Map[K, +V]
       (that canEqual this) &&
       (this.size == that.size) && {
         try {
-          this forall {
-            case (k, v) => that.get(k) match {
-              case Some(`v`) =>
-                true
-              case _ => false
-            }
-          }
+          this forall { case (k, v) => that.get(k).contains(v) }
         } catch {
           case _: ClassCastException => false
         }
@@ -44,7 +38,7 @@ trait Map[K, +V]
 }
 
 /** Base Map implementation type */
-trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V]
     with Equals {


### PR DESCRIPTION
This is another idea to provide a `MultiMap` collection type. Here, `MultiMap[K, V]` is a new “branch” of the hierarchy, it inherits from `Iterable[(K, Set[V])]`. The PR provides two implementations, a mutable one and an immutable one.

Cons:
- the fact that `MultiMap` has its own branch makes it incomparable with `Map` collections.
- if we want to make it work with an underlying `SortedMap` we have to create a new branch for that in the hierarchy.

Pros:
- `map`, `flatMap` and `concat` return a `MultiMap[K, V]` instead of a `Map[K, Set[V]`
- maybe cleaner hierarchy?

Also, when we manipulate a `MultiMap[K, V]`, sometimes we want to see the entries as `(K, Set[V])` pairs, but sometimes we want to see them as `(K, V)` pairs… I don’t see a reason to not support both, actually. So, what I’ve done is that several methods have two variants: `map` shows the entries as `(K, Set[V])` pairs, and `mapByValue` shows the entries as `(K, V)` pairs ; `iterator()` returns an `Iterator[(K, Set[V])]` and `iteratorByValue()` returns an `Iterator[(K, V)]`. Basically I used the suffix “byValue” when an operation sees its entries as `(K, V)` pairs.