### PR TITLE
Optimize Seq factory methods.

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListFillBenchmarks.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListFillBenchmarks.scala
@@ -1,0 +1,39 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import strawman.collection.immutable
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
+@State(Scope.Benchmark)
+class ListFillBenchmarks {
+
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  var size: Int = _
+
+  @Benchmark
+  def fill(bh: Blackhole): Unit = bh.consume(immutable.List.fill(size)(()))
+
+}
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
+@State(Scope.Benchmark)
+class ScalaListFillBenchmarks {
+
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  var size: Int = _
+
+  @Benchmark
+  def fill(bh: Blackhole): Unit = bh.consume(scala.List.fill(size)(()))
+
+}

--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -261,6 +261,32 @@ object SeqFactory {
   }
 }
 
+trait StrictOptimizedSeqFactory[+CC[_]] extends SeqFactory[CC] {
+
+  override def fill[A](n: Int)(elem: => A): CC[A] = {
+    val b = newBuilder[A]()
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += elem
+      i += 1
+    }
+    b.result()
+  }
+
+  override def tabulate[A](n: Int)(f: Int => A): CC[A] = {
+    val b = newBuilder[A]()
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += f(i)
+      i += 1
+    }
+    b.result()
+  }
+
+}
+
 trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   def empty: C
   def apply(xs: A*): C = fromSpecific(View.Elems(xs: _*))

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -2,7 +2,7 @@ package strawman
 package collection.immutable
 
 import strawman.collection.mutable.{ArrayBuffer, Builder}
-import strawman.collection.{IterableOnce, Iterator, SeqFactory, View}
+import strawman.collection.{IterableOnce, Iterator, SeqFactory, StrictOptimizedSeqFactory, View}
 
 import scala.{Any, ArrayIndexOutOfBoundsException, Boolean, Int, Nothing, UnsupportedOperationException, throws}
 import scala.runtime.ScalaRunTime
@@ -110,7 +110,7 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
 
 }
 
-object ImmutableArray extends SeqFactory[ImmutableArray] {
+object ImmutableArray extends StrictOptimizedSeqFactory[ImmutableArray] {
 
   private[this] lazy val emptyImpl = new ImmutableArray[Nothing](new scala.Array[Any](0))
 

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -364,20 +364,14 @@ case object Nil extends List[Nothing] {
   override def init: Nothing = throw new UnsupportedOperationException("init of empty list")
 }
 
-object List extends SeqFactory[List] {
+object List extends StrictOptimizedSeqFactory[List] {
 
   def from[B](coll: collection.IterableOnce[B]): List[B] = coll match {
     case coll: List[B] => coll
     case _ => ListBuffer.from(coll).toList
   }
 
-  def newBuilder[A](): Builder[A, List[A]] =
-    new ReusableBuilder[A, List[A]] {
-      private[this] val buffer = ListBuffer.empty[A]
-      override def clear(): Unit = buffer.clear()
-      override def result(): List[A] = buffer.toList
-      def add(elem: A): this.type = { buffer += elem; this }
-    }
+  def newBuilder[A](): Builder[A, List[A]] = new ListBuffer()
 
   def empty[A]: List[A] = Nil
 

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -10,7 +10,7 @@ import scala.Predef.intWrapper
 
 /** Companion object to the Vector class
  */
-object Vector extends SeqFactory[Vector] {
+object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def empty[A]: Vector[A] = NIL
 

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -132,7 +132,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
 }
 
-object ArrayBuffer extends SeqFactory[ArrayBuffer] {
+object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
 
   /** Avoid reallocation of buffer if length is known. */
   def from[B](coll: collection.IterableOnce[B]): ArrayBuffer[B] =

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -14,7 +14,8 @@ import scala.Predef.{assert, intWrapper}
 class ListBuffer[A]
   extends Seq[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]
-     with StrictOptimizedSeqOps[A, ListBuffer, ListBuffer[A]] {
+     with StrictOptimizedSeqOps[A, ListBuffer, ListBuffer[A]]
+     with ReusableBuilder[A, immutable.List[A]] {
 
   private var first: List[A] = Nil
   private var last0: ::[A] = null
@@ -35,6 +36,9 @@ class ListBuffer[A]
   def length = len
   override def knownSize = len
 
+  override def isEmpty: Boolean = len == 0
+  override def nonEmpty: Boolean = len > 0
+
   protected[this] def newSpecificBuilder(): Builder[A, ListBuffer[A]] = ListBuffer.newBuilder()
 
   private def copyElems(): Unit = {
@@ -51,6 +55,8 @@ class ListBuffer[A]
     aliased = true
     first
   }
+
+  def result(): immutable.List[A] = toList
 
   /** Prepends the elements of this buffer to a given list
     *
@@ -244,7 +250,7 @@ class ListBuffer[A]
 
 }
 
-object ListBuffer extends SeqFactory[ListBuffer] {
+object ListBuffer extends StrictOptimizedSeqFactory[ListBuffer] {
 
   def from[A](coll: collection.IterableOnce[A]): ListBuffer[A] = new ListBuffer[A] ++= coll
 


### PR DESCRIPTION
Fixes #232.

I’m copying here the comment I’ve posted [there](https://github.com/scala/collection-strawman/issues/233#issuecomment-337634804) explaining what I’ve done:

I’ve run the benchmark given in #232 and we effectively are between 2x to 20x slower than the current collections. Here are the detailed result:

![fill](https://user-images.githubusercontent.com/332812/31725858-aad122a8-b425-11e7-9dea-b23f6c62f993.png)

~~~
[info] Benchmark                      (size)  Mode  Cnt         Score          Error  Units
[info] ListFillBenchmarks.fill             0  avgt    8        63.071 ±       16.316  ns/op
[info] ListFillBenchmarks.fill             1  avgt    8        62.975 ±        1.338  ns/op
[info] ListFillBenchmarks.fill             2  avgt    8        70.110 ±        0.903  ns/op
[info] ListFillBenchmarks.fill             3  avgt    8        76.061 ±        0.617  ns/op
[info] ListFillBenchmarks.fill             4  avgt    8        82.497 ±        0.849  ns/op
[info] ListFillBenchmarks.fill             7  avgt    8       102.004 ±        2.411  ns/op
[info] ListFillBenchmarks.fill             8  avgt    8       108.855 ±        6.923  ns/op
[info] ListFillBenchmarks.fill            15  avgt    8       153.340 ±        5.451  ns/op
[info] ListFillBenchmarks.fill            16  avgt    8       159.890 ±        3.992  ns/op
[info] ListFillBenchmarks.fill            17  avgt    8       166.250 ±        2.695  ns/op
[info] ListFillBenchmarks.fill            39  avgt    8       312.888 ±        6.620  ns/op
[info] ListFillBenchmarks.fill           282  avgt    8      1888.001 ±       98.034  ns/op
[info] ListFillBenchmarks.fill          4096  avgt    8     26378.845 ±      383.970  ns/op
[info] ListFillBenchmarks.fill        131070  avgt    8    894854.368 ±    57599.780  ns/op
[info] ListFillBenchmarks.fill       7312102  avgt    8  88026649.694 ± 21819653.519  ns/op
[info] ScalaListFillBenchmarks.fill        0  avgt    8         3.160 ±        0.464  ns/op
[info] ScalaListFillBenchmarks.fill        1  avgt    8         7.040 ±        0.492  ns/op
[info] ScalaListFillBenchmarks.fill        2  avgt    8        11.110 ±        0.449  ns/op
[info] ScalaListFillBenchmarks.fill        3  avgt    8        14.947 ±        0.498  ns/op
[info] ScalaListFillBenchmarks.fill        4  avgt    8        18.722 ±        0.503  ns/op
[info] ScalaListFillBenchmarks.fill        7  avgt    8        30.299 ±        0.747  ns/op
[info] ScalaListFillBenchmarks.fill        8  avgt    8        33.845 ±        0.291  ns/op
[info] ScalaListFillBenchmarks.fill       15  avgt    8        61.261 ±        0.336  ns/op
[info] ScalaListFillBenchmarks.fill       16  avgt    8        67.908 ±        5.099  ns/op
[info] ScalaListFillBenchmarks.fill       17  avgt    8        70.202 ±        1.357  ns/op
[info] ScalaListFillBenchmarks.fill       39  avgt    8       164.304 ±        6.854  ns/op
[info] ScalaListFillBenchmarks.fill      282  avgt    8      1168.763 ±       47.152  ns/op
[info] ScalaListFillBenchmarks.fill     4096  avgt    8     15938.166 ±      201.876  ns/op
[info] ScalaListFillBenchmarks.fill   131070  avgt    8    450498.820 ±    76816.504  ns/op
[info] ScalaListFillBenchmarks.fill  7312102  avgt    8  71174568.325 ± 21687327.564  ns/op
~~~

One main difference between the current `List.fill` method and the new `List.fill` method is that the former is builder-based whereas the latter is view-based. Being view based means that we allocate a `View`, we get its `Iterator`, and we loop through it to copy its elements to a `ListBuffer`, which we eventually convert to a `List` (this is a O(1) operation). The builder-based version runs a while loop (with no calls to `hasNext` or `next()` in each iteration) to put the elements in a builder on which it eventually calls `result()`.

If we switch to a builder-based version, we are “only” between 1.8x to 2x slower. Here are the detailed results:

![fill](https://user-images.githubusercontent.com/332812/31725320-54124ec0-b424-11e7-8b98-95271a3ffe8a.png)

~~~
[info] Benchmark                      (size)  Mode  Cnt          Score          Error  Units
[info] ListFillBenchmarks.fill             0  avgt    8          6.155 ±        0.042  ns/op
[info] ListFillBenchmarks.fill             1  avgt    8         12.885 ±        0.071  ns/op
[info] ListFillBenchmarks.fill             2  avgt    8         23.851 ±        9.650  ns/op
[info] ListFillBenchmarks.fill             3  avgt    8         28.434 ±        0.260  ns/op
[info] ListFillBenchmarks.fill             4  avgt    8         36.062 ±        0.264  ns/op
[info] ListFillBenchmarks.fill             7  avgt    8         58.790 ±        0.595  ns/op
[info] ListFillBenchmarks.fill             8  avgt    8         66.179 ±        0.565  ns/op
[info] ListFillBenchmarks.fill            15  avgt    8        120.001 ±        2.231  ns/op
[info] ListFillBenchmarks.fill            16  avgt    8        126.864 ±        1.074  ns/op
[info] ListFillBenchmarks.fill            17  avgt    8        134.766 ±        1.768  ns/op
[info] ListFillBenchmarks.fill            39  avgt    8        306.982 ±        5.840  ns/op
[info] ListFillBenchmarks.fill           282  avgt    8       2156.660 ±       45.336  ns/op
[info] ListFillBenchmarks.fill          4096  avgt    8      30987.071 ±      425.642  ns/op
[info] ListFillBenchmarks.fill        131070  avgt    8     788364.790 ±    20478.630  ns/op
[info] ListFillBenchmarks.fill       7312102  avgt    8  117394249.156 ± 24024250.783  ns/op
[info] ScalaListFillBenchmarks.fill        0  avgt    8          2.962 ±        0.019  ns/op
[info] ScalaListFillBenchmarks.fill        1  avgt    8          6.551 ±        0.035  ns/op
[info] ScalaListFillBenchmarks.fill        2  avgt    8         10.778 ±        0.155  ns/op
[info] ScalaListFillBenchmarks.fill        3  avgt    8         14.664 ±        0.154  ns/op
[info] ScalaListFillBenchmarks.fill        4  avgt    8         18.579 ±        0.348  ns/op
[info] ScalaListFillBenchmarks.fill        7  avgt    8         30.252 ±        0.211  ns/op
[info] ScalaListFillBenchmarks.fill        8  avgt    8         34.273 ±        0.955  ns/op
[info] ScalaListFillBenchmarks.fill       15  avgt    8        107.036 ±        6.590  ns/op
[info] ScalaListFillBenchmarks.fill       16  avgt    8         75.901 ±        0.301  ns/op
[info] ScalaListFillBenchmarks.fill       17  avgt    8         79.008 ±       11.629  ns/op
[info] ScalaListFillBenchmarks.fill       39  avgt    8        164.342 ±        4.242  ns/op
[info] ScalaListFillBenchmarks.fill      282  avgt    8       1126.003 ±       32.348  ns/op
[info] ScalaListFillBenchmarks.fill     4096  avgt    8      15757.792 ±      127.241  ns/op
[info] ScalaListFillBenchmarks.fill   131070  avgt    8     426613.585 ±     4512.173  ns/op
[info] ScalaListFillBenchmarks.fill  7312102  avgt    8   64553320.047 ± 15811815.206  ns/op
~~~

I guess one reason to still be behind the current collections is that our `List` builder is a wrapper around a `ListBuffer` whereas in the current collections, `ListBuffer` **is** a `List` builder (so it removes one level of indirection).

If we make `ListBuffer[A]` a `Builder[A, List[A]]`, then we become slightly closer to the current collection’s performance, but still between 1.15x to 1.6x slower:

![fill](https://user-images.githubusercontent.com/332812/31727858-053565ba-b42b-11e7-8990-5433622abcd1.png)

~~~
[info] Benchmark                      (size)  Mode  Cnt         Score          Error  Units
[info] ListFillBenchmarks.fill             0  avgt    8         2.958 ±        0.018  ns/op
[info] ListFillBenchmarks.fill             1  avgt    8         8.659 ±        0.054  ns/op
[info] ListFillBenchmarks.fill             2  avgt    8        15.652 ±        0.196  ns/op
[info] ListFillBenchmarks.fill             3  avgt    8        21.528 ±        0.153  ns/op
[info] ListFillBenchmarks.fill             4  avgt    8        28.154 ±        0.285  ns/op
[info] ListFillBenchmarks.fill             7  avgt    8        47.948 ±        0.405  ns/op
[info] ListFillBenchmarks.fill             8  avgt    8        56.171 ±        2.883  ns/op
[info] ListFillBenchmarks.fill            15  avgt    8       101.886 ±        1.919  ns/op
[info] ListFillBenchmarks.fill            16  avgt    8       108.414 ±        3.938  ns/op
[info] ListFillBenchmarks.fill            17  avgt    8       115.572 ±        5.349  ns/op
[info] ListFillBenchmarks.fill            39  avgt    8       269.576 ±       16.616  ns/op
[info] ListFillBenchmarks.fill           282  avgt    8      1882.431 ±       53.435  ns/op
[info] ListFillBenchmarks.fill          4096  avgt    8     27177.490 ±      368.861  ns/op
[info] ListFillBenchmarks.fill        131070  avgt    8    784631.266 ±    10743.474  ns/op
[info] ListFillBenchmarks.fill       7312102  avgt    8  66293246.112 ± 37729502.445  ns/op
[info] ScalaListFillBenchmarks.fill        0  avgt    8         3.042 ±        0.058  ns/op
[info] ScalaListFillBenchmarks.fill        1  avgt    8         6.628 ±        0.200  ns/op
[info] ScalaListFillBenchmarks.fill        2  avgt    8        10.865 ±        0.575  ns/op
[info] ScalaListFillBenchmarks.fill        3  avgt    8        14.787 ±        0.171  ns/op
[info] ScalaListFillBenchmarks.fill        4  avgt    8        18.594 ±        0.216  ns/op
[info] ScalaListFillBenchmarks.fill        7  avgt    8        30.438 ±        0.536  ns/op
[info] ScalaListFillBenchmarks.fill        8  avgt    8        35.216 ±        3.655  ns/op
[info] ScalaListFillBenchmarks.fill       15  avgt    8        62.409 ±        2.968  ns/op
[info] ScalaListFillBenchmarks.fill       16  avgt    8        67.442 ±        3.715  ns/op
[info] ScalaListFillBenchmarks.fill       17  avgt    8        75.503 ±        4.087  ns/op
[info] ScalaListFillBenchmarks.fill       39  avgt    8       163.350 ±        9.226  ns/op
[info] ScalaListFillBenchmarks.fill      282  avgt    8      1114.375 ±       25.540  ns/op
[info] ScalaListFillBenchmarks.fill     4096  avgt    8     16795.959 ±     2800.531  ns/op
[info] ScalaListFillBenchmarks.fill   131070  avgt    8    449145.273 ±    39378.066  ns/op
[info] ScalaListFillBenchmarks.fill  7312102  avgt    8  61872483.394 ± 16982269.950  ns/op
~~~

I’ve spent a few hours to try to understand why we are still slower but didn’t make significant progress. Performance is a bit unpredictable. For instance, I tried to inline `(a :: Nil).asInstanceOf[::[A]]` to `new :: (a, Nil)` but the benchmarks ran 3x slower!