### PR TITLE
Enable scalacheck tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For more information, see the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `indices`
 - [x] `isDefinedAt`
 - [x] `isEmpty` / `nonEmpty`
-- [x] `keysIteratorFrom`
+- [x] `iteratorFrom` / `keysIteratorFrom` / `valuesIteratorFrom`
 - [x] `last` / `lastOption`
 - [x] `lastKey`
 - [x] `max` / `maxBy`
@@ -200,7 +200,7 @@ For more information, see the [CONTRIBUTING](CONTRIBUTING.md) file.
 - [x] `init`
 - [x] `intersect`
 - [x] `partition`
-- [x] `range`
+- [x] `range` / `rangeTo`
 - [x] `rangeImpl`
 - [x] `sorted` / `sortBy` / `sortWith`
 - [x] `slice`

--- a/collections/src/main/scala/strawman/collection/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/BitSet.scala
@@ -40,9 +40,9 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   def contains(elem: Int): Boolean =
     0 <= elem && (word(elem >> LogWL) & (1L << elem)) != 0L
 
-  def iterator(): Iterator[Int] = keysIteratorFrom(0)
+  def iterator(): Iterator[Int] = iteratorFrom(0)
 
-  def keysIteratorFrom(start: Int) = new Iterator[Int] {
+  def iteratorFrom(start: Int) = new Iterator[Int] {
     private var current = start
     private val end = nwords * WordLength
     def hasNext: Boolean = {

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -92,7 +92,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   // Consumes all the collection!
   protected[this] def reversed: Iterable[A] = {
     var xs: immutable.List[A] = immutable.Nil
-    val it = toIterable.iterator()
+    val it = iterator()
     while (it.hasNext) xs = it.next() :: xs
     xs
   }
@@ -100,7 +100,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   /** Apply `f` to each element for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
-  def foreach[U](f: A => U): Unit = toIterable.iterator().foreach(f)
+  def foreach[U](f: A => U): Unit = iterator().foreach(f)
 
   /** Tests whether a predicate holds for all elements of this $coll.
    *
@@ -110,7 +110,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @return        `true` if this $coll is empty or the given predicate `p`
    *                 holds for all elements of this $coll, otherwise `false`.
    */
-  def forall(p: A => Boolean): Boolean = toIterable.iterator().forall(p)
+  def forall(p: A => Boolean): Boolean = iterator().forall(p)
 
   /** Tests whether a predicate holds for at least one element of this $coll.
    *
@@ -119,14 +119,14 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @param   p     the predicate used to test elements.
    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this $coll, otherwise `false`
    */
-  def exists(p: A => Boolean): Boolean = toIterable.iterator().exists(p)
+  def exists(p: A => Boolean): Boolean = iterator().exists(p)
 
   /** Counts the number of elements in the $coll which satisfy a predicate.
    *
    *  @param p     the predicate  used to test elements.
    *  @return      the number of elements satisfying the predicate `p`.
    */
-  def count(p: A => Boolean): Int = toIterable.iterator().count(p)
+  def count(p: A => Boolean): Int = iterator().count(p)
 
   /** Finds the first element of the $coll satisfying a predicate, if any.
     *
@@ -137,13 +137,13 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     *  @return        an option value containing the first element in the $coll
     *                 that satisfies `p`, or `None` if none exists.
     */
-  def find(p: A => Boolean): Option[A] = toIterable.iterator().find(p)
+  def find(p: A => Boolean): Option[A] = iterator().find(p)
 
   /** Fold left */
-  def foldLeft[B](z: B)(op: (B, A) => B): B = toIterable.iterator().foldLeft(z)(op)
+  def foldLeft[B](z: B)(op: (B, A) => B): B = iterator().foldLeft(z)(op)
 
   /** Fold right */
-  def foldRight[B](z: B)(op: (A, B) => B): B = toIterable.iterator().foldRight(z)(op)
+  def foldRight[B](z: B)(op: (A, B) => B): B = iterator().foldRight(z)(op)
 
   @deprecated("Use foldLeft instead of /:", "2.13.0")
   @`inline` final def /: [B](z: B)(op: (B, A) => B): B = foldLeft[B](z)(op)
@@ -161,7 +161,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @throws UnsupportedOperationException
    *  if this $coll is empty.
    */
-  def reduce[B >: A](op: (B, B) => B): B = reduceLeft(op)
+  def reduce[B >: A](op: (B, B) => B): B = iterator().reduce(op)
 
   /** Reduces the elements of this $coll, if any, using the specified
    *  associative binary operator.
@@ -173,7 +173,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @return        An option value containing result of applying reduce operator `op` between all
    *                 the elements if the collection is nonempty, and `None` otherwise.
    */
-  def reduceOption[B >: A](op: (B, B) => B): Option[B] = reduceLeftOption(op)
+  def reduceOption[B >: A](op: (B, B) => B): Option[B] = iterator().reduceOption(op)
 
   /** Applies a binary operator to all elements of this $coll,
    *  going left to right.
@@ -189,22 +189,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *           }}}
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
    *  @throws UnsupportedOperationException if this $coll is empty.   */
-  def reduceLeft[B >: A](op: (B, A) => B): B = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.reduceLeft")
-
-    var first = true
-    var acc: B = 0.asInstanceOf[B]
-
-    for (x <- toIterable) {
-      if (first) {
-        acc = x
-        first = false
-      }
-      else acc = op(acc, x)
-    }
-    acc
-  }
+  def reduceLeft[B >: A](op: (B, A) => B): B = iterator().reduceLeft(op)
 
   /** Applies a binary operator to all elements of this $coll, going right to left.
    *  $willNotTerminateInf
@@ -220,12 +205,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
    *  @throws UnsupportedOperationException if this $coll is empty.
    */
-  def reduceRight[B >: A](op: (A, B) => B): B = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.reduceRight")
-
-    reversed.reduceLeft[B]((x, y) => op(y, x))
-  }
+  def reduceRight[B >: A](op: (A, B) => B): B = iterator().reduceRight(op)
 
   /** Optionally applies a binary operator to all elements of this $coll, going left to right.
    *  $willNotTerminateInf
@@ -236,7 +216,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @return  an option value containing the result of `reduceLeft(op)` if this $coll is nonempty,
    *           `None` otherwise.
    */
-  def reduceLeftOption[B >: A](op: (B, A) => B): Option[B] = if (isEmpty) None else Some(reduceLeft(op))
+  def reduceLeftOption[B >: A](op: (B, A) => B): Option[B] = iterator().reduceLeftOption(op)
 
   /** Optionally applies a binary operator to all elements of this $coll, going
    *  right to left.
@@ -248,20 +228,28 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *  @return  an option value containing the result of `reduceRight(op)` if this $coll is nonempty,
    *           `None` otherwise.
    */
-  def reduceRightOption[B >: A](op: (A, B) => B): Option[B] = if (isEmpty) None else Some(reduceRight(op))
+  def reduceRightOption[B >: A](op: (A, B) => B): Option[B] = iterator().reduceRightOption(op)
 
   /** Is the collection empty? */
-  def isEmpty: Boolean = !toIterable.iterator().hasNext
+  def isEmpty: Boolean = !iterator().hasNext
 
   /** Is the collection not empty? */
-  def nonEmpty: Boolean = toIterable.iterator().hasNext
+  def nonEmpty: Boolean = iterator().hasNext
 
-  /** The first element of the collection. */
-  def head: A = toIterable.iterator().next()
+  /** Selects the first element of this $coll.
+    *  $orderDependent
+    *  @return  the first element of this $coll.
+    *  @throws NoSuchElementException if the $coll is empty.
+    */
+  def head: A = iterator().next()
 
-  /** The first element of the collection. */
+  /** Optionally selects the first element.
+    *  $orderDependent
+    *  @return  the first element of this $coll if it is nonempty,
+    *           `None` if it is empty.
+    */
   def headOption: Option[A] = {
-    val it = toIterable.iterator()
+    val it = iterator()
     if(it.hasNext) Some(it.next()) else None
   }
 
@@ -271,7 +259,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     * @throws NoSuchElementException If the $coll is empty.
     */
   def last: A = {
-    val it = toIterable.iterator()
+    val it = iterator()
     var lst = it.next()
     while (it.hasNext) lst = it.next()
     lst
@@ -295,10 +283,10 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   /** The number of elements in this collection. Does not terminate for
     *  infinite collections.
     */
-  def size: Int = if (knownSize >= 0) knownSize else toIterable.iterator().length
+  def size: Int = if (knownSize >= 0) knownSize else iterator().length
 
   /** A view representing the elements of this collection. */
-  def view: View[A] = View.fromIteratorProvider(() => toIterable.iterator())
+  def view: View[A] = View.fromIteratorProvider(() => iterator())
 
   /** Given a collection factory `factory`, convert this collection to the appropriate
     * representation for the current element type `A`. Example uses:
@@ -307,30 +295,30 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     *      xs.to(ArrayBuffer)
     *      xs.to(BitSet) // for xs: Iterable[Int]
     */
-  def to[C1](factory: Factory[A, C1]): C1 = factory.fromSpecific(toIterable)
+  def to[C1](factory: Factory[A, C1]): C1 = factory.fromSpecific(this)
 
-  def toList: immutable.List[A] = immutable.List.from(toIterable)
+  def toList: immutable.List[A] = immutable.List.from(this)
 
-  def toVector: immutable.Vector[A] = immutable.Vector.from(toIterable)
+  def toVector: immutable.Vector[A] = immutable.Vector.from(this)
 
   def toMap[K, V](implicit ev: A <:< (K, V)): immutable.Map[K, V] =
-    immutable.Map.from(toIterable.asInstanceOf[Iterable[(K, V)]])
+    immutable.Map.from(this.asInstanceOf[IterableOnce[(K, V)]])
 
-  def toSet[B >: A]: immutable.Set[B] = immutable.Set.from(toIterable)
+  def toSet[B >: A]: immutable.Set[B] = immutable.Set.from(this)
 
-  def toSeq: immutable.Seq[A] = immutable.Seq.from(toIterable)
+  def toSeq: immutable.Seq[A] = immutable.Seq.from(this)
 
-  def toIndexedSeq: immutable.IndexedSeq[A] = immutable.IndexedSeq.from(toIterable)
+  def toIndexedSeq: immutable.IndexedSeq[A] = immutable.IndexedSeq.from(this)
 
   /** Convert collection to array. */
   def toArray[B >: A: ClassTag]: Array[B] =
     if (knownSize >= 0) copyToArray(new Array[B](knownSize), 0)
-    else ArrayBuffer.from(toIterable).toArray[B]
+    else ArrayBuffer.from(this).toArray[B]
 
   /** Copy all elements of this collection to array `xs`, starting at `start`. */
   def copyToArray[B >: A](xs: Array[B], start: Int = 0): xs.type = {
     var i = start
-    val it = toIterable.iterator()
+    val it = iterator()
     while (it.hasNext) {
       xs(i) = it.next()
       i += 1
@@ -449,7 +437,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
     *
     */
-  def sum[B >: A](implicit num: Numeric[B]): B = foldLeft(num.zero)(num.plus)
+  def sum[B >: A](implicit num: Numeric[B]): B = iterator().sum[B]
 
   /** Multiplies up the elements of this collection.
    *
@@ -466,7 +454,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *     can be used as element type of the $coll and as result type of `product`.
    *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
    */
-  def product[B >: A](implicit num: Numeric[B]): B = foldLeft(num.one)(num.times)
+  def product[B >: A](implicit num: Numeric[B]): B = iterator().product[B]
 
   /** Finds the smallest element.
    *
@@ -479,12 +467,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *
    *    @return   the smallest element of this $coll
    */
-  def min[B >: A](implicit ord: Ordering[B]): A = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.min")
-
-    reduceLeft((x, y) => if (ord.lteq(x, y)) x else y)
-  }
+  def min[B >: A](implicit ord: Ordering[B]): A = iterator().min[B]
 
   /** Finds the largest element.
    *
@@ -497,12 +480,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *
    *    @return   the largest element of this $coll.
    */
-  def max[B >: A](implicit ord: Ordering[B]): A = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.max")
-
-    reduceLeft((x, y) => if (ord.gteq(x, y)) x else y)
-  }
+  def max[B >: A](implicit ord: Ordering[B]): A = iterator().max[B]
 
   /** Finds the first element which yields the largest value measured by function f.
    *
@@ -517,24 +495,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *
    *    @return   the first element of this $coll with the largest value measured by function f.
    */
-  def maxBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.maxBy")
-
-    var maxF: B = null.asInstanceOf[B]
-    var maxElem: A = null.asInstanceOf[A]
-    var first = true
-
-    for (elem <- toIterable) {
-      val fx = f(elem)
-      if (first || cmp.gt(fx, maxF)) {
-        maxElem = elem
-        maxF = fx
-        first = false
-      }
-    }
-    maxElem
-  }
+  def maxBy[B](f: A => B)(implicit cmp: Ordering[B]): A = iterator().maxBy(f)
 
   /** Finds the first element which yields the smallest value measured by function f.
    *
@@ -549,24 +510,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *
    *    @return   the first element of this $coll with the smallest value measured by function f.
    */
-  def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
-    if (isEmpty)
-      throw new UnsupportedOperationException("empty.minBy")
-
-    var minF: B = null.asInstanceOf[B]
-    var minElem: A = null.asInstanceOf[A]
-    var first = true
-
-    for (elem <- toIterable) {
-      val fx = f(elem)
-      if (first || cmp.lt(fx, minF)) {
-        minElem = elem
-        minF = fx
-        first = false
-      }
-    }
-    minElem
-  }
+  def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A = iterator().minBy(f)
 
   /** Selects all elements of this $coll which satisfy a predicate.
     *
@@ -649,8 +593,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   def takeRight(n: Int): C = {
     val b = newSpecificBuilder()
     b.sizeHintBounded(n, toIterable)
-    val lead = toIterable.iterator() drop n
-    val it = toIterable.iterator()
+    val lead = iterator() drop n
+    val it = iterator()
     while (lead.hasNext) {
       lead.next()
       it.next()
@@ -691,8 +635,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   def dropRight(n: Int): C = {
     val b = newSpecificBuilder()
     if (n >= 0) b.sizeHint(toIterable, delta = -n)
-    val lead = toIterable.iterator() drop n
-    val it = toIterable.iterator()
+    val lead = iterator() drop n
+    val it = iterator()
     while (lead.hasNext) {
       b += it.next()
       lead.next()
@@ -716,7 +660,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
    *          last will be less than size `size` if the elements don't divide evenly.
    */
   def grouped(size: Int): Iterator[C] =
-    toIterable.iterator().grouped(size).map(fromSpecificIterable)
+    iterator().grouped(size).map(fromSpecificIterable)
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
     *  over them (as opposed to partitioning them, as is done in `grouped`.)
@@ -742,17 +686,17 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     *          if there are fewer than `size` elements remaining to be grouped.
     */
   def sliding(size: Int, step: Int): Iterator[C] =
-    toIterable.iterator().sliding(size, step).map(fromSpecificIterable)
+    iterator().sliding(size, step).map(fromSpecificIterable)
 
   /** The rest of the collection without its first element. */
   def tail: C = {
-    if (toIterable.isEmpty) throw new UnsupportedOperationException
+    if (isEmpty) throw new UnsupportedOperationException
     drop(1)
   }
 
   /** The initial part of the collection without its last element. */
   def init: C = {
-    if (toIterable.isEmpty) throw new UnsupportedOperationException
+    if (isEmpty) throw new UnsupportedOperationException
     dropRight(1)
   }
 
@@ -788,7 +732,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     */
   def groupBy[K](f: A => K): immutable.Map[K, C] = {
     val m = mutable.Map.empty[K, Builder[A, C]]
-    for (elem <- toIterable) {
+    for (elem <- this) {
       val key = f(elem)
       val bldr = m.getOrElseUpdate(key, newSpecificBuilder())
       bldr += elem
@@ -820,7 +764,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     */
   def groupMap[K, B](key: A => K)(f: A => B): immutable.Map[K, CC[B]] = {
     val m = mutable.Map.empty[K, Builder[B, CC[B]]]
-    for (elem <- toIterable) {
+    for (elem <- this) {
       val k = key(elem)
       val bldr = m.getOrElseUpdate(k, iterableFactory.newBuilder[B]())
       bldr += f(elem)
@@ -846,7 +790,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     */
   def groupMapReduce[K, B](key: A => K)(f: A => B)(reduce: (B, B) => B): immutable.Map[K, B] = {
     val m = mutable.Map.empty[K, B]
-    for (elem <- toIterable) {
+    for (elem <- this) {
       val k = key(elem)
       val v =
         m.get(k) match {
@@ -941,7 +885,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     *  @example    `Seq("a", 1, 5L).collectFirst({ case x: Int => x*10 }) = Some(10)`
     */
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
-    val i: Iterator[A] = toIterable.iterator()
+    val i: Iterator[A] = iterator()
     // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself
     // (Tested to be lower-overhead than runWith.  Would be better yet to not need to (formally) allocate it)
     val sentinel: scala.Function1[A, Any] = new scala.runtime.AbstractFunction1[A, Any]{ def apply(a: A) = this }

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -2,7 +2,7 @@ package strawman.collection
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
-import scala.{Any, Array, Boolean, IllegalArgumentException, Int, NoSuchElementException, None, Nothing, Option, PartialFunction, Some, StringContext, Unit, `inline`, math, throws}
+import scala.{Any, Array, Boolean, IllegalArgumentException, Int, NoSuchElementException, None, Nothing, Numeric, Option, Ordering, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, `inline`, math, throws}
 import scala.Predef.{identity, intWrapper, require, String}
 import strawman.collection.mutable.{ArrayBuffer, StringBuilder}
 
@@ -434,6 +434,248 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       i += 1
     }
     -1
+  }
+
+  /** Reduces the elements of this $coll using the specified associative binary operator.
+    *
+    *  $undefinedorder
+    *
+    *  @tparam B      A type parameter for the binary operator, a supertype of `A`.
+    *  @param op       A binary operator that must be associative.
+    *  @return         The result of applying reduce operator `op` between all the elements if the $coll is nonempty.
+    *  @throws UnsupportedOperationException
+    *  if this $coll is empty.
+    */
+  def reduce[B >: A](op: (B, B) => B): B = reduceLeft(op)
+
+  /** Reduces the elements of this $coll, if any, using the specified
+    *  associative binary operator.
+    *
+    *  $undefinedorder
+    *
+    *  @tparam B     A type parameter for the binary operator, a supertype of `A`.
+    *  @param op      A binary operator that must be associative.
+    *  @return        An option value containing result of applying reduce operator `op` between all
+    *                 the elements if the collection is nonempty, and `None` otherwise.
+    */
+  def reduceOption[B >: A](op: (B, B) => B): Option[B] = reduceLeftOption(op)
+
+  /** Applies a binary operator to all elements of this $coll,
+    *  going left to right.
+    *  $willNotTerminateInf
+    *  $orderDependentFold
+    *
+    *  @param  op    the binary operator.
+    *  @tparam  B    the result type of the binary operator.
+    *  @return  the result of inserting `op` between consecutive elements of this $coll,
+    *           going left to right:
+    *           {{{
+    *             op( op( ... op(x_1, x_2) ..., x_{n-1}), x_n)
+    *           }}}
+    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+    *  @throws UnsupportedOperationException if this $coll is empty.   */
+  def reduceLeft[B >: A](op: (B, A) => B): B = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.reduceLeft")
+
+    var first = true
+    var acc: B = 0.asInstanceOf[B]
+
+    for (x <- this) {
+      if (first) {
+        acc = x
+        first = false
+      }
+      else acc = op(acc, x)
+    }
+    acc
+  }
+
+  // For internal use
+  protected[this] def reversed: Iterable[A] = {
+    var xs: immutable.List[A] = immutable.Nil
+    val it = iterator()
+    while (it.hasNext) xs = it.next() :: xs
+    xs
+  }
+
+  /** Applies a binary operator to all elements of this $coll, going right to left.
+    *  $willNotTerminateInf
+    *  $orderDependentFold
+    *
+    *  @param  op    the binary operator.
+    *  @tparam  B    the result type of the binary operator.
+    *  @return  the result of inserting `op` between consecutive elements of this $coll,
+    *           going right to left:
+    *           {{{
+    *             op(x_1, op(x_2, ..., op(x_{n-1}, x_n)...))
+    *           }}}
+    *           where `x,,1,,, ..., x,,n,,` are the elements of this $coll.
+    *  @throws UnsupportedOperationException if this $coll is empty.
+    */
+  def reduceRight[B >: A](op: (A, B) => B): B = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.reduceRight")
+
+    reversed.reduceLeft[B]((x, y) => op(y, x))
+  }
+
+  /** Optionally applies a binary operator to all elements of this $coll, going left to right.
+    *  $willNotTerminateInf
+    *  $orderDependentFold
+    *
+    *  @param  op    the binary operator.
+    *  @tparam  B    the result type of the binary operator.
+    *  @return  an option value containing the result of `reduceLeft(op)` if this $coll is nonempty,
+    *           `None` otherwise.
+    */
+  def reduceLeftOption[B >: A](op: (B, A) => B): Option[B] = if (isEmpty) None else Some(reduceLeft(op))
+
+  /** Optionally applies a binary operator to all elements of this $coll, going
+    *  right to left.
+    *  $willNotTerminateInf
+    *  $orderDependentFold
+    *
+    *  @param  op    the binary operator.
+    *  @tparam  B    the result type of the binary operator.
+    *  @return  an option value containing the result of `reduceRight(op)` if this $coll is nonempty,
+    *           `None` otherwise.
+    */
+  def reduceRightOption[B >: A](op: (A, B) => B): Option[B] = if (isEmpty) None else Some(reduceRight(op))
+
+  /** Sums up the elements of this collection.
+    *
+    *   @param   num  an implicit parameter defining a set of numeric operations
+    *                 which includes the `+` operator to be used in forming the sum.
+    *   @tparam  B    the result type of the `+` operator.
+    *   @return       the sum of all elements of this $coll with respect to the `+` operator in `num`.
+    *
+    *   @usecase def sum: A
+    *     @inheritdoc
+    *
+    *     @return       the sum of all elements in this $coll of numbers of type `Int`.
+    *     Instead of `Int`, any other type `T` with an implicit `Numeric[T]` implementation
+    *     can be used as element type of the $coll and as result type of `sum`.
+    *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
+    *
+    */
+  def sum[B >: A](implicit num: Numeric[B]): B = foldLeft(num.zero)(num.plus)
+
+  /** Multiplies up the elements of this collection.
+    *
+    *   @param   num  an implicit parameter defining a set of numeric operations
+    *                 which includes the `*` operator to be used in forming the product.
+    *   @tparam  B   the result type of the `*` operator.
+    *   @return       the product of all elements of this $coll with respect to the `*` operator in `num`.
+    *
+    *   @usecase def product: A
+    *     @inheritdoc
+    *
+    *     @return       the product of all elements in this $coll of numbers of type `Int`.
+    *     Instead of `Int`, any other type `T` with an implicit `Numeric[T]` implementation
+    *     can be used as element type of the $coll and as result type of `product`.
+    *     Examples of such types are: `Long`, `Float`, `Double`, `BigInt`.
+    */
+  def product[B >: A](implicit num: Numeric[B]): B = foldLeft(num.one)(num.times)
+
+  /** Finds the smallest element.
+    *
+    *  @param    ord   An ordering to be used for comparing elements.
+    *  @tparam   B    The type over which the ordering is defined.
+    *  @return   the smallest element of this $coll with respect to the ordering `ord`.
+    *
+    *  @usecase def min: A
+    *    @inheritdoc
+    *
+    *    @return   the smallest element of this $coll
+    */
+  def min[B >: A](implicit ord: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.min")
+
+    reduceLeft((x, y) => if (ord.lteq(x, y)) x else y)
+  }
+
+  /** Finds the largest element.
+    *
+    *  @param    ord   An ordering to be used for comparing elements.
+    *  @tparam   B    The type over which the ordering is defined.
+    *  @return   the largest element of this $coll with respect to the ordering `ord`.
+    *
+    *  @usecase def max: A
+    *    @inheritdoc
+    *
+    *    @return   the largest element of this $coll.
+    */
+  def max[B >: A](implicit ord: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.max")
+
+    reduceLeft((x, y) => if (ord.gteq(x, y)) x else y)
+  }
+
+  /** Finds the first element which yields the largest value measured by function f.
+    *
+    *  @param    cmp   An ordering to be used for comparing elements.
+    *  @tparam   B     The result type of the function f.
+    *  @param    f     The measuring function.
+    *  @return   the first element of this $coll with the largest value measured by function f
+    *  with respect to the ordering `cmp`.
+    *
+    *  @usecase def maxBy[B](f: A => B): A
+    *    @inheritdoc
+    *
+    *    @return   the first element of this $coll with the largest value measured by function f.
+    */
+  def maxBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.maxBy")
+
+    var maxF: B = null.asInstanceOf[B]
+    var maxElem: A = null.asInstanceOf[A]
+    var first = true
+
+    for (elem <- this) {
+      val fx = f(elem)
+      if (first || cmp.gt(fx, maxF)) {
+        maxElem = elem
+        maxF = fx
+        first = false
+      }
+    }
+    maxElem
+  }
+
+  /** Finds the first element which yields the smallest value measured by function f.
+    *
+    *  @param    cmp   An ordering to be used for comparing elements.
+    *  @tparam   B     The result type of the function f.
+    *  @param    f     The measuring function.
+    *  @return   the first element of this $coll with the smallest value measured by function f
+    *  with respect to the ordering `cmp`.
+    *
+    *  @usecase def minBy[B](f: A => B): A
+    *    @inheritdoc
+    *
+    *    @return   the first element of this $coll with the smallest value measured by function f.
+    */
+  def minBy[B](f: A => B)(implicit cmp: Ordering[B]): A = {
+    if (isEmpty)
+      throw new UnsupportedOperationException("empty.minBy")
+
+    var minF: B = null.asInstanceOf[B]
+    var minElem: A = null.asInstanceOf[A]
+    var first = true
+
+    for (elem <- this) {
+      val fx = f(elem)
+      if (first || cmp.lt(fx, minF)) {
+        minElem = elem
+        minF = fx
+        first = false
+      }
+    }
+    minElem
   }
 
   def length: Int = {

--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -142,7 +142,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     *  @return an iterator over all keys.
     */
   def keysIterator(): Iterator[K] = new Iterator[K] {
-    val iter = toIterable.iterator()
+    val iter = MapOps.this.iterator()
     def hasNext = iter.hasNext
     def next() = iter.next()._1
   }
@@ -152,7 +152,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     *  @return an iterator over all values that are associated with some key in this map.
     */
   def valuesIterator(): Iterator[V] = new Iterator[V] {
-    val iter = toIterable.iterator()
+    val iter = MapOps.this.iterator()
     def hasNext = iter.hasNext
     def next() = iter.next()._2
   }
@@ -233,7 +233,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   override def toString(): String = super[IterableOps].toString()
 
   override def mkString(start: String, sep: String, end: String): String =
-    toIterable.iterator().map { case (k, v) => s"$k -> $v" }.mkString(start, sep, end)
+    iterator().map { case (k, v) => s"$k -> $v" }.mkString(start, sep, end)
 
 }
 

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -2,7 +2,7 @@ package strawman.collection
 
 import scala.{Any, AnyRef, Array, Boolean, Equals, IndexOutOfBoundsException, Int, NoSuchElementException, Ordering, Unit, math, throws, `inline`, deprecated, PartialFunction}
 import scala.Predef.{identity, intWrapper}
-import java.lang.Object
+import java.lang.{Object, String}
 
 import strawman.collection.immutable.Range
 
@@ -50,6 +50,8 @@ trait Seq[+A]
     MurmurHash3.finalizeHash(h, n)
   }
 
+  override def toString(): String = super[Iterable].toString()
+
 }
 
 /**
@@ -79,7 +81,7 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
   * @define coll sequence
   * @define Coll `Seq`
   */
-trait SeqOps[+A, +CC[X], +C] extends Any
+trait SeqOps[+A, +CC[_], +C] extends Any
   with IterableOps[A, CC, C]
   with ArrayLike[A] {
 
@@ -197,7 +199,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     * @tparam B the type of the elements after being transformed by `f`
     * @return a new $coll consisting of all the elements of this $coll without duplicates.
     */
-  def distinctBy[B](f: A => B): C = fromSpecificIterable(new View.DistinctBy(toIterable, f))
+  def distinctBy[B](f: A => B): C = fromSpecificIterable(View.DistinctBy(toIterable, f))
 
   /** Returns new $coll with elements in reversed order.
    *
@@ -228,7 +230,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *         index `offset`, otherwise `false`.
     */
   def startsWith[B >: A](that: IterableOnce[B], offset: Int = 0): Boolean = {
-    val i = toIterable.iterator() drop offset
+    val i = iterator() drop offset
     val j = that.iterator()
     while (j.hasNext && i.hasNext)
       if (i.next() != j.next())
@@ -243,7 +245,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
     */
   def endsWith[B >: A](that: Iterable[B]): Boolean = {
-    val i = toIterable.iterator().drop(length - that.size)
+    val i = iterator().drop(length - that.size)
     val j = that.iterator()
     while (i.hasNext && j.hasNext)
       if (i.next() != j.next())
@@ -282,7 +284,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *  @return  the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
     *           or `-1`, if none exists.
     */
-  def indexWhere(p: A => Boolean, from: Int = 0): Int = toIterable.iterator().indexWhere(p, from)
+  def indexWhere(p: A => Boolean, from: Int = 0): Int = iterator().indexWhere(p, from)
 
   /** Finds index of first occurrence of some value in this $coll after or at some start index.
     *
@@ -639,7 +641,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     * as those of `that`?
     */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean =
-    toIterable.iterator().sameElements(that)
+    iterator().sameElements(that)
 
   /** Tests whether every element of this $coll relates to the
     * corresponding element of another sequence by satisfying a test predicate.
@@ -652,7 +654,7 @@ trait SeqOps[+A, +CC[X], +C] extends Any
     *                  and `y` of `that`, otherwise `false`.
     */
   def corresponds[B](that: Seq[B])(p: (A, B) => Boolean): Boolean = {
-    val i = toIterable.iterator()
+    val i = iterator()
     val j = that.iterator()
     while (i.hasNext && j.hasNext)
       if (!p(i.next(), j.next()))

--- a/collections/src/main/scala/strawman/collection/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/SortedMap.scala
@@ -20,8 +20,55 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2]
 
+  /**
+    * Creates an iterator over all the key/value pairs
+    * contained in this map having a key greater than or
+    * equal to `start` according to the ordering of
+    * this map. x.iteratorFrom(y) is equivalent
+    * to but often more efficient than x.from(y).iterator.
+    *
+    * @param start The lower bound (inclusive)
+    * on the keys to be returned
+    */
+  def iteratorFrom(start: K): Iterator[(K, V)]
+
+  /**
+    * Creates an iterator over all the keys(or elements)  contained in this
+    * collection greater than or equal to `start`
+    * according to the ordering of this collection. x.keysIteratorFrom(y)
+    * is equivalent to but often more efficient than
+    * x.from(y).keysIterator.
+    *
+    * @param start The lower bound (inclusive)
+    * on the keys to be returned
+    */
+  def keysIteratorFrom(start: K): Iterator[K]
+
+  /**
+    * Creates an iterator over all the values contained in this
+    * map that are associated with a key greater than or equal to `start`
+    * according to the ordering of this map. x.valuesIteratorFrom(y) is
+    * equivalent to but often more efficient than
+    * x.from(y).valuesIterator.
+    *
+    * @param start The lower bound (inclusive)
+    * on the keys to be returned
+    */
+  def valuesIteratorFrom(start: K): Iterator[V] = iteratorFrom(start).map(_._2)
+
   def firstKey: K = head._1
   def lastKey: K = last._1
+
+  def rangeTo(to: K): C = {
+    val i = keySet.from(to).iterator()
+    if (i.isEmpty) return coll
+    val next = i.next()
+    if (ordering.compare(next, to) == 0)
+      if (i.isEmpty) coll
+      else until(i.next())
+    else
+      until(next)
+  }
 
   override def keySet: SortedSet[K] = new KeySortedSet
 
@@ -43,7 +90,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   /** A generic trait that is reused by sorted keyset implementations */
   protected trait GenKeySortedSet extends GenKeySet { this: SortedSet[K] =>
     implicit def ordering: Ordering[K] = SortedMapOps.this.ordering
-    def keysIteratorFrom(start: K): Iterator[K] = SortedMapOps.this.keysIteratorFrom(start)
+    def iteratorFrom(start: K): Iterator[K] = SortedMapOps.this.keysIteratorFrom(start)
   }
 
   override def withFilter(p: ((K, V)) => Boolean): SortedMapWithFilter = new SortedMapWithFilter(p)

--- a/collections/src/main/scala/strawman/collection/SortedOps.scala
+++ b/collections/src/main/scala/strawman/collection/SortedOps.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import scala.{Ordering, Option, Some}
+import scala.{None, Ordering, Option, Some}
 
 /** Base trait for sorted collections */
 trait SortedOps[A, +C] {
@@ -12,18 +12,6 @@ trait SortedOps[A, +C] {
 
   /** Returns the last key of the collection. */
   def lastKey: A
-
-  /**
-    * Creates an iterator over all the keys(or elements)  contained in this
-    * collection greater than or equal to `start`
-    * according to the ordering of this collection. x.keysIteratorFrom(y)
-    * is equivalent to but often more efficient than
-    * x.from(y).keysIterator.
-    *
-    * @param start The lower bound (inclusive)
-    * on the keys to be returned
-    */
-  def keysIteratorFrom(start: A): Iterator[A]
 
   /** Creates a ranged projection of this collection. Any mutations in the
     *  ranged projection will update this collection and vice versa.
@@ -46,4 +34,22 @@ trait SortedOps[A, +C] {
     *  @param until The upper-bound (exclusive) of the ranged projection.
     */
   def range(from: A, until: A): C = rangeImpl(Some(from), Some(until))
+
+  /** Creates a ranged projection of this collection with no upper-bound.
+    *
+    *  @param from The lower-bound (inclusive) of the ranged projection.
+    */
+  def from(from: A): C = rangeImpl(Some(from), None)
+
+  /** Creates a ranged projection of this collection with no lower-bound.
+    *
+    *  @param until The upper-bound (exclusive) of the ranged projection.
+    */
+  def until(until: A): C = rangeImpl(None, Some(until))
+
+  /** Create a range projection of this collection with no lower-bound.
+    *  @param to The upper-bound (inclusive) of the ranged projection.
+    */
+  def rangeTo(to: A): C
+
 }

--- a/collections/src/main/scala/strawman/collection/SortedSet.scala
+++ b/collections/src/main/scala/strawman/collection/SortedSet.scala
@@ -14,8 +14,29 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 
   protected[this] def sortedFromIterable[B: Ordering](it: Iterable[B]): CC[B]
 
+  /**
+    * Creates an iterator that contains all values from this collection
+    * greater than or equal to `start` according to the ordering of
+    * this collection. x.iteratorFrom(y) is equivalent to but will usually
+    * be more efficient than x.from(y).iterator
+    *
+    * @param start The lower-bound (inclusive) of the iterator
+    */
+  def iteratorFrom(start: A): Iterator[A]
+
   def firstKey: A = head
   def lastKey: A = last
+
+  def rangeTo(to: A): C = {
+    val i = from(to).iterator()
+    if (i.isEmpty) return coll
+    val next = i.next()
+    if (ordering.compare(next, to) == 0)
+      if (i.isEmpty) coll
+      else until(i.next())
+    else
+      until(next)
+  }
 
   override def withFilter(p: A => Boolean): SortedWithFilter = new SortedWithFilter(p)
 

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -17,14 +17,14 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   /** Optimized, push-based version of `partition`. */
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder()
-    toIterable.iterator().foreach(x => (if (p(x)) l else r) += x)
+    iterator().foreach(x => (if (p(x)) l else r) += x)
     (l.result(), r.result())
   }
 
   override def span(p: A => Boolean): (C, C) = {
     val first = newSpecificBuilder()
     val second = newSpecificBuilder()
-    val it = toIterable.iterator()
+    val it = iterator()
     var inFirst = true
     while (it.hasNext && inFirst) {
       val a = it.next()
@@ -44,7 +44,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   override def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (CC[A1], CC[A2]) = {
     val first = iterableFactory.newBuilder[A1]()
     val second = iterableFactory.newBuilder[A2]()
-    toIterable.foreach { a =>
+    foreach { a =>
       val (a1, a2) = asPair(a)
       first += a1
       second += a2

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
@@ -12,7 +12,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     val builder = newSpecificBuilder()
     val seen = mutable.HashSet.empty[B]
 
-    for (x <- toIterable) {
+    for (x <- this) {
       val y = f(x)
       if (!seen.contains(y)) {
         seen += y

--- a/collections/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
@@ -17,7 +17,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size + 1)
     }
     b += elem
-    b ++= toIterable
+    b ++= this
     b.result()
   }
 
@@ -26,7 +26,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
     if (knownSize >= 0) {
       b.sizeHint(size + 1)
     }
-    b ++= toIterable
+    b ++= this
     b += elem
     b.result()
   }
@@ -38,7 +38,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b.sizeHint(size)
     }
     var i = 0
-    val it = toIterable.iterator()
+    val it = iterator()
     while (i < index && it.hasNext) {
       b += it.next()
       i += 1
@@ -53,7 +53,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] = {
     val b = iterableFactory.newBuilder[B]()
     var i = 0
-    val it = toIterable.iterator()
+    val it = iterator()
     while (i < from && it.hasNext) {
       b += it.next()
       i += 1

--- a/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -52,6 +52,10 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def keysIteratorFrom(start: K): collection.Iterator[K] = RB.keysIterator(tree, Some(start))
 
+  def iteratorFrom(start: K): Iterator[(K, V)] = RB.iterator(tree, Some(start))
+
+  override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
+
   def get(key: K): Option[V] = RB.get(tree, key)
 
   def remove(key: K): TreeMap[K,V] =

--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -97,7 +97,7 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
 
   def iterator(): Iterator[A] = RB.keysIterator(tree)
 
-  def keysIteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
+  def iteratorFrom(start: A): Iterator[A] = RB.keysIterator(tree, Some(start))
 
   def unordered: Set[A] = this
 

--- a/collections/src/main/scala/strawman/collection/mutable/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Seq.scala
@@ -1,14 +1,22 @@
 package strawman.collection.mutable
 
-import scala.{Int, Long, Unit, Boolean, Array, throws, IndexOutOfBoundsException, IllegalArgumentException}
+import scala.{Array, Boolean, IllegalArgumentException, IndexOutOfBoundsException, Int, Long, Unit, throws}
 import strawman.collection
-import strawman.collection.{IterableOnce, toNewSeq, toOldSeq}
+import strawman.collection.{IterableOnce, SeqFactory, toNewSeq, toOldSeq}
+
 import scala.Predef.intWrapper
 
 trait Seq[A]
   extends Iterable[A]
     with collection.Seq[A]
     with SeqOps[A, Seq, Seq[A]]
+
+/**
+  * $factoryInfo
+  * @define coll mutable sequence
+  * @define Coll `mutable.Seq`
+  */
+object Seq extends SeqFactory.Delegate[Seq](ArrayBuffer)
 
 /**
   * @define coll mutable sequence

--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -48,6 +48,10 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def keysIteratorFrom(start: K): Iterator[K] = RB.keysIterator(tree, Some(start))
 
+  def iteratorFrom(start: K): Iterator[(K, V)] = RB.iterator(tree, Some(start))
+
+  override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
+
   def empty: TreeMap[K, V] = TreeMap.empty
 
   def add(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
@@ -139,6 +143,8 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
     override def iterator() = RB.iterator(tree, from, until)
     override def keysIteratorFrom(start: K) = RB.keysIterator(tree, pickLowerBound(Some(start)), until)
+    override def iteratorFrom(start: K) = RB.iterator(tree, pickLowerBound(Some(start)), until)
+    override def valuesIteratorFrom(start: K) = RB.valuesIterator(tree, pickLowerBound(Some(start)), until)
 
     override def size = iterator().length
     override def isEmpty = !iterator().hasNext

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -50,7 +50,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def sortedIterableFactory = TreeSet
 
-  def keysIteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
+  def iteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
 
   def empty: TreeSet[A] = TreeSet.empty
 
@@ -136,8 +136,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     override def contains(key: A) = isInsideViewBounds(key) && RB.contains(tree, key)
 
     override def iterator() = RB.keysIterator(tree, from, until)
-    override def keysIteratorFrom(start: A) = RB.keysIterator(tree, pickLowerBound(Some(start)), until)
-//    override def iteratorFrom(start: A) = RB.keysIterator(tree, pickLowerBound(Some(start)), until)
+    override def iteratorFrom(start: A) = RB.keysIterator(tree, pickLowerBound(Some(start)), until)
 
     override def size = iterator().length
     override def isEmpty = !iterator().hasNext

--- a/test/scalacheck/src/test/scala/CheckCollections.scala
+++ b/test/scalacheck/src/test/scala/CheckCollections.scala
@@ -1,7 +1,9 @@
 import org.scalacheck.Properties
 import org.scalacheck.Prop._
 
-import scala.reflect.internal.util.Collections._
+import strawman.reflect.internal.util.Collections._
+import strawman.collection.immutable.{List, Nil}
+import strawman.collection.Generators._
 
 object CheckCollectionsTest extends Properties("reflect.internal.util.Collections") {
   def map2ConserveOld[A <: AnyRef, B](xs: List[A], ys: List[B])(f: (A, B) => A): List[A] =

--- a/test/scalacheck/src/test/scala/Ctrie.scala
+++ b/test/scalacheck/src/test/scala/Ctrie.scala
@@ -1,10 +1,8 @@
 import org.scalacheck._
 import Prop._
 import org.scalacheck.Gen._
-import collection._
-import collection.concurrent.TrieMap
-
-
+import strawman.collection.Map
+import strawman.collection.concurrent.TrieMap
 
 case class Wrap(i: Int) {
   override def hashCode = i // * 0x9e3775cd

--- a/test/scalacheck/src/test/scala/array-new.scala
+++ b/test/scalacheck/src/test/scala/array-new.scala
@@ -7,6 +7,10 @@ import util._
 import Buildable._
 import scala.collection.mutable.ArraySeq
 
+import scala.Predef.{ refArrayOps => _, genericArrayOps => _, genericWrapArray => _, wrapRefArray => _, _ }
+import strawman.collection.arrayToArrayOps
+import strawman.collection.IterableOnce
+
 object ArrayNewTest extends Properties("Array") {
   /** At this moment the authentic scalacheck Array Builder/Arb bits are commented out.
    */
@@ -31,7 +35,7 @@ object ArrayNewTest extends Properties("Array") {
   def smallInt = choose(1, 10)
   property("ofDim") = forAll(smallInt, smallInt, smallInt) { (i1, i2, i3) =>
     val arr = Array.ofDim[String](i1, i2, i3)
-    val flattened = arr flatMap (x => x) flatMap (x => x)
+    val flattened = arr flatMap (x => (x: IterableOnce[Array[String]])) flatMap (x => x: IterableOnce[String])
     flattened.length == i1 * i2 * i3
   }
 }

--- a/test/scalacheck/src/test/scala/array-old.scala
+++ b/test/scalacheck/src/test/scala/array-old.scala
@@ -6,6 +6,10 @@ import util._
 import Buildable._
 import scala.collection.mutable.ArraySeq
 
+import scala.Predef.{ refArrayOps => _, genericArrayOps => _, genericWrapArray => _, wrapRefArray => _, _ }
+import strawman.collection.arrayToArrayOps
+import strawman.collection.IterableOnce
+
 object ArrayOldTest extends Properties("Array") {
   /** At this moment the authentic scalacheck Array Builder/Arb bits are commented out.
    */
@@ -30,7 +34,7 @@ object ArrayOldTest extends Properties("Array") {
   def smallInt = choose(1, 10)
   property("ofDim") = forAll(smallInt, smallInt, smallInt) { (i1, i2, i3) =>
     val arr = Array.ofDim[String](i1, i2, i3)
-    val flattened = arr flatMap (x => x) flatMap (x => x)
+    val flattened = arr flatMap (x => (x: IterableOnce[Array[String]])) flatMap (x => x: IterableOnce[String])
     flattened.length == i1 * i2 * i3
   }
 }

--- a/test/scalacheck/src/test/scala/concurrent-map.scala
+++ b/test/scalacheck/src/test/scala/concurrent-map.scala
@@ -26,17 +26,20 @@ object ConcurrentMapTest extends Properties("concurrent.TrieMap") {
   /* helpers */
 
   def inParallel[T](totalThreads: Int)(body: Int => T): Seq[T] = {
-    val threads = for (idx <- 0 until totalThreads) yield new Thread {
+
+    class Make(idx: Int) extends Thread {
       setName("ParThread-" + idx)
       private var res: T = _
       override def run(): Unit = {
         res = body(idx)
       }
-      def result = {
+      def result: T = {
         this.join()
         res
       }
     }
+
+    val threads = for (idx <- 0 until totalThreads) yield new Make(idx)
 
     threads foreach (_.start())
     threads map (_.result)

--- a/test/scalacheck/src/test/scala/list.scala
+++ b/test/scalacheck/src/test/scala/list.scala
@@ -2,6 +2,10 @@ import org.scalacheck._
 import Prop._
 import Gen._
 
+import strawman.collection.immutable.List
+import strawman.collection.Set
+import strawman.collection.Generators._
+
 object ListTest extends Properties("List") {
   def sorted(xs: List[Int]) = xs sortWith (_ < _)
 

--- a/test/scalacheck/src/test/scala/range.scala
+++ b/test/scalacheck/src/test/scala/range.scala
@@ -3,6 +3,9 @@ import Prop._
 import Gen._
 import Arbitrary._
 
+import strawman.collection.immutable.Range
+import strawman.collection.Set
+
 class Counter(r: Range) {
   var cnt = 0L
   var last: Option[Int] = None
@@ -62,7 +65,7 @@ abstract class RangeTest(kind: String) extends Properties("Range "+kind) {
     if (r.end.toLong - r.start.toLong).abs <= 10000000L
   } yield if (r.start < r.end) Range(r.start, r.end) else Range(r.end, r.start)
 
-  def genRangeClosedByOne = for (r <- genRangeOpenByOne) yield r.start to r.end
+  def genRangeClosedByOne = for (r <- genRangeOpenByOne) yield Range.inclusive(r.start, r.end)
 
   def str(r: Range) = "Range["+r.start+", "+r.end+", "+r.step+(if (r.isInclusive) "]" else ")")
 

--- a/test/scalacheck/src/test/scala/redblacktree.scala
+++ b/test/scalacheck/src/test/scala/redblacktree.scala
@@ -1,6 +1,6 @@
-package scala.collection.immutable.redblacktree
+package strawman.collection.immutable.redblacktree
 
-import collection.immutable.{RedBlackTree => RB}
+import strawman.collection.immutable.{RedBlackTree => RB, List}
 import org.scalacheck._
 import Prop._
 import Gen._
@@ -24,7 +24,7 @@ abstract class RedBlackTreeTest extends Properties("RedBlackTree") {
   import RB._
 
   def nodeAt[A](tree: Tree[String, A], n: Int): Option[(String, A)] = if (n < iterator(tree).size && n >= 0)
-    Some(iterator(tree).drop(n).next)
+    Some(iterator(tree).drop(n).next())
   else
     None
 
@@ -199,11 +199,10 @@ object TestRange extends RedBlackTreeTest with RedBlackTreeInvariants  {
   property("range returns all elements") = forAll(genInput) { case (tree, parm, newTree) =>
     val from = parm._1 flatMap (nodeAt(tree, _) map (_._1))
     val to = parm._2 flatMap (nodeAt(tree, _) map (_._1))
-    val filteredTree = (keysIterator(tree)
+    val filteredTree = List.from(keysIterator(tree)
       .filter(key => from forall (key >=))
-      .filter(key => to forall (key <))
-      .toList)
-    filteredTree == keysIterator(newTree).toList
+      .filter(key => to forall (key <)))
+    filteredTree == List.from(keysIterator(newTree))
   }
 }
 
@@ -215,7 +214,7 @@ object TestDrop extends RedBlackTreeTest with RedBlackTreeInvariants  {
   override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] = drop(tree, parm)
 
   property("drop") = forAll(genInput) { case (tree, parm, newTree) =>
-    iterator(tree).drop(parm).toList == iterator(newTree).toList
+    List.from(iterator(tree).drop(parm)) == List.from(iterator(newTree))
   }
 }
 
@@ -227,7 +226,7 @@ object TestTake extends RedBlackTreeTest with RedBlackTreeInvariants  {
   override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] = take(tree, parm)
 
   property("take") = forAll(genInput) { case (tree, parm, newTree) =>
-    iterator(tree).take(parm).toList == iterator(newTree).toList
+    List.from(iterator(tree).take(parm)) == List.from(iterator(newTree))
   }
 }
 
@@ -242,6 +241,6 @@ object TestSlice extends RedBlackTreeTest with RedBlackTreeInvariants  {
   override def modify(tree: Tree[String, Int], parm: ModifyParm): Tree[String, Int] = slice(tree, parm._1, parm._2)
 
   property("slice") = forAll(genInput) { case (tree, parm, newTree) =>
-    iterator(tree).slice(parm._1, parm._2).toList == iterator(newTree).toList
+    List.from(iterator(tree).slice(parm._1, parm._2)) == List.from(iterator(newTree))
   }
 }

--- a/test/scalacheck/src/test/scala/redblacktree.scala
+++ b/test/scalacheck/src/test/scala/redblacktree.scala
@@ -178,7 +178,7 @@ object TestRange extends RedBlackTreeTest with RedBlackTreeInvariants  {
   override type ModifyParm = (Option[Int], Option[Int])
   override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = for {
     from <- choose(0, iterator(tree).size)
-    to <- choose(0, iterator(tree).size) suchThat (from <=)
+    to <- choose(0, iterator(tree).size) suchThat (from <= _)
     optionalFrom <- oneOf(Some(from), None, Some(from)) // Double Some(n) to get around a bug
     optionalTo <- oneOf(Some(to), None, Some(to)) // Double Some(n) to get around a bug
   } yield (optionalFrom, optionalTo)

--- a/test/scalacheck/src/test/scala/scala/reflect/internal/util/Collections.scala
+++ b/test/scalacheck/src/test/scala/scala/reflect/internal/util/Collections.scala
@@ -3,10 +3,13 @@
  * @author  Paul Phillips
  */
 
-package scala
+package strawman
 package reflect.internal.util
 
-import scala.collection.{ mutable, immutable }
+import strawman.collection.{ mutable, immutable }
+import strawman.collection.immutable.{List, Nil, ::}
+import strawman.collection.{Iterable, Map, toOldSeq}
+
 import scala.annotation.tailrec
 import mutable.ListBuffer
 
@@ -54,7 +57,7 @@ trait Collections {
     var rest = as.tail
     while (rest ne Nil) {
       val next = new ::(f(rest.head), Nil)
-      tail.tl = next
+      tail.next = next
       tail = next
       rest = rest.tail
     }
@@ -148,10 +151,10 @@ trait Collections {
       ys1 = ys1.tail
       ys2 = ys2.tail
     }
-    if (lb eq null) Nil else lb.result
+    if (lb eq null) Nil else lb.toList
   }
 
-  final def flatCollect[A, B](elems: List[A])(pf: PartialFunction[A, Traversable[B]]): List[B] = {
+  final def flatCollect[A, B](elems: List[A])(pf: PartialFunction[A, Iterable[B]]): List[B] = {
     val lb = new ListBuffer[B]
     for (x <- elems ; if pf isDefinedAt x)
       lb ++= pf(x)
@@ -187,15 +190,15 @@ trait Collections {
   }
 
   // @inline
-  final def findOrElse[A](xs: TraversableOnce[A])(p: A => Boolean)(orElse: => A): A = {
+  final def findOrElse[A](xs: Iterable[A])(p: A => Boolean)(orElse: => A): A = {
     xs find p getOrElse orElse
   }
 
   final def mapFrom[A, A1 >: A, B](xs: List[A])(f: A => B): Map[A1, B] = {
-    Map[A1, B](xs map (x => (x, f(x))): _*)
+    Map[A1, B]((xs map (x => (x, f(x)))).toClassic: _*)
   }
   final def linkedMapFrom[A, A1 >: A, B](xs: List[A])(f: A => B): mutable.LinkedHashMap[A1, B] = {
-    mutable.LinkedHashMap[A1, B](xs map (x => (x, f(x))): _*)
+    mutable.LinkedHashMap[A1, B]((xs map (x => (x, f(x)))).toClassic: _*)
   }
 
   final def mapWithIndex[A, B](xs: List[A])(f: (A, Int) => B): List[B] = {

--- a/test/scalacheck/src/test/scala/scan.scala
+++ b/test/scalacheck/src/test/scala/scan.scala
@@ -2,7 +2,10 @@ import org.scalacheck._
 import Prop._
 import Gen._
 
-object ScanTest extends Properties("TraversableLike.scanLeft") {
+import strawman.collection.immutable.List
+import strawman.collection.Generators._
+
+object ScanTest extends Properties("Iterable.scanLeft") {
   property("scanLeft") = forAll { (xs: List[Int], z: Int) => {
     val sums = xs.scanLeft(z)(_ + _)
     (xs.size == 0) || sums.zip(sums.tail).map(x => x._2 - x._1) == xs

--- a/test/scalacheck/src/test/scala/strawman/collection/Generators.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/Generators.scala
@@ -1,0 +1,31 @@
+package strawman.collection
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.listOf
+
+import scala.collection.immutable.{List => ScalaList}
+import strawman.collection.immutable.List
+import org.scalacheck.{Arbitrary, Gen}
+
+object Generators {
+
+  implicit def arbitraryList[A](implicit arbitraryOldList: Arbitrary[ScalaList[A]]): Arbitrary[List[A]] =
+    Arbitrary(arbitraryOldList.arbitrary.map(scalaList => List.from(scalaList.toStrawman)))
+
+  implicit def arbitraryMutableSeq[A](implicit arbitraryOldMutableSeq: Arbitrary[scala.collection.mutable.Seq[A]]): Arbitrary[mutable.Seq[A]] =
+    Arbitrary(arbitraryOldMutableSeq.arbitrary.map(seq => mutable.Seq.from(seq.toStrawman)))
+
+  implicit def arbitraryMutableMap[K, V](implicit arbitraryOldMutableMap: Arbitrary[scala.collection.mutable.Map[K, V]]): Arbitrary[mutable.Map[K, V]] =
+    Arbitrary(arbitraryOldMutableMap.arbitrary.map(m => mutable.Map.from(m.toSeq.toStrawman)))
+
+  implicit def arbitraryMutableSet[A](implicit arbitraryOldMutableSet: Arbitrary[scala.collection.mutable.Set[A]]): Arbitrary[mutable.Set[A]] =
+    Arbitrary(arbitraryOldMutableSet.arbitrary.map(m => mutable.Set.from(m.toSeq.toStrawman)))
+
+  def genTreeSet[A: Arbitrary: Ordering]: Gen[mutable.TreeSet[A]] =
+    for {
+      elements <- listOf(arbitrary[A])
+    } yield mutable.TreeSet(elements: _*)
+  implicit def arbTreeSet[A : Arbitrary : Ordering]: Arbitrary[mutable.TreeSet[A]] = Arbitrary(genTreeSet)
+
+
+}

--- a/test/scalacheck/src/test/scala/t4147.scala
+++ b/test/scalacheck/src/test/scala/t4147.scala
@@ -1,27 +1,26 @@
 import org.scalacheck.Prop.{forAll, throws}
 import org.scalacheck.Properties
 import org.scalacheck.Gen
-
-
-import collection.mutable
+import strawman.collection.{BuildFrom, Set, mutable, toNewSeq, toOldSeq}
+import strawman.collection.immutable.List
 
 
 object SI4147Test extends Properties("Mutable TreeSet") {
 
-  val generator = Gen.listOfN(1000, Gen.chooseNum(0, 1000))
+  val generator = Gen.listOfN(1000, Gen.chooseNum(0, 1000)).map(l => List.from(l.toStrawman))
 
-  val denseGenerator = Gen.listOfN(1000, Gen.chooseNum(0, 200))
+  val denseGenerator = Gen.listOfN(1000, Gen.chooseNum(0, 200)).map(l => List.from(l.toStrawman))
 
   property("Insertion doesn't allow duplicates values.") = forAll(generator) { (s: List[Int]) =>
     {
-      val t = mutable.TreeSet[Int](s: _*)
+      val t = mutable.TreeSet[Int](s.toClassic: _*)
       t == s.toSet
     }
   }
 
   property("Verification of size method validity") = forAll(generator) { (s: List[Int]) =>
     {
-      val t = mutable.TreeSet[Int](s: _*)
+      val t = mutable.TreeSet[Int](s.toClassic: _*)
       for (a <- s) {
         t -= a
       }
@@ -31,7 +30,7 @@ object SI4147Test extends Properties("Mutable TreeSet") {
 
   property("All inserted elements are removed") = forAll(generator) { (s: List[Int]) =>
     {
-      val t = mutable.TreeSet[Int](s: _*)
+      val t = mutable.TreeSet[Int](s.toClassic: _*)
       for (a <- s) {
         t -= a
       }
@@ -41,7 +40,7 @@ object SI4147Test extends Properties("Mutable TreeSet") {
 
   property("Elements are sorted.") = forAll(generator) { (s: List[Int]) =>
     {
-      val t = mutable.TreeSet[Int](s: _*)
+      val t = mutable.TreeSet[Int](s.toClassic: _*)
       t.toList == s.distinct.sorted
     }
   }
@@ -49,15 +48,16 @@ object SI4147Test extends Properties("Mutable TreeSet") {
   property("Implicit CanBuildFrom resolution succeeds as well as the \"same-result-type\" principle.") =
     forAll(generator) { (s: List[Int]) =>
       {
-        val t = mutable.TreeSet[Int](s: _*)
-        val t2 = t.map(_ * 2)
-        t2.isInstanceOf[collection.mutable.TreeSet[Int]]
+        val t = mutable.TreeSet[Int](s.toClassic: _*)
+        def getBuildFrom[C](implicit bf: BuildFrom[t.type, Int, C]) = bf
+        val t2 = getBuildFrom.fromSpecificIterable(t)(List(1, 2, 3))
+        t2.isInstanceOf[mutable.TreeSet[Int]]
       }
     }
 
   property("A view doesn't expose off bounds elements") = forAll(denseGenerator) { (s: List[Int]) =>
     {
-      val t = mutable.TreeSet[Int](s: _*)
+      val t = mutable.TreeSet[Int](s.toClassic: _*)
       val view = t.rangeImpl(Some(50), Some(150))
       view.filter(_ < 50) == Set[Int]() && view.filter(_ >= 150) == Set[Int]()
     }

--- a/test/scalacheck/src/test/scala/treemap.scala
+++ b/test/scalacheck/src/test/scala/treemap.scala
@@ -1,10 +1,13 @@
-import collection.immutable._
+import strawman.collection.immutable._
 import org.scalacheck._
 import Prop._
 import Gen._
 import Arbitrary._
 import util._
 import Buildable._
+
+import strawman.collection.{toOldSeq, Seq}
+import strawman.collection.Generators._
 
 object TreeMapTest extends Properties("TreeMap") {
   def genTreeMap[A: Arbitrary: Ordering, B: Arbitrary]: Gen[TreeMap[A, B]] =
@@ -15,10 +18,10 @@ object TreeMapTest extends Properties("TreeMap") {
   implicit def arbTreeMap[A : Arbitrary : Ordering, B : Arbitrary] = Arbitrary(genTreeMap[A, B])
 
   property("foreach/iterator consistency") = forAll { (subject: TreeMap[Int, String]) =>
-    val it = subject.iterator
+    val it = subject.iterator()
     var consistent = true
     subject.foreach { element =>
-      consistent &&= it.hasNext && element == it.next
+      consistent &&= it.hasNext && element == it.next()
     }
     consistent
   }
@@ -44,27 +47,27 @@ object TreeMapTest extends Properties("TreeMap") {
   }}
 
   property("contains all") = forAll { (arr: List[(Int, String)]) =>
-    val subject = TreeMap(arr: _*)
+    val subject = TreeMap(arr.toClassic: _*)
     arr.map(_._1).forall(subject.contains(_))
   }
 
   property("size") = forAll { (elements: List[(Int, Int)]) =>
-    val subject = TreeMap(elements: _*)
+    val subject = TreeMap(elements.toClassic: _*)
     elements.map(_._1).distinct.size == subject.size
   }
 
   property("toSeq") = forAll { (elements: List[(Int, Int)]) =>
-    val subject = TreeMap(elements: _*)
+    val subject = TreeMap(elements.toClassic: _*)
     elements.map(_._1).distinct.sorted == subject.toSeq.map(_._1)
   }
 
   property("head") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
-    val subject = TreeMap(elements zip elements: _*)
+    val subject = TreeMap((elements zip elements).toClassic: _*)
     elements.min == subject.head._1
   }}
 
   property("last") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
-    val subject = TreeMap(elements zip elements: _*)
+    val subject = TreeMap((elements zip elements).toClassic: _*)
     elements.max == subject.last._1
   }}
 
@@ -132,7 +135,7 @@ object TreeMapTest extends Properties("TreeMap") {
   property("to is inclusive") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
     val n = choose(0, subject.size - 1).sample.get
     val to = subject.drop(n).firstKey
-    subject.to(to).lastKey == to && subject.to(to).forall(_._1 <= to)
+    subject.rangeTo(to).lastKey == to && subject.rangeTo(to).forall(_._1 <= to)
   }}
 
   property("until is exclusive") = forAll { (subject: TreeMap[Int, String]) => subject.size > 1 ==> {
@@ -142,7 +145,7 @@ object TreeMapTest extends Properties("TreeMap") {
   }}
 
   property("remove single") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
-    val key = oneOf(subject.keys.toSeq).sample.get
+    val key = oneOf(subject.keys.toSeq.toClassic).sample.get
     val removed = subject - key
     subject.contains(key) && !removed.contains(key) && subject.size - 1 == removed.size
   }}

--- a/test/scalacheck/src/test/scala/treeset.scala
+++ b/test/scalacheck/src/test/scala/treeset.scala
@@ -1,9 +1,11 @@
-import collection.immutable._
+import strawman.collection.immutable._
 import org.scalacheck._
 import Prop._
 import Gen._
 import Arbitrary._
 import util._
+
+import strawman.collection.Generators._
 
 object TreeSetTest extends Properties("TreeSet") {
   def genTreeSet[A: Arbitrary: Ordering]: Gen[TreeSet[A]] =
@@ -13,10 +15,10 @@ object TreeSetTest extends Properties("TreeSet") {
   implicit def arbTreeSet[A : Arbitrary : Ordering]: Arbitrary[TreeSet[A]] = Arbitrary(genTreeSet)
 
   property("foreach/iterator consistency") = forAll { (subject: TreeSet[Int]) =>
-    val it = subject.iterator
+    val it = subject.iterator()
     var consistent = true
     subject.foreach { element =>
-      consistent &&= it.hasNext && element == it.next
+      consistent &&= it.hasNext && element == it.next()
     }
     consistent
   }
@@ -33,8 +35,8 @@ object TreeSetTest extends Properties("TreeSet") {
     val highest = if (even) (1 << (n+1)) - 2 else 3*(1 << n) - 2
     val values = (1 to highest).reverse
     val subject = TreeSet(values: _*)
-    val it = subject.iterator
-    try { while (it.hasNext) it.next; true } catch { case _: Throwable => false }
+    val it = subject.iterator()
+    try { while (it.hasNext) it.next(); true } catch { case _: Throwable => false }
   }
 
   property("sorted") = forAll { (subject: TreeSet[Int]) => (subject.size >= 3) ==> {
@@ -42,27 +44,27 @@ object TreeSetTest extends Properties("TreeSet") {
   }}
 
   property("contains all") = forAll { (elements: List[Int]) =>
-    val subject = TreeSet(elements: _*)
+    val subject = TreeSet(elements.toClassic: _*)
     elements.forall(subject.contains)
   }
 
   property("size") = forAll { (elements: List[Int]) =>
-    val subject = TreeSet(elements: _*)
+    val subject = TreeSet(elements.toClassic: _*)
     elements.distinct.size == subject.size
   }
 
   property("toSeq") = forAll { (elements: List[Int]) =>
-    val subject = TreeSet(elements: _*)
+    val subject = TreeSet(elements.toClassic: _*)
     elements.distinct.sorted == subject.toSeq
   }
 
   property("head") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
-    val subject = TreeSet(elements: _*)
+    val subject = TreeSet(elements.toClassic: _*)
     elements.min == subject.head
   }}
 
   property("last") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
-    val subject = TreeSet(elements: _*)
+    val subject = TreeSet(elements.toClassic: _*)
     elements.max == subject.last
   }}
 
@@ -130,7 +132,7 @@ object TreeSetTest extends Properties("TreeSet") {
   property("to is inclusive") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
     val n = choose(0, subject.size - 1).sample.get
     val to = subject.drop(n).firstKey
-    subject.to(to).lastKey == to && subject.to(to).forall(_ <= to)
+    subject.rangeTo(to).lastKey == to && subject.rangeTo(to).forall(_ <= to)
   }}
 
   property("until is exclusive") = forAll { (subject: TreeSet[Int]) => subject.size > 1 ==> {
@@ -140,7 +142,7 @@ object TreeSetTest extends Properties("TreeSet") {
   }}
 
   property("remove single") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
-    val element = oneOf(subject.toSeq).sample.get
+    val element = oneOf(subject.toSeq.toClassic).sample.get
     val removed = subject - element
     subject.contains(element) && !removed.contains(element) && subject.size - 1 == removed.size
   }}


### PR DESCRIPTION
Fixes #103.

I’ve adapted the scalacheck tests to use the strawman collections instead of the standard collections.

I’ve fixed a couple of issues I’ve discovered by doing so.

Two collections haven’t been adapted, `UnrolledBuffer` and `PriorityQueue`, because these classes don’t exist in the strawman. We can still enable them afterwards, if we introduce these collections.

Also, the tests against the `java.util.concurrent.ConcurrentHashMap` wrapper haven’t been adapted because the strawman version of this adapter is in #279 (which is unmerged yet).