### PR TITLE
Add back the non-deprecated Java collection converter APIs

### DIFF
--- a/collections/src/main/scala/strawman/collection/JavaConverters.scala
+++ b/collections/src/main/scala/strawman/collection/JavaConverters.scala
@@ -1,0 +1,72 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+
+import convert._
+
+/** A variety of decorators that enable converting between
+ *  Scala and Java collections using extension methods, `asScala` and `asJava`.
+ *
+ *  The extension methods return adapters for the corresponding API.
+ *
+ *  The following conversions are supported via `asScala` and `asJava`:
+ *{{{
+ *    strawman.collection.Iterable       <=> java.lang.Iterable
+ *    strawman.collection.Iterator       <=> java.util.Iterator
+ *    strawman.collection.mutable.Buffer <=> java.util.List
+ *    strawman.collection.mutable.Set    <=> java.util.Set
+ *    strawman.collection.mutable.Map    <=> java.util.Map
+ *    strawman.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
+ *}}}
+ *  The following conversions are supported via `asScala` and through
+ *  specially-named extension methods to convert to Java collections, as shown:
+ *{{{
+ *    strawman.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
+ *    strawman.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
+ *    strawman.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
+ *}}}
+ *  In addition, the following one-way conversions are provided via `asJava`:
+ *{{{
+ *    strawman.collection.Seq         => java.util.List
+ *    strawman.collection.mutable.Seq => java.util.List
+ *    strawman.collection.Set         => java.util.Set
+ *    strawman.collection.Map         => java.util.Map
+ *}}}
+ *  The following one way conversion is provided via `asScala`:
+ *{{{
+ *    java.util.Properties => strawman.collection.mutable.Map
+ *}}}
+ *  In all cases, converting from a source type to a target type and back
+ *  again will return the original source object. For example:
+ *  {{{
+ *    import strawman.collection.JavaConverters._
+ *
+ *    val source = new strawman.collection.mutable.ListBuffer[Int]
+ *    val target: java.util.List[Int] = source.asJava
+ *    val other: strawman.collection.mutable.Buffer[Int] = target.asScala
+ *    assert(source eq other)
+ *  }}}
+ *  Alternatively, the conversion methods have descriptive names and can be invoked explicitly.
+ *  {{{
+ *    scala> val vs = java.util.Arrays.asList("hi", "bye")
+ *    vs: java.util.List[String] = [hi, bye]
+ *
+ *    scala> val ss = asScalaIterator(vs.iterator)
+ *    ss: Iterator[String] = non-empty iterator
+ *
+ *    scala> .toList
+ *    res0: List[String] = List(hi, bye)
+ *
+ *    scala> val ss = asScalaBuffer(vs)
+ *    ss: strawman.collection.mutable.Buffer[String] = Buffer(hi, bye)
+ *  }}}
+ *
+ *  @since  2.8.1
+ */
+object JavaConverters extends DecorateAsJava with DecorateAsScala

--- a/collections/src/main/scala/strawman/collection/convert/AsJavaConverters.scala
+++ b/collections/src/main/scala/strawman/collection/convert/AsJavaConverters.scala
@@ -1,0 +1,265 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+
+/** Defines converter methods from Scala to Java collections. */
+trait AsJavaConverters {
+  import Wrappers._
+
+  /**
+   * Converts a Scala `Iterator` to a Java `Iterator`.
+   *
+   * The returned Java `Iterator` is backed by the provided Scala `Iterator` and any side-effects of
+   * using it via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaIterator]](java.util.Iterator)` then the original Java `Iterator` will
+   * be returned.
+   *
+   * @param i The Scala `Iterator` to be converted.
+   * @return  A Java `Iterator` view of the argument.
+   */
+  def asJavaIterator[A](i: Iterator[A]): ju.Iterator[A] = i match {
+    case null                       => null
+    case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
+    case _                          => IteratorWrapper(i)
+  }
+
+  /**
+   * Converts a Scala `Iterator` to a Java `Enumeration`.
+   *
+   * The returned Java `Enumeration` is backed by the provided Scala `Iterator` and any side-effects
+   * of using it via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.enumerationAsScalaIterator]](java.util.Enumeration)` then the original Java
+   * `Enumeration` will be returned.
+   *
+   * @param i The Scala `Iterator` to be converted.
+   * @return  A Java `Enumeration` view of the argument.
+   */
+  def asJavaEnumeration[A](i: Iterator[A]): ju.Enumeration[A] = i match {
+    case null                         => null
+    case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
+    case _                            => IteratorWrapper(i)
+  }
+
+  /**
+   * Converts a Scala `Iterable` to a Java `Iterable`.
+   *
+   * The returned Java `Iterable` is backed by the provided Scala `Iterable` and any side-effects of
+   * using it via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.iterableAsScalaIterable]](java.lang.Iterable)` then the original Java
+   * `Iterable` will be returned.
+   *
+   * @param i The Scala `Iterable` to be converted.
+   * @return  A Java `Iterable` view of the argument.
+   */
+  def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
+    case null                       => null
+    case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
+    case _                          => IterableWrapper(i)
+  }
+
+  /**
+   * Converts a Scala `Iterable` to an immutable Java `Collection`.
+   *
+   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.collectionAsScalaIterable]](java.util.Collection)` then the original Java
+   * `Collection` will be returned.
+   *
+   * @param i The Scala `Iterable` to be converted.
+   * @return  A Java `Collection` view of the argument.
+   */
+  def asJavaCollection[A](i: Iterable[A]): ju.Collection[A] = i match {
+    case null                         => null
+    case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
+    case _                            => new IterableWrapper(i)
+  }
+
+  /**
+   * Converts a Scala mutable `Buffer` to a Java List.
+   *
+   * The returned Java List is backed by the provided Scala `Buffer` and any side-effects of using
+   * it via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Buffer` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
+   *
+   * @param b The Scala `Buffer` to be converted.
+   * @return A Java `List` view of the argument.
+   */
+  def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableBufferWrapper(b)
+  }
+
+  /**
+   * Converts a Scala mutable `Seq` to a Java `List`.
+   *
+   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
+   *
+   * @param s The Scala `Seq` to be converted.
+   * @return  A Java `List` view of the argument.
+   */
+  def mutableSeqAsJavaList[A](s: mutable.Seq[A]): ju.List[A] = s match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableSeqWrapper(s)
+  }
+
+  /**
+   * Converts a Scala `Seq` to a Java `List`.
+   *
+   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaBuffer]](java.util.List)` then the original Java `List` will be
+   * returned.
+   *
+   * @param s The Scala `Seq` to be converted.
+   * @return  A Java `List` view of the argument.
+   */
+  def seqAsJavaList[A](s: Seq[A]): ju.List[A] = s match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
+    case _                      => new SeqWrapper(s)
+  }
+
+  /**
+   * Converts a Scala mutable `Set` to a Java `Set`.
+   *
+   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaSet]](java.util.Set)` then the original Java `Set` will be returned.
+   *
+   * @param s The Scala mutable `Set` to be converted.
+   * @return  A Java `Set` view of the argument.
+   */
+  def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
+    case null                 => null
+    case JSetWrapper(wrapped) => wrapped
+    case _                    => new MutableSetWrapper(s)
+  }
+
+  /**
+   * Converts a Scala `Set` to a Java `Set`.
+   *
+   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asScalaSet]](java.util.Set)` then the original Java `Set` will be returned.
+   *
+   * @param s The Scala `Set` to be converted.
+   * @return  A Java `Set` view of the argument.
+   */
+  def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
+    case null                 => null
+    case JSetWrapper(wrapped) => wrapped
+    case _                    => new SetWrapper(s)
+  }
+
+  /**
+   * Converts a Scala mutable `Map` to a Java `Map`.
+   *
+   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaMap]](java.util.Map)` then the original Java `Map` will be
+   * returned.
+   *
+   * @param m The Scala mutable `Map` to be converted.
+   * @return  A Java `Map` view of the argument.
+   */
+  def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+    case null                 => null
+    case JMapWrapper(wrapped) => wrapped
+    case _                    => new MutableMapWrapper(m)
+  }
+
+  /**
+   * Converts a Scala mutable `Map` to a Java `Dictionary`.
+   *
+   * The returned Java `Dictionary` is backed by the provided Scala `Dictionary` and any
+   * side-effects of using it via the Java interface will be visible via the Scala interface and
+   * vice versa.
+   *
+   * If the Scala `Dictionary` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.dictionaryAsScalaMap]](java.util.Dictionary)` then the original Java
+   * `Dictionary` will be returned.
+   *
+   * @param m The Scala `Map` to be converted.
+   * @return  A Java `Dictionary` view of the argument.
+   */
+  def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+    case null                         => null
+    case JDictionaryWrapper(wrapped)  => wrapped
+    case _                            => new DictionaryWrapper(m)
+  }
+
+  /**
+   * Converts a Scala `Map` to a Java `Map`.
+   *
+   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   * via the Java interface will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaMap]](java.util.Map)` then the original Java `Map` will be
+   * returned.
+   *
+   * @param m The Scala `Map` to be converted.
+   * @return  A Java `Map` view of the argument.
+   */
+  def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+    case null                 => null
+    case JMapWrapper(wrapped) => wrapped.asInstanceOf[ju.Map[A, B]]
+    case _                    => new MapWrapper(m)
+  }
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
+   *
+   * The returned Java `ConcurrentMap` is backed by the provided Scala `concurrent.Map` and any
+   * side-effects of using it via the Java interface will be visible via the Scala interface and
+   * vice versa.
+   *
+   * If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsScalaConcurrentMap]](java.util.concurrent.ConcurrentMap)` then the
+   * original Java `ConcurrentMap` will be returned.
+   *
+   * @param m The Scala `concurrent.Map` to be converted.
+   * @return  A Java `ConcurrentMap` view of the argument.
+   */
+  def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+    case null                           => null
+    case JConcurrentMapWrapper(wrapped) => wrapped
+    case _                              => new ConcurrentMapWrapper(m)
+  }
+  */
+}

--- a/collections/src/main/scala/strawman/collection/convert/AsScalaConverters.scala
+++ b/collections/src/main/scala/strawman/collection/convert/AsScalaConverters.scala
@@ -1,0 +1,211 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import scala.Predef.String
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+
+/** Defines converter methods from Java to Scala collections. */
+trait AsScalaConverters {
+  import Wrappers._
+
+  /**
+   * Converts a Java `Iterator` to a Scala `Iterator`.
+   *
+   * The returned Scala `Iterator` is backed by the provided Java `Iterator` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Iterator` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaIterator]](scala.collection.Iterator)` then the original Scala
+   * `Iterator` will be returned.
+   *
+   * @param i The Java `Iterator` to be converted.
+   * @return  A Scala `Iterator` view of the argument.
+   */
+  def asScalaIterator[A](i: ju.Iterator[A]): Iterator[A] = i match {
+    case null                     => null
+    case IteratorWrapper(wrapped) => wrapped
+    case _                        => JIteratorWrapper(i)
+  }
+
+  /**
+   * Converts a Java `Enumeration` to a Scala `Iterator`.
+   *
+   * The returned Scala `Iterator` is backed by the provided Java `Enumeration` and any side-effects
+   * of using it via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Enumeration` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaEnumeration]](scala.collection.Iterator)` then the original Scala
+   * `Iterator` will be returned.
+   *
+   * @param i The Java `Enumeration` to be converted.
+   * @return  A Scala `Iterator` view of the argument.
+   */
+  def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
+    case null                     => null
+    case IteratorWrapper(wrapped) => wrapped
+    case _                        => JEnumerationWrapper(i)
+  }
+
+  /**
+   * Converts a Java `Iterable` to a Scala `Iterable`.
+   *
+   * The returned Scala `Iterable` is backed by the provided Java `Iterable` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Iterable` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaIterable]](scala.collection.Iterable) then the original Scala
+   * `Iterable` will be returned.
+   *
+   * @param i The Java `Iterable` to be converted.
+   * @return  A Scala `Iterable` view of the argument.
+   */
+  def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
+    case null                     => null
+    case IterableWrapper(wrapped) => wrapped
+    case _                        => JIterableWrapper(i)
+  }
+
+  /**
+   * Converts a Java `Collection` to an Scala `Iterable`.
+   *
+   * If the Java `Collection` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaCollection]](scala.collection.Iterable)` then the original Scala
+   * `Iterable` will be returned.
+   *
+   * @param i The Java `Collection` to be converted.
+   * @return  A Scala `Iterable` view of the argument.
+   */
+  def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
+    case null                     => null
+    case IterableWrapper(wrapped) => wrapped
+    case _                        => JCollectionWrapper(i)
+  }
+
+  /**
+   * Converts a Java `List` to a Scala mutable `Buffer`.
+   *
+   * The returned Scala `Buffer` is backed by the provided Java `List` and any side-effects of using
+   * it via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `List` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.bufferAsJavaList]](scala.collection.mutable.Buffer)` then the original Scala
+   * `Buffer` will be returned.
+   *
+   * @param l The Java `List` to be converted.
+   * @return A Scala mutable `Buffer` view of the argument.
+   */
+  def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
+    case null                           => null
+    case MutableBufferWrapper(wrapped)  => wrapped
+    case _                              => new JListWrapper(l)
+  }
+
+  /**
+   * Converts a Java `Set` to a Scala mutable `Set`.
+   *
+   * The returned Scala `Set` is backed by the provided Java `Set` and any side-effects of using it
+   * via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Set` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mutableSetAsJavaSet]](scala.collection.mutable.Set)` then the original Scala
+   * `Set` will be returned.
+   *
+   * @param s The Java `Set` to be converted.
+   * @return  A Scala mutable `Set` view of the argument.
+   */
+  def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
+    case null                       => null
+    case MutableSetWrapper(wrapped) => wrapped
+    case _                          => new JSetWrapper(s)
+  }
+
+  /**
+   * Converts a Java `Map` to a Scala mutable `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java `Map` and any side-effects of using it
+   * via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Map` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mutableMapAsJavaMap]](scala.collection.mutable.Map)` then the original Scala
+   * `Map` will be returned.
+   *
+   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`), it is
+   * your responsibility to wrap all non-atomic operations with `underlying.synchronized`.
+   * This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
+   * values may be present.
+   *
+   * @param m The Java `Map` to be converted.
+   * @return  A Scala mutable `Map` view of the argument.
+   */
+  def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
+    case null                       => null
+    case MutableMapWrapper(wrapped) => wrapped
+    case _                          => new JMapWrapper(m)
+  }
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
+   *
+   * The returned Scala `ConcurrentMap` is backed by the provided Java `ConcurrentMap` and any
+   * side-effects of using it via the Scala interface will be visible via the Java interface and
+   * vice versa.
+   *
+   * If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.mapAsJavaConcurrentMap]](scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala `ConcurrentMap` will be returned.
+   *
+   * @param m The Java `ConcurrentMap` to be converted.
+   * @return  A Scala mutable `ConcurrentMap` view of the argument.
+   */
+  def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+    case null                             => null
+    case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
+    case _                                => new JConcurrentMapWrapper(m)
+  }
+  */
+
+  /**
+   * Converts a Java `Dictionary` to a Scala mutable `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java `Dictionary` and any side-effects of
+   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *
+   * If the Java `Dictionary` was previously obtained from an implicit or explicit call of
+   * `[[JavaConverters.asJavaDictionary]](scala.collection.mutable.Map)` then the original
+   * Scala `Map` will be returned.
+   *
+   * @param p The Java `Dictionary` to be converted.
+   * @return  A Scala mutable `Map` view of the argument.
+   */
+  def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+    case null                       => null
+    case DictionaryWrapper(wrapped) => wrapped
+    case _                          => new JDictionaryWrapper(p)
+  }
+
+  /**
+   * Converts a Java `Properties` to a Scala mutable `Map[String, String]`.
+   *
+   * The returned Scala `Map[String, String]` is backed by the provided Java `Properties` and any
+   * side-effects of using it via the Scala interface will be visible via the Java interface and
+   * vice versa.
+   *
+   * @param p The Java `Properties` to be converted.
+   * @return  A Scala mutable `Map[String, String]` view of the argument.
+   */
+  def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
+    case null => null
+    case _    => new JPropertiesWrapper(p)
+  }
+}

--- a/collections/src/main/scala/strawman/collection/convert/DecorateAsJava.scala
+++ b/collections/src/main/scala/strawman/collection/convert/DecorateAsJava.scala
@@ -1,0 +1,112 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import Decorators._
+import scala.language.implicitConversions
+
+/** Defines `asJava` extension methods for [[JavaConverters]]. */
+trait DecorateAsJava extends AsJavaConverters {
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
+   * @see [[asJavaIterator]]
+   */
+  implicit def asJavaIteratorConverter[A](i : Iterator[A]): AsJava[ju.Iterator[A]] =
+    new AsJava(asJavaIterator(i))
+
+  /**
+   * Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java `Enumeration`.
+   * @see [[asJavaEnumeration]]
+   */
+  implicit def asJavaEnumerationConverter[A](i : Iterator[A]): AsJavaEnumeration[A] =
+    new AsJavaEnumeration(i)
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
+   * @see [[asJavaIterable]]
+   */
+  implicit def asJavaIterableConverter[A](i : Iterable[A]): AsJava[jl.Iterable[A]] =
+    new AsJava(asJavaIterable(i))
+
+  /**
+   * Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
+   * @see [[asJavaCollection]]
+   */
+  implicit def asJavaCollectionConverter[A](i : Iterable[A]): AsJavaCollection[A] =
+    new AsJavaCollection(i)
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
+   * @see [[bufferAsJavaList]]
+   */
+  implicit def bufferAsJavaListConverter[A](b : mutable.Buffer[A]): AsJava[ju.List[A]] =
+    new AsJava(bufferAsJavaList(b))
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
+   * @see [[mutableSeqAsJavaList]]
+   */
+  implicit def mutableSeqAsJavaListConverter[A](b : mutable.Seq[A]): AsJava[ju.List[A]] =
+    new AsJava(mutableSeqAsJavaList(b))
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
+   * @see [[seqAsJavaList]]
+   */
+  implicit def seqAsJavaListConverter[A](b : Seq[A]): AsJava[ju.List[A]] =
+    new AsJava(seqAsJavaList(b))
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
+   * @see [[mutableSetAsJavaSet]]
+   */
+  implicit def mutableSetAsJavaSetConverter[A](s : mutable.Set[A]): AsJava[ju.Set[A]] =
+    new AsJava(mutableSetAsJavaSet(s))
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
+   * @see [[setAsJavaSet]]
+   */
+  implicit def setAsJavaSetConverter[A](s : Set[A]): AsJava[ju.Set[A]] =
+    new AsJava(setAsJavaSet(s))
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
+   * @see [[mutableMapAsJavaMap]]
+   */
+  implicit def mutableMapAsJavaMapConverter[A, B](m : mutable.Map[A, B]): AsJava[ju.Map[A, B]] =
+    new AsJava(mutableMapAsJavaMap(m))
+
+  /**
+   * Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   * @see [[asJavaDictionary]]
+   */
+  implicit def asJavaDictionaryConverter[A, B](m : mutable.Map[A, B]): AsJavaDictionary[A, B] =
+    new AsJavaDictionary(m)
+
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
+   * @see [[mapAsJavaMap]]
+   */
+  implicit def mapAsJavaMapConverter[A, B](m : Map[A, B]): AsJava[ju.Map[A, B]] =
+    new AsJava(mapAsJavaMap(m))
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
+   * @see [[mapAsJavaConcurrentMap]].
+   */
+  implicit def mapAsJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
+    new AsJava(mapAsJavaConcurrentMap(m))
+  */
+}

--- a/collections/src/main/scala/strawman/collection/convert/DecorateAsScala.scala
+++ b/collections/src/main/scala/strawman/collection/convert/DecorateAsScala.scala
@@ -1,0 +1,92 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import scala.Predef.String
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import Decorators._
+import scala.language.implicitConversions
+
+/** Defines `asScala` extension methods for [[JavaConverters]]. */
+trait DecorateAsScala extends AsScalaConverters {
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   * @see [[asScalaIterator]]
+   */
+  implicit def asScalaIteratorConverter[A](i : ju.Iterator[A]): AsScala[Iterator[A]] =
+    new AsScala(asScalaIterator(i))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
+   * @see [[enumerationAsScalaIterator]]
+   */
+  implicit def enumerationAsScalaIteratorConverter[A](i : ju.Enumeration[A]): AsScala[Iterator[A]] =
+    new AsScala(enumerationAsScalaIterator(i))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   * @see [[iterableAsScalaIterable]]
+   */
+  implicit def iterableAsScalaIterableConverter[A](i : jl.Iterable[A]): AsScala[Iterable[A]] =
+    new AsScala(iterableAsScalaIterable(i))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
+   * @see [[collectionAsScalaIterable]]
+   */
+  implicit def collectionAsScalaIterableConverter[A](i : ju.Collection[A]): AsScala[Iterable[A]] =
+    new AsScala(collectionAsScalaIterable(i))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   * @see [[asScalaBuffer]]
+   */
+  implicit def asScalaBufferConverter[A](l : ju.List[A]): AsScala[mutable.Buffer[A]] =
+    new AsScala(asScalaBuffer(l))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
+   * @see [[asScalaSet]]
+   */
+  implicit def asScalaSetConverter[A](s : ju.Set[A]): AsScala[mutable.Set[A]] =
+    new AsScala(asScalaSet(s))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
+   * @see [[mapAsScalaMap]]
+   */
+  implicit def mapAsScalaMapConverter[A, B](m : ju.Map[A, B]): AsScala[mutable.Map[A, B]] =
+    new AsScala(mapAsScalaMap(m))
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
+   * @see [[mapAsScalaConcurrentMap]]
+   */
+  implicit def mapAsScalaConcurrentMapConverter[A, B](m: juc.ConcurrentMap[A, B]): AsScala[concurrent.Map[A, B]] =
+    new AsScala(mapAsScalaConcurrentMap(m))
+   */
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
+   * @see [[dictionaryAsScalaMap]]
+   */
+  implicit def dictionaryAsScalaMapConverter[A, B](p: ju.Dictionary[A, B]): AsScala[mutable.Map[A, B]] =
+    new AsScala(dictionaryAsScalaMap(p))
+
+  /**
+   * Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable `Map[String, String]`.
+   * @see [[propertiesAsScalaMap]]
+   */
+  implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
+    new AsScala(propertiesAsScalaMap(p))
+}

--- a/collections/src/main/scala/strawman/collection/convert/Decorators.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Decorators.scala
@@ -1,0 +1,45 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import java.{ util => ju }
+
+private[collection] object Decorators {
+  /** Generic class containing the `asJava` converter method */
+  class AsJava[A](op: => A) {
+    /** Converts a Scala collection to the corresponding Java collection */
+    def asJava: A = op
+  }
+
+  /** Generic class containing the `asScala` converter method */
+  class AsScala[A](op: => A) {
+    /** Converts a Java collection to the corresponding Scala collection */
+    def asScala: A = op
+  }
+
+  /** Generic class containing the `asJavaCollection` converter method */
+  class AsJavaCollection[A](i: Iterable[A]) {
+    /** Converts a Scala `Iterable` to a Java `Collection` */
+    def asJavaCollection: ju.Collection[A] = JavaConverters.asJavaCollection(i)
+  }
+
+  /** Generic class containing the `asJavaEnumeration` converter method */
+  class AsJavaEnumeration[A](i: Iterator[A]) {
+    /** Converts a Scala `Iterator` to a Java `Enumeration` */
+    def asJavaEnumeration: ju.Enumeration[A] = JavaConverters.asJavaEnumeration(i)
+  }
+
+  /** Generic class containing the `asJavaDictionary` converter method */
+  class AsJavaDictionary[A, B](m : mutable.Map[A, B]) {
+    /** Converts a Scala `Map` to a Java `Dictionary` */
+    def asJavaDictionary: ju.Dictionary[A, B] = JavaConverters.asJavaDictionary(m)
+  }
+}

--- a/collections/src/main/scala/strawman/collection/convert/WrapAsJava.scala
+++ b/collections/src/main/scala/strawman/collection/convert/WrapAsJava.scala
@@ -1,0 +1,295 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import scala.deprecated
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import scala.language.implicitConversions
+
+@deprecated("use JavaConverters or consider ToJavaImplicits", since="2.12.0")
+trait WrapAsJava extends LowPriorityWrapAsJava {
+  // provide higher-priority implicits with names that don't exist in JavaConverters for the case
+  // when importing both JavaConverters._ and JavaConversions._. otherwise implicit conversions
+  // would not apply, see https://github.com/scala/scala/pull/5109#issuecomment-212417789
+  implicit def `deprecated asJavaIterator`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
+  implicit def `deprecated asJavaEnumeration`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
+  implicit def `deprecated asJavaIterable`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
+  implicit def `deprecated asJavaCollection`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
+  implicit def `deprecated bufferAsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
+  implicit def `deprecated mutableSeqAsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
+  implicit def `deprecated seqAsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
+  implicit def `deprecated mutableSetAsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
+  implicit def `deprecated setAsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
+  implicit def `deprecated mutableMapAsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+  implicit def `deprecated asJavaDictionary`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+  implicit def `deprecated mapAsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+  //TODO Add concurrent maps back
+  //implicit def `deprecated mapAsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+}
+
+private[convert] trait LowPriorityWrapAsJava {
+  import Wrappers._
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Iterator.
+   * The returned Java Iterator is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Iterator)` then the original
+   * Java Iterator will be returned.
+   *
+   * @param  it The Iterator to be converted.
+   * @return    A Java Iterator view of the argument.
+   */
+  implicit def asJavaIterator[A](it: Iterator[A]): ju.Iterator[A] = it match {
+    case null                       => null
+    case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
+    case _                          => IteratorWrapper(it)
+  }
+
+  /**
+   * Implicitly converts a Scala Iterator to a Java Enumeration.
+   * The returned Java Enumeration is backed by the provided Scala
+   * Iterator and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterator was previously obtained from an implicit or
+   * explicit call of `asIterator(java.util.Enumeration)` then the
+   * original Java Enumeration will be returned.
+   *
+   * @param it The Iterator to be converted.
+   * @return   A Java Enumeration view of the argument.
+   */
+  implicit def asJavaEnumeration[A](it: Iterator[A]): ju.Enumeration[A] = it match {
+    case null                         => null
+    case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
+    case _                            => IteratorWrapper(it)
+  }
+
+  /**
+   * Implicitly converts a Scala Iterable to a Java Iterable.
+   * The returned Java Iterable is backed by the provided Scala
+   * Iterable and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asIterable(java.lang.Iterable)` then the original
+   * Java Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Java Iterable view of the argument.
+   */
+  implicit def asJavaIterable[A](i: Iterable[A]): jl.Iterable[A] = i match {
+    case null                       => null
+    case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
+    case _                          => IterableWrapper(i)
+  }
+
+  /**
+   * Implicitly converts a Scala Iterable to an immutable Java
+   * Collection.
+   *
+   * If the Scala Iterable was previously obtained from an implicit or
+   * explicit call of `asSizedIterable(java.util.Collection)` then the original
+   * Java Collection will be returned.
+   *
+   * @param it The SizedIterable to be converted.
+   * @return   A Java Collection view of the argument.
+   */
+  implicit def asJavaCollection[A](it: Iterable[A]): ju.Collection[A] = it match {
+    case null                         => null
+    case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
+    case _                            => new IterableWrapper(it)
+  }
+
+  /**
+   * Implicitly converts a Scala mutable Buffer to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Buffer and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Buffer was previously obtained from an implicit or
+   * explicit call of `asBuffer(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param b The Buffer to be converted.
+   * @return A Java List view of the argument.
+   */
+  implicit def bufferAsJavaList[A](b: mutable.Buffer[A]): ju.List[A] = b match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableBufferWrapper(b)
+  }
+
+  /**
+   * Implicitly converts a Scala mutable Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def mutableSeqAsJavaList[A](seq: mutable.Seq[A]): ju.List[A] = seq match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped
+    case _                      => new MutableSeqWrapper(seq)
+  }
+
+  /**
+   * Implicitly converts a Scala Seq to a Java List.
+   * The returned Java List is backed by the provided Scala
+   * Seq and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Seq was previously obtained from an implicit or
+   * explicit call of `asSeq(java.util.List)` then the original
+   * Java List will be returned.
+   *
+   * @param seq The Seq to be converted.
+   * @return    A Java List view of the argument.
+   */
+  implicit def seqAsJavaList[A](seq: Seq[A]): ju.List[A] = seq match {
+    case null                   => null
+    case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
+    case _                      => new SeqWrapper(seq)
+  }
+
+  /**
+   * Implicitly converts a Scala mutable Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of `asSet(java.util.Set)` then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def mutableSetAsJavaSet[A](s: mutable.Set[A]): ju.Set[A] = s match {
+    case null                 => null
+    case JSetWrapper(wrapped) => wrapped
+    case _                    => new MutableSetWrapper(s)
+  }
+
+  /**
+   * Implicitly converts a Scala Set to a Java Set.
+   * The returned Java Set is backed by the provided Scala
+   * Set and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Set was previously obtained from an implicit or
+   * explicit call of asSet(java.util.Set) then the original
+   * Java Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Java Set view of the argument.
+   */
+  implicit def setAsJavaSet[A](s: Set[A]): ju.Set[A] = s match {
+    case null                 => null
+    case JSetWrapper(wrapped) => wrapped
+    case _                    => new SetWrapper(s)
+  }
+
+  /**
+   * Implicitly converts a Scala mutable Map to a Java Map.
+   * The returned Java Map is backed by the provided Scala
+   * Map and any side-effects of using it via the Java interface will
+   * be visible via the Scala interface and vice versa.
+   *
+   * If the Scala Map was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java Map will be returned.
+   *
+   * @param m The Map to be converted.
+   * @return A Java Map view of the argument.
+   */
+  implicit def mutableMapAsJavaMap[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = m match {
+    case null                 => null
+    case JMapWrapper(wrapped) => wrapped
+    case _                    => new MutableMapWrapper(m)
+  }
+
+  /**
+   * Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   *
+   * The returned Java `Dictionary` is backed by the provided Scala
+   * `Dictionary` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `Dictionary` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Dictionary)` then the original
+   * Java Dictionary will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Dictionary` view of the argument.
+   */
+  implicit def asJavaDictionary[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = m match {
+    case null                         => null
+    case JDictionaryWrapper(wrapped)  => wrapped
+    case _                            => new DictionaryWrapper(m)
+  }
+
+  /**
+   * Implicitly converts a Scala `Map` to a Java `Map`.
+   *
+   * The returned Java `Map` is backed by the provided Scala `Map` and
+   * any side-effects of using it via the Java interface will be visible
+   * via the Scala interface and vice versa.
+   *
+   * If the Scala `Map` was previously obtained from an implicit or
+   * explicit call of `asMap(java.util.Map)` then the original
+   * Java `Map` will be returned.
+   *
+   * @param m The `Map` to be converted.
+   * @return A Java `Map` view of the argument.
+   */
+  implicit def mapAsJavaMap[A, B](m: Map[A, B]): ju.Map[A, B] = m match {
+    case null                 => null
+    case JMapWrapper(wrapped) => wrapped.asInstanceOf[ju.Map[A, B]]
+    case _                    => new MapWrapper(m)
+  }
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Implicitly converts a Scala mutable `concurrent.Map` to a Java
+   * `ConcurrentMap`.
+   *
+   * The returned Java `ConcurrentMap` is backed by the provided Scala
+   * `concurrent.Map` and any side-effects of using it via the Java interface
+   * will be visible via the Scala interface and vice versa.
+   *
+   * If the Scala `concurrent.Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaConcurrentMap(java.util.concurrent.ConcurrentMap)`
+   * then the original Java ConcurrentMap will be returned.
+   *
+   * @param m The Scala `concurrent.Map` to be converted.
+   * @return A Java `ConcurrentMap` view of the argument.
+   */
+  implicit def mapAsJavaConcurrentMap[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = m match {
+    case null                           => null
+    case JConcurrentMapWrapper(wrapped) => wrapped
+    case _                              => new ConcurrentMapWrapper(m)
+  }
+  */
+}
+
+@deprecated("use JavaConverters or consider ImplicitConversionsToJava", since="2.12.0")
+object WrapAsJava extends WrapAsJava

--- a/collections/src/main/scala/strawman/collection/convert/WrapAsScala.scala
+++ b/collections/src/main/scala/strawman/collection/convert/WrapAsScala.scala
@@ -1,0 +1,235 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import scala.deprecated
+import scala.Predef.String
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import scala.language.implicitConversions
+
+@deprecated("use JavaConverters or consider ToScalaImplicits", since="2.12.0")
+trait WrapAsScala extends LowPriorityWrapAsScala {
+  // provide higher-priority implicits with names that don't exist in JavaConverters for the case
+  // when importing both JavaConverters._ and JavaConversions._. otherwise implicit conversions
+  // would not apply, see https://github.com/scala/scala/pull/5109#issuecomment-212417789
+  implicit def `deprecated asScalaIterator`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
+  implicit def `deprecated enumerationAsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
+  implicit def `deprecated iterableAsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
+  implicit def `deprecated collectionAsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
+  implicit def `deprecated asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
+  implicit def `deprecated asScalaSet`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
+  implicit def `deprecated mapAsScalaMap`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+  //TODO Add concurrent maps back
+  //implicit def `deprecated mapAsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+  implicit def `deprecated dictionaryAsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+  implicit def `deprecated propertiesAsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+private[convert] trait LowPriorityWrapAsScala {
+  import Wrappers._
+
+  /**
+   * Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   *
+   * The returned Scala `Iterator` is backed by the provided Java `Iterator`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterator` was previously obtained from an implicit or
+   * explicit call of `asIterator(scala.collection.Iterator)` then the
+   * original Scala `Iterator` will be returned.
+   *
+   * @param it The `Iterator` to be converted.
+   * @return   A Scala `Iterator` view of the argument.
+   */
+  implicit def asScalaIterator[A](it: ju.Iterator[A]): Iterator[A] = it match {
+    case null                     => null
+    case IteratorWrapper(wrapped) => wrapped
+    case _                        => JIteratorWrapper(it)
+  }
+
+  /**
+   * Implicitly converts a Java Enumeration to a Scala Iterator.
+   * The returned Scala Iterator is backed by the provided Java
+   * Enumeration and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Enumeration was previously obtained from an implicit or
+   * explicit call of `enumerationAsScalaIterator(scala.collection.Iterator)`
+   * then the original Scala Iterator will be returned.
+   *
+   * @param i The Enumeration to be converted.
+   * @return A Scala Iterator view of the argument.
+   */
+  implicit def enumerationAsScalaIterator[A](i: ju.Enumeration[A]): Iterator[A] = i match {
+    case null                     => null
+    case IteratorWrapper(wrapped) => wrapped
+    case _                        => JEnumerationWrapper(i)
+  }
+
+  /**
+   * Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   *
+   * The returned Scala `Iterable` is backed by the provided Java `Iterable`
+   * and any side-effects of using it via the Scala interface will be visible
+   * via the Java interface and vice versa.
+   *
+   * If the Java `Iterable` was previously obtained from an implicit or
+   * explicit call of `iterableAsScalaIterable(scala.collection.Iterable)`
+   * then the original Scala Iterable will be returned.
+   *
+   * @param i The Iterable to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def iterableAsScalaIterable[A](i: jl.Iterable[A]): Iterable[A] = i match {
+    case null                     => null
+    case IterableWrapper(wrapped) => wrapped
+    case _                        => JIterableWrapper(i)
+  }
+
+  /**
+   * Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   *
+   * If the Java `Collection` was previously obtained from an implicit or
+   * explicit call of `collectionAsScalaIterable(scala.collection.SizedIterable)`
+   * then the original Scala `Iterable` will be returned.
+   *
+   * @param i The Collection to be converted.
+   * @return A Scala Iterable view of the argument.
+   */
+  implicit def collectionAsScalaIterable[A](i: ju.Collection[A]): Iterable[A] = i match {
+    case null                     => null
+    case IterableWrapper(wrapped) => wrapped
+    case _                        => JCollectionWrapper(i)
+  }
+
+  /**
+   * Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   *
+   * The returned Scala `Buffer` is backed by the provided Java `List`
+   * and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java `List` was previously obtained from an implicit or
+   * explicit call of `asScalaBuffer(scala.collection.mutable.Buffer)`
+   * then the original Scala `Buffer` will be returned.
+   *
+   * @param l The `List` to be converted.
+   * @return A Scala mutable `Buffer` view of the argument.
+   */
+  implicit def asScalaBuffer[A](l: ju.List[A]): mutable.Buffer[A] = l match {
+    case null                           => null
+    case MutableBufferWrapper(wrapped)  => wrapped
+    case _                              => new JListWrapper(l)
+  }
+
+  /**
+   * Implicitly converts a Java Set to a Scala mutable Set.
+   * The returned Scala Set is backed by the provided Java
+   * Set and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java Set was previously obtained from an implicit or
+   * explicit call of `asScalaSet(scala.collection.mutable.Set)` then
+   * the original Scala Set will be returned.
+   *
+   * @param s The Set to be converted.
+   * @return A Scala mutable Set view of the argument.
+   */
+  implicit def asScalaSet[A](s: ju.Set[A]): mutable.Set[A] = s match {
+    case null                       => null
+    case MutableSetWrapper(wrapped) => wrapped
+    case _                          => new JSetWrapper(s)
+  }
+
+  /**
+   * Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java `Map` and any
+   * side-effects of using it via the Scala interface will be visible via
+   * the Java interface and vice versa.
+   *
+   * If the Java `Map` was previously obtained from an implicit or
+   * explicit call of `mapAsScalaMap(scala.collection.mutable.Map)` then
+   * the original Scala Map will be returned.
+   *
+   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`),
+   * it is your responsibility to wrap all
+   * non-atomic operations with `underlying.synchronized`.
+   * This includes `get`, as `java.util.Map`'s API does not allow for an
+   * atomic `get` when `null` values may be present.
+   *
+   * @param m The Map to be converted.
+   * @return A Scala mutable Map view of the argument.
+   */
+  implicit def mapAsScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
+    case null                       => null
+    case MutableMapWrapper(wrapped) => wrapped
+    case _                          => new JMapWrapper(m)
+  }
+
+  //TODO Add concurrent maps back
+  /*
+  /**
+   * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
+   * The returned Scala ConcurrentMap is backed by the provided Java
+   * ConcurrentMap and any side-effects of using it via the Scala interface will
+   * be visible via the Java interface and vice versa.
+   *
+   * If the Java ConcurrentMap was previously obtained from an implicit or
+   * explicit call of `asConcurrentMap(scala.collection.mutable.ConcurrentMap)`
+   * then the original Scala ConcurrentMap will be returned.
+   *
+   * @param m The ConcurrentMap to be converted.
+   * @return A Scala mutable ConcurrentMap view of the argument.
+   */
+  implicit def mapAsScalaConcurrentMap[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
+    case null                             => null
+    case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
+    case _                                => new JConcurrentMapWrapper(m)
+  }
+  */
+
+  /**
+   * Implicitly converts a Java `Dictionary` to a Scala mutable
+   * `Map`.
+   *
+   * The returned Scala `Map` is backed by the provided Java
+   * `Dictionary` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Dictionary to be converted.
+   * @return  A Scala mutable Map view of the argument.
+   */
+  implicit def dictionaryAsScalaMap[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = p match {
+    case null                       => null
+    case DictionaryWrapper(wrapped) => wrapped
+    case _                          => new JDictionaryWrapper(p)
+  }
+
+  /**
+   * Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   *
+   * The returned Scala `Map[String, String]` is backed by the provided Java
+   * `Properties` and any side-effects of using it via the Scala interface
+   * will be visible via the Java interface and vice versa.
+   *
+   * @param p The Properties to be converted.
+   * @return  A Scala mutable Map[String, String] view of the argument.
+   */
+  implicit def propertiesAsScalaMap(p: ju.Properties): mutable.Map[String, String] = p match {
+    case null => null
+    case _    => new JPropertiesWrapper(p)
+  }
+}
+
+@deprecated("use JavaConverters or consider ImplicitConversionsToScala", since="2.12.0")
+object WrapAsScala extends WrapAsScala

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -1,0 +1,495 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import scala.{Some, None, Serializable, AnyRef, Boolean, Option, Int, ClassCastException, SerialVersionUID, Any, Unit}
+import scala.Predef.String
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import java.util.function.Predicate
+import java.lang.{IllegalStateException, UnsupportedOperationException, Object}
+import WrapAsScala._
+import WrapAsJava._
+
+/** Adapters for Java/Scala collections API. */
+private[collection] trait Wrappers {
+  trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {
+    val underlying: Iterable[A]
+    def size = underlying.size
+    override def iterator() = IteratorWrapper(underlying.iterator())
+    override def isEmpty = underlying.isEmpty
+  }
+
+  case class IteratorWrapper[A](underlying: Iterator[A]) extends ju.Iterator[A] with ju.Enumeration[A] {
+    def hasNext = underlying.hasNext
+    def next() = underlying.next()
+    def hasMoreElements = underlying.hasNext
+    def nextElement() = underlying.next()
+    override def remove() = throw new UnsupportedOperationException
+  }
+
+  class ToIteratorWrapper[A](underlying : Iterator[A]) {
+    def asJava = new IteratorWrapper(underlying)
+  }
+
+  case class JIteratorWrapper[A](underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] {
+    def hasNext = underlying.hasNext
+    def next() = underlying.next
+  }
+
+  case class JEnumerationWrapper[A](underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] {
+    def hasNext = underlying.hasMoreElements
+    def next() = underlying.nextElement
+  }
+
+  case class IterableWrapper[A](underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] { }
+
+  case class JIterableWrapper[A](underlying: jl.Iterable[A]) extends AbstractIterable[A] with Iterable[A] {
+    def iterator() = underlying.iterator
+    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
+    def iterableFactory = mutable.ArrayBuffer
+    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+  }
+
+  case class JCollectionWrapper[A](underlying: ju.Collection[A]) extends AbstractIterable[A] with Iterable[A] {
+    def iterator() = underlying.iterator
+    override def size = underlying.size
+    override def isEmpty = underlying.isEmpty
+    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
+    def iterableFactory = mutable.ArrayBuffer
+    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+  }
+
+  case class SeqWrapper[A](underlying: Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
+    def get(i: Int) = underlying(i)
+  }
+
+  case class MutableSeqWrapper[A](underlying: mutable.Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
+    def get(i: Int) = underlying(i)
+    override def set(i: Int, elem: A) = {
+      val p = underlying(i)
+      underlying(i) = elem
+      p
+    }
+  }
+
+  case class MutableBufferWrapper[A](underlying: mutable.Buffer[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
+    def get(i: Int) = underlying(i)
+    override def set(i: Int, elem: A) = { val p = underlying(i); underlying(i) = elem; p }
+    override def add(elem: A) = { underlying += elem; true }
+    override def remove(i: Int) = underlying remove i
+  }
+
+  case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with SeqOps[A, mutable.Buffer, mutable.Buffer[A]] {
+    def length = underlying.size
+    override def isEmpty = underlying.isEmpty
+    override def iterator(): Iterator[A] = underlying.iterator
+    def apply(i: Int) = underlying.get(i)
+    def update(i: Int, elem: A) = underlying.set(i, elem)
+    def prepend(elem: A) = { underlying.subList(0, 0) add elem; this }
+    def add(elem: A): this.type = { underlying add elem; this }
+    def insert(idx: Int,elem: A): Unit = underlying.subList(0, idx).add(elem)
+    def insertAll(i: Int, elems: IterableOnce[A]) = {
+      val ins = underlying.subList(0, i)
+      elems.iterator().foreach(ins.add(_))
+    }
+    def remove(i: Int) = underlying.remove(i)
+    def clear() = underlying.clear()
+    // Note: Clone cannot just call underlying.clone because in Java, only specific collections
+    // expose clone methods.  Generically, they're protected.
+    override def clone(): JListWrapper[A] = JListWrapper(new ju.ArrayList[A](underlying))
+
+    def flatMapInPlace(f: A => strawman.collection.IterableOnce[A]): this.type = {
+      val it = underlying.listIterator()
+      while(it.hasNext()) {
+        val e = it.next()
+        it.remove()
+        val es = f(e)
+        es.foreach(it.add)
+      }
+      this
+    }
+    def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
+      remove(from, replaced)
+      insertAll(from, patch)
+      this
+    }
+    def filterInPlace(p: A => Boolean): this.type = { underlying.removeIf((x => p(x)): Predicate[A]); this }
+    def remove(from: Int, n: Int): Unit = underlying.subList(from, from+n).clear()
+    def mapInPlace(f: A => A): this.type = {
+      val it = underlying.listIterator()
+      while(it.hasNext()) {
+        val e = it.next()
+        val e2 = f(e)
+        if(e2.asInstanceOf[AnyRef] ne e.asInstanceOf[AnyRef]) it.set(e2)
+      }
+      this
+    }
+    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
+    def iterableFactory = mutable.ArrayBuffer
+    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+    def subtract(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
+  }
+
+  @SerialVersionUID(1L)
+  class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] with Serializable { self =>
+    // Note various overrides to avoid performance gotchas.
+    override def contains(o: Object): Boolean = {
+      try { underlying.contains(o.asInstanceOf[A]) }
+      catch { case cce: ClassCastException => false }
+    }
+    override def isEmpty = underlying.isEmpty
+    def size = underlying.size
+    def iterator = new ju.Iterator[A] {
+      val ui = underlying.iterator()
+      var prev: Option[A] = None
+      def hasNext = ui.hasNext
+      def next = { val e = ui.next(); prev = Some(e); e }
+      override def remove() = prev match {
+        case Some(e) =>
+          underlying match {
+            case ms: mutable.Set[a] =>
+              ms remove e
+              prev = None
+            case _ =>
+              throw new UnsupportedOperationException("remove")
+          }
+        case _ =>
+          throw new IllegalStateException("next must be called at least once before remove")
+      }
+    }
+  }
+
+  case class MutableSetWrapper[A](underlying: mutable.Set[A]) extends SetWrapper[A](underlying) {
+    override def add(elem: A) = {
+      val sz = underlying.size
+      underlying += elem
+      sz < underlying.size
+    }
+    override def remove(elem: AnyRef) =
+      try underlying.remove(elem.asInstanceOf[A]).isDefined
+      catch { case ex: ClassCastException => false }
+    override def clear() = underlying.clear()
+  }
+
+  case class JSetWrapper[A](underlying: ju.Set[A]) extends mutable.AbstractSet[A] with mutable.Set[A] with mutable.SetOps[A, mutable.Set, mutable.Set[A]] {
+
+    override def size = underlying.size
+
+    def iterator() = underlying.iterator
+
+    def contains(elem: A): Boolean = underlying.contains(elem)
+
+    def add(elem: A): this.type = { underlying add elem; this }
+    def subtract(elem: A): this.type = { underlying remove elem; this }
+
+    //TODO Should Set.remove return the canonical element? There is no efficient way to support this for wrapped Java Sets
+    override def remove(elem: A): Option[A] = if(underlying remove elem) Some(elem) else None
+    override def clear() = underlying.clear()
+
+    //TODO Should Set.get be supported? There is no efficient way to return the canonical element from a Java Set
+    def get(elem: A): Option[A] = if(underlying.contains(elem)) Some(elem) else None
+
+    override def empty = JSetWrapper(new ju.HashSet[A])
+    // Note: Clone cannot just call underlying.clone because in Java, only specific collections
+    // expose clone methods.  Generically, they're protected.
+    override def clone() =
+      new JSetWrapper[A](new ju.LinkedHashSet[A](underlying))
+
+    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.HashSet.from(coll)
+    def iterableFactory = mutable.HashSet
+    protected[this] def newSpecificBuilder() = mutable.HashSet.newBuilder()
+  }
+
+  @SerialVersionUID(1L)
+  class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] with Serializable { self =>
+    override def size = underlying.size
+
+    override def get(key: AnyRef): B = try {
+      underlying get key.asInstanceOf[A] match {
+        case None => null.asInstanceOf[B]
+        case Some(v) => v
+      }
+    } catch {
+      case ex: ClassCastException => null.asInstanceOf[B]
+    }
+
+    override def entrySet: ju.Set[ju.Map.Entry[A, B]] = new ju.AbstractSet[ju.Map.Entry[A, B]] {
+      def size = self.size
+
+      def iterator = new ju.Iterator[ju.Map.Entry[A, B]] {
+        val ui = underlying.iterator()
+        var prev : Option[A] = None
+
+        def hasNext = ui.hasNext
+
+        def next() = {
+          val (k, v) = ui.next()
+          prev = Some(k)
+          new ju.Map.Entry[A, B] {
+            import scala.util.hashing.byteswap32
+            def getKey = k
+            def getValue = v
+            def setValue(v1 : B) = self.put(k, v1)
+            override def hashCode = byteswap32(k.##) + (byteswap32(v.##) << 16)
+            override def equals(other: Any) = other match {
+              case e: ju.Map.Entry[_, _] => k == e.getKey && v == e.getValue
+              case _ => false
+            }
+          }
+        }
+
+        override def remove(): Unit = {
+          prev match {
+            case Some(k) =>
+              underlying match {
+                case mm: mutable.Map[a, _] =>
+                  mm -= k
+                  prev = None
+                case _ =>
+                  throw new UnsupportedOperationException("remove")
+              }
+            case _ =>
+              throw new IllegalStateException("next must be called at least once before remove")
+          }
+        }
+      }
+    }
+
+    override def containsKey(key: AnyRef): Boolean = try {
+      // Note: Subclass of collection.Map with specific key type may redirect generic
+      // contains to specific contains, which will throw a ClassCastException if the
+      // wrong type is passed. This is why we need a type cast to A inside a try/catch.
+      underlying.contains(key.asInstanceOf[A])
+    } catch {
+      case ex: ClassCastException => false
+    }
+  }
+
+  case class MutableMapWrapper[A, B](underlying: mutable.Map[A, B]) extends MapWrapper[A, B](underlying) {
+    override def put(k: A, v: B) = underlying.put(k, v) match {
+      case Some(v1) => v1
+      case None => null.asInstanceOf[B]
+    }
+
+    override def remove(k: AnyRef): B = try {
+      underlying remove k.asInstanceOf[A] match {
+        case None => null.asInstanceOf[B]
+        case Some(v) => v
+      }
+    } catch {
+      case ex: ClassCastException => null.asInstanceOf[B]
+    }
+
+    override def clear() = underlying.clear()
+  }
+
+  trait JMapWrapperLike[K, V, +C <: mutable.Map[K, V] with mutable.Map[K, V]] extends mutable.Map[K, V] with mutable.MapOps[K, V, mutable.Map, mutable.Map[K, V]] {
+    def underlying: ju.Map[K, V]
+
+    override def size = underlying.size
+
+    def get(k: K) = {
+      val v = underlying get k
+      if (v != null)
+        Some(v)
+      else if (underlying containsKey k)
+        Some(null.asInstanceOf[V])
+      else
+        None
+    }
+
+    def add(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtract(key: K): this.type = { underlying remove key; this }
+
+    override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
+
+    override def update(k: K, v: V): Unit = { underlying.put(k, v) }
+
+    override def remove(k: K): Option[V] = Option(underlying remove k)
+
+    def iterator(): Iterator[(K, V)] = new AbstractIterator[(K, V)] {
+      val ui = underlying.entrySet.iterator
+      def hasNext = ui.hasNext
+      def next() = { val e = ui.next(); (e.getKey, e.getValue) }
+    }
+
+    override def clear() = underlying.clear()
+
+    override def empty: C = null.asInstanceOf[C]
+
+    protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]) = mutable.HashMap.from(coll)
+    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
+    def mapFactory = mutable.HashMap
+    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
+  }
+
+  /** Wraps a Java map as a Scala one.  If the map is to support concurrent access,
+    * use [[JConcurrentMapWrapper]] instead.  If the wrapped map is synchronized
+    * (e.g. from `java.util.Collections.synchronizedMap`), it is your responsibility
+    * to wrap all non-atomic operations with `underlying.synchronized`.
+    * This includes `get`, as `java.util.Map`'s API does not allow for an
+    * atomic `get` when `null` values may be present.
+    */
+  case class JMapWrapper[A, B](underlying : ju.Map[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JMapWrapper[A, B]] {
+    override def empty = JMapWrapper(new ju.HashMap[A, B])
+  }
+
+  //TODO Add concurrent maps back
+  /*
+  class ConcurrentMapWrapper[A, B](override val underlying: concurrent.Map[A, B]) extends MutableMapWrapper[A, B](underlying) with juc.ConcurrentMap[A, B] {
+
+    override def putIfAbsent(k: A, v: B) = underlying.putIfAbsent(k, v) match {
+      case Some(v) => v
+      case None => null.asInstanceOf[B]
+    }
+
+    override def remove(k: AnyRef, v: AnyRef) = try {
+      underlying.remove(k.asInstanceOf[A], v.asInstanceOf[B])
+    } catch {
+      case ex: ClassCastException =>
+        false
+    }
+
+    override def replace(k: A, v: B): B = underlying.replace(k, v) match {
+      case Some(v) => v
+      case None => null.asInstanceOf[B]
+    }
+
+    override def replace(k: A, oldval: B, newval: B) = underlying.replace(k, oldval, newval)
+  }
+
+  /** Wraps a concurrent Java map as a Scala one.  Single-element concurrent
+    * access is supported; multi-element operations such as maps and filters
+    * are not guaranteed to be atomic.
+    */
+  case class JConcurrentMapWrapper[A, B](underlying: juc.ConcurrentMap[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JConcurrentMapWrapper[A, B]] with concurrent.Map[A, B] {
+    override def get(k: A) = Option(underlying get k)
+
+    override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[A, B])
+
+    def putIfAbsent(k: A, v: B): Option[B] = Option(underlying.putIfAbsent(k, v))
+
+    def remove(k: A, v: B): Boolean = underlying.remove(k, v)
+
+    def replace(k: A, v: B): Option[B] = Option(underlying.replace(k, v))
+
+    def replace(k: A, oldvalue: B, newvalue: B): Boolean =
+      underlying.replace(k, oldvalue, newvalue)
+  }
+  */
+
+  case class DictionaryWrapper[A, B](underlying: mutable.Map[A, B]) extends ju.Dictionary[A, B] {
+    def size: Int = underlying.size
+    def isEmpty: Boolean = underlying.isEmpty
+    def keys: ju.Enumeration[A] = asJavaEnumeration(underlying.keysIterator())
+    def elements: ju.Enumeration[B] = asJavaEnumeration(underlying.valuesIterator())
+    def get(key: AnyRef) = try {
+      underlying get key.asInstanceOf[A] match {
+        case None => null.asInstanceOf[B]
+        case Some(v) => v
+      }
+    } catch {
+      case ex: ClassCastException => null.asInstanceOf[B]
+    }
+    def put(key: A, value: B): B = underlying.put(key, value) match {
+      case Some(v) => v
+      case None => null.asInstanceOf[B]
+    }
+    override def remove(key: AnyRef) = try {
+      underlying remove key.asInstanceOf[A] match {
+        case None => null.asInstanceOf[B]
+        case Some(v) => v
+      }
+    } catch {
+      case ex: ClassCastException => null.asInstanceOf[B]
+    }
+  }
+
+  case class JDictionaryWrapper[A, B](underlying: ju.Dictionary[A, B]) extends mutable.AbstractMap[A, B] with mutable.Map[A, B] {
+    override def size: Int = underlying.size
+
+    def get(k: A) = Option(underlying get k)
+
+    def add(kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtract(key: A): this.type = { underlying remove key; this }
+
+    override def put(k: A, v: B): Option[B] = Option(underlying.put(k, v))
+
+    override def update(k: A, v: B): Unit = { underlying.put(k, v) }
+
+    override def remove(k: A): Option[B] = Option(underlying remove k)
+
+    def iterator() = enumerationAsScalaIterator(underlying.keys) map (k => (k, underlying get k))
+
+    override def clear() = underlying.clear()
+
+    protected[this] def fromSpecificIterable(coll: Iterable[(A, B)]) = mutable.HashMap.from(coll)
+    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
+    def mapFactory = mutable.HashMap
+    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
+    def empty = mutable.HashMap.empty
+  }
+
+  case class JPropertiesWrapper(underlying: ju.Properties) extends mutable.AbstractMap[String, String]
+            with mutable.MapOps[String, String, mutable.Map, mutable.Map[String, String]] {
+
+    override def size = underlying.size
+
+    def get(k: String) = {
+      val v = underlying get k
+      if (v != null) Some(v.asInstanceOf[String]) else None
+    }
+
+    def add(kv: (String, String)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtract(key: String): this.type = { underlying remove key; this }
+
+    override def put(k: String, v: String): Option[String] = {
+      val r = underlying.put(k, v)
+      if (r != null) Some(r.asInstanceOf[String]) else None
+    }
+
+    override def update(k: String, v: String): Unit = { underlying.put(k, v) }
+
+    override def remove(k: String): Option[String] = {
+      val r = underlying remove k
+      if (r != null) Some(r.asInstanceOf[String]) else None
+    }
+
+    def iterator(): Iterator[(String, String)] = new AbstractIterator[(String, String)] {
+      val ui = underlying.entrySet.iterator
+      def hasNext = ui.hasNext
+      def next() = {
+        val e = ui.next()
+        (e.getKey.asInstanceOf[String], e.getValue.asInstanceOf[String])
+      }
+    }
+
+    override def clear() = underlying.clear()
+
+    override def empty = JPropertiesWrapper(new ju.Properties)
+
+    def getProperty(key: String) = underlying.getProperty(key)
+
+    def getProperty(key: String, defaultValue: String) =
+      underlying.getProperty(key, defaultValue)
+
+    def setProperty(key: String, value: String) =
+      underlying.setProperty(key, value)
+
+    protected[this] def fromSpecificIterable(coll: Iterable[(String, String)]) = mutable.HashMap.from(coll)
+    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
+    def mapFactory = mutable.HashMap
+    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
+  }
+}
+
+@SerialVersionUID(0 - 5857859809262781311L)
+object Wrappers extends Wrappers with Serializable

--- a/test/junit/src/test/scala/strawman/collection/convert/MapWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/MapWrapperTest.scala
@@ -1,0 +1,59 @@
+package strawman.collection.convert
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MapWrapperTest {
+
+  /* Test for scala/bug#7883 */
+  @Test
+  def testContains(): Unit = {
+    import strawman.collection.JavaConverters.mapAsJavaMapConverter
+    import scala.language.reflectiveCalls  // for accessing containsCounter
+
+    // A HashMap which throws an exception when the iterator() method is called.
+    // Before the fix for scala/bug#7883, calling MapWrapper.containsKey() used to
+    // iterate through every element of the wrapped Map, and thus would crash
+    // in this case.
+    val scalaMap = new strawman.collection.mutable.HashMap[String, String] {
+      var containsCounter = 0  // keep track of how often contains() has been called.
+      override def iterator = throw new UnsupportedOperationException
+
+      override def contains(key: String): Boolean = {
+        containsCounter += 1
+        super.contains(key)
+      }
+    }
+
+    val javaMap = scalaMap.asJava
+
+    scalaMap("hello") = "world"
+    scalaMap(null) = "null's value"
+
+    assertEquals(0, scalaMap.containsCounter)
+    assertTrue(javaMap.containsKey("hello"))     // positive test
+    assertTrue(javaMap.containsKey(null))        // positive test, null key
+
+    assertFalse(javaMap.containsKey("goodbye"))  // negative test
+    // Note: this case does NOT make it to scalaMap's contains() method because the runtime
+    // cast fails in MapWrapper, so the containsCounter is not incremented in this case.
+    assertFalse(javaMap.containsKey(42))         // negative test, wrong key type
+
+    assertEquals(Some("null's value"), scalaMap.remove(null))
+    assertFalse(javaMap.containsKey(null))       // negative test, null key
+    assertEquals(4, scalaMap.containsCounter)
+  }
+
+  // test for scala/bug#8504
+  @Test
+  def testHashCode(): Unit = {
+    import strawman.collection.JavaConverters._
+    val javaMap = strawman.collection.immutable.Map(1 -> null).asJava
+
+    // Before the fix for scala/bug#8504, this throws a NPE
+    javaMap.hashCode
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/NullSafetyToJavaTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/NullSafetyToJavaTest.scala
@@ -1,0 +1,72 @@
+package strawman.collection.convert
+
+import java.util.{concurrent => juc}
+import java.{lang => jl, util => ju}
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import strawman.collection.JavaConverters._
+import strawman.collection.{concurrent, mutable}
+
+// scala/bug#9113: tests to insure that wrappers return null instead of wrapping it as a collection
+
+@RunWith(classOf[JUnit4])
+class NullSafetyToJavaTest {
+  @Test def testIteratorDecoration(): Unit = {
+    val nullIterator: strawman.collection.Iterator[AnyRef] = null
+
+    assert(nullIterator.asJava == null)
+  }
+
+  @Test def testEnumerationDecoration(): Unit = {
+    val nullEnumeration: strawman.collection.Iterator[AnyRef] = null
+
+    assert(nullEnumeration.asJavaEnumeration == null)
+  }
+
+  @Test def testIterableDecoration(): Unit = {
+    val nullIterable: strawman.collection.Iterable[AnyRef] = null
+
+    assert(nullIterable.asJava == null)
+  }
+
+  @Test def testCollectionDecoration(): Unit = {
+    val nullCollection: strawman.collection.Iterable[AnyRef] = null
+
+    assert(nullCollection.asJavaCollection == null)
+  }
+
+  @Test def testBufferDecoration(): Unit = {
+    val nullBuffer: mutable.Buffer[AnyRef] = null
+
+    assert(nullBuffer.asJava == null)
+  }
+
+  @Test def testSetDecoration(): Unit = {
+    val nullSet: strawman.collection.immutable.Set[AnyRef] = null
+
+    assert(nullSet.asJava == null)
+  }
+
+  @Test def testMapDecoration(): Unit = {
+    val nullMap: mutable.Map[AnyRef, AnyRef] = null
+
+    assert(nullMap.asJava == null)
+  }
+
+  @Test def testConcurrentMapDecoration(): Unit = {
+    val nullConMap: concurrent.Map[AnyRef, AnyRef] = null
+
+    assert(nullConMap.asJava == null)
+  }
+
+  @Test def testDictionaryDecoration(): Unit = {
+    val nullDict: mutable.Map[AnyRef, AnyRef] = null
+
+    assert(nullDict.asJavaDictionary == null)
+  }
+
+  // Decorator conversion to ju.Properties is not available
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/NullSafetyToScalaTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/NullSafetyToScalaTest.scala
@@ -1,0 +1,76 @@
+package strawman.collection.convert
+
+import java.util.{concurrent => juc}
+import java.{lang => jl, util => ju}
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import strawman.collection.JavaConverters._
+import strawman.collection.{concurrent, mutable}
+
+// scala/bug#9113: tests to insure that wrappers return null instead of wrapping it as a collection
+
+@RunWith(classOf[JUnit4])
+class NullSafetyToScalaTest {
+  @Test def testIteratorDecoration(): Unit = {
+    val nullJIterator: ju.Iterator[AnyRef] = null
+
+    assert(nullJIterator.asScala == null)
+  }
+
+  @Test def testEnumerationDecoration(): Unit = {
+    val nullJEnumeration: ju.Enumeration[AnyRef] = null
+
+    assert(nullJEnumeration.asScala == null)
+  }
+
+  @Test def testIterableDecoration(): Unit = {
+    val nullJIterable: jl.Iterable[AnyRef] = null
+
+    assert(nullJIterable.asScala == null)
+  }
+
+  @Test def testCollectionDecoration(): Unit = {
+    val nullJCollection: ju.Collection[AnyRef] = null
+
+    assert(nullJCollection.asScala == null)
+  }
+
+  @Test def testBufferDecoration(): Unit = {
+    val nullJBuffer: ju.List[AnyRef] = null
+
+    assert(nullJBuffer.asScala == null)
+  }
+
+  @Test def testSetDecoration(): Unit = {
+    val nullJSet: ju.Set[AnyRef] = null
+
+    assert(nullJSet.asScala == null)
+  }
+
+  @Test def testMapDecoration(): Unit = {
+    val nullJMap: ju.Map[AnyRef, AnyRef] = null
+
+    assert(nullJMap.asScala == null)
+  }
+
+  @Test def testConcurrentMapDecoration(): Unit = {
+    val nullJConMap: juc.ConcurrentMap[AnyRef, AnyRef] = null
+
+    assert(nullJConMap.asScala == null)
+  }
+
+  @Test def testDictionaryDecoration(): Unit = {
+    val nullJDict: ju.Dictionary[AnyRef, AnyRef] = null
+
+    assert(nullJDict.asScala == null)
+  }
+
+  @Test def testPropertiesDecoration(): Unit = {
+    val nullJProperties: ju.Properties = null
+
+    assert(nullJProperties.asScala == null)
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/WrapperSerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/WrapperSerializationTest.scala
@@ -1,0 +1,29 @@
+package strawman.collection.convert
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class WrapperSerializationTest {
+  def ser(a: AnyRef) = {
+    val baos = new java.io.ByteArrayOutputStream
+    (new java.io.ObjectOutputStream(baos)).writeObject(a)
+    baos
+  }
+  def des(baos: java.io.ByteArrayOutputStream): AnyRef = {
+    val bais = new java.io.ByteArrayInputStream(baos.toByteArray)
+    (new java.io.ObjectInputStream(bais)).readObject()
+  }
+  def serdes(a: AnyRef): Boolean = a == des(ser(a))
+
+  @Test
+  def test_SI8911(): Unit = {
+    import strawman.collection.JavaConverters._
+    assert( serdes(strawman.collection.mutable.ArrayBuffer(1,2).asJava) )
+    assert( serdes(strawman.collection.Seq(1,2).asJava) )
+    assert( serdes(strawman.collection.immutable.Set(1,2).asJava) )
+    assert( serdes(strawman.collection.immutable.Map(1 -> "one", 2 -> "two").asJava) )
+  }
+}


### PR DESCRIPTION
Pretty much 1:1 from the current 2.12/2.13 impl. Deprecated parts only when necessary to implement the non-deprecated ones.