### PR TITLE
Enable Java converters for concurrent maps

### DIFF
--- a/collections/src/main/scala/strawman/collection/convert/AsJavaConverters.scala
+++ b/collections/src/main/scala/strawman/collection/convert/AsJavaConverters.scala
@@ -240,8 +240,6 @@ trait AsJavaConverters {
     case _                    => new MapWrapper(m)
   }
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *
@@ -261,5 +259,4 @@ trait AsJavaConverters {
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)
   }
-  */
 }

--- a/collections/src/main/scala/strawman/collection/convert/AsScalaConverters.scala
+++ b/collections/src/main/scala/strawman/collection/convert/AsScalaConverters.scala
@@ -152,8 +152,6 @@ trait AsScalaConverters {
     case _                          => new JMapWrapper(m)
   }
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
    *
@@ -173,7 +171,6 @@ trait AsScalaConverters {
     case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
     case _                                => new JConcurrentMapWrapper(m)
   }
-  */
 
   /**
    * Converts a Java `Dictionary` to a Scala mutable `Map`.

--- a/collections/src/main/scala/strawman/collection/convert/DecorateAsJava.scala
+++ b/collections/src/main/scala/strawman/collection/convert/DecorateAsJava.scala
@@ -100,13 +100,10 @@ trait DecorateAsJava extends AsJavaConverters {
   implicit def mapAsJavaMapConverter[A, B](m : Map[A, B]): AsJava[ju.Map[A, B]] =
     new AsJava(mapAsJavaMap(m))
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    * @see [[mapAsJavaConcurrentMap]].
    */
   implicit def mapAsJavaConcurrentMapConverter[A, B](m: concurrent.Map[A, B]): AsJava[juc.ConcurrentMap[A, B]] =
     new AsJava(mapAsJavaConcurrentMap(m))
-  */
 }

--- a/collections/src/main/scala/strawman/collection/convert/DecorateAsScala.scala
+++ b/collections/src/main/scala/strawman/collection/convert/DecorateAsScala.scala
@@ -66,15 +66,12 @@ trait DecorateAsScala extends AsScalaConverters {
   implicit def mapAsScalaMapConverter[A, B](m : ju.Map[A, B]): AsScala[mutable.Map[A, B]] =
     new AsScala(mapAsScalaMap(m))
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
    * @see [[mapAsScalaConcurrentMap]]
    */
   implicit def mapAsScalaConcurrentMapConverter[A, B](m: juc.ConcurrentMap[A, B]): AsScala[concurrent.Map[A, B]] =
     new AsScala(mapAsScalaConcurrentMap(m))
-   */
 
   /**
    * Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.

--- a/collections/src/main/scala/strawman/collection/convert/WrapAsJava.scala
+++ b/collections/src/main/scala/strawman/collection/convert/WrapAsJava.scala
@@ -31,8 +31,7 @@ trait WrapAsJava extends LowPriorityWrapAsJava {
   implicit def `deprecated mutableMapAsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
   implicit def `deprecated asJavaDictionary`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
   implicit def `deprecated mapAsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
-  //TODO Add concurrent maps back
-  //implicit def `deprecated mapAsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+  implicit def `deprecated mapAsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
 }
 
 private[convert] trait LowPriorityWrapAsJava {
@@ -266,8 +265,6 @@ private[convert] trait LowPriorityWrapAsJava {
     case _                    => new MapWrapper(m)
   }
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Implicitly converts a Scala mutable `concurrent.Map` to a Java
    * `ConcurrentMap`.
@@ -288,7 +285,6 @@ private[convert] trait LowPriorityWrapAsJava {
     case JConcurrentMapWrapper(wrapped) => wrapped
     case _                              => new ConcurrentMapWrapper(m)
   }
-  */
 }
 
 @deprecated("use JavaConverters or consider ImplicitConversionsToJava", since="2.12.0")

--- a/collections/src/main/scala/strawman/collection/convert/WrapAsScala.scala
+++ b/collections/src/main/scala/strawman/collection/convert/WrapAsScala.scala
@@ -27,8 +27,7 @@ trait WrapAsScala extends LowPriorityWrapAsScala {
   implicit def `deprecated asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
   implicit def `deprecated asScalaSet`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
   implicit def `deprecated mapAsScalaMap`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
-  //TODO Add concurrent maps back
-  //implicit def `deprecated mapAsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+  implicit def `deprecated mapAsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
   implicit def `deprecated dictionaryAsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
   implicit def `deprecated propertiesAsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
 }
@@ -176,8 +175,6 @@ private[convert] trait LowPriorityWrapAsScala {
     case _                          => new JMapWrapper(m)
   }
 
-  //TODO Add concurrent maps back
-  /*
   /**
    * Implicitly converts a Java ConcurrentMap to a Scala mutable ConcurrentMap.
    * The returned Scala ConcurrentMap is backed by the provided Java
@@ -196,7 +193,6 @@ private[convert] trait LowPriorityWrapAsScala {
     case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
     case _                                => new JConcurrentMapWrapper(m)
   }
-  */
 
   /**
    * Implicitly converts a Java `Dictionary` to a Scala mutable

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -342,8 +342,6 @@ private[collection] trait Wrappers {
     override def empty = JMapWrapper(new ju.HashMap[A, B])
   }
 
-  //TODO Add concurrent maps back
-  /*
   class ConcurrentMapWrapper[A, B](override val underlying: concurrent.Map[A, B]) extends MutableMapWrapper[A, B](underlying) with juc.ConcurrentMap[A, B] {
 
     override def putIfAbsent(k: A, v: B) = underlying.putIfAbsent(k, v) match {
@@ -384,7 +382,6 @@ private[collection] trait Wrappers {
     def replace(k: A, oldvalue: B, newvalue: B): Boolean =
       underlying.replace(k, oldvalue, newvalue)
   }
-  */
 
   case class DictionaryWrapper[A, B](underlying: mutable.Map[A, B]) extends ju.Dictionary[A, B] {
     def size: Int = underlying.size


### PR DESCRIPTION
Here's the `concurrent.Map` support that was still missing in #279