### PR TITLE
Fix broken scalafix tests

### DIFF
--- a/scalafix/output/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/output/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -1,6 +1,6 @@
 package fix
 
-import scala.Predef.{ augmentString => _, genericArrayOps => _, genericWrapArray => _, intArrayOps => _, wrapIntArray => _, wrapString => _, _ }
+import scala.Predef.{ augmentString => _, genericArrayOps => _, intArrayOps => _, wrapString => _, _ }
 import strawman.collection.{ arrayToArrayOps, stringToStringOps }
 import strawman.collection.immutable.{ ::, HashMap, LazyList, List, Map, Nil, Range, Vector }
 import strawman.collection.immutable.LazyList.#::


### PR DESCRIPTION
There are two scalafix tests failing:

- scala/fix/Collectionstrawman_v0_Traversable.scala:
```
[info]   =======
[info]   => Diff
[info]   =======
[info]        xs.to(strawman.collection.Map)
[info]   -    xs.iterator
[info]   +    xs.iterator()
```

`scala.collection.TraversableLike.toIterator` was being converted to `iterable` without `()`

- scala/fix/Collectionstrawman_v0.scala:
```
[info]   =======
[info]   => Diff
[info]   =======
[info]   -import scala.Predef.{ augmentString => _, intArrayOps => _, wrapString => _, _ }
[info]   +import scala.Predef.{ augmentString => _, genericArrayOps => _, genericWrapArray => _, intArrayOps => _, wrapIntArray => _, wrapString => _, _ }
```

Here some unimports from Predef were not being added to the resulting file (`genericArrayOps`, `genericWrapArray` and `wrapIntArray`).