### PR TITLE
Add the `splitWith` operation to SeqDecorator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,10 @@ val `collections-contrib` =
   crossProj("collections-contrib", file("collections-contrib"))
     .dependsOn(collections)
     .settings(
-      name := "collections-contrib"
+      name := "collections-contrib",
+      libraryDependencies ++= Seq(
+        ("org.scalacheck" %% "scalacheck" % "1.13.5" % Test).withDottyCompat()
+      )
     )
 
 val `collections-contrib-jvm` = `collections-contrib`.jvm

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/SeqDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/SeqDecorator.scala
@@ -44,4 +44,47 @@ class SeqDecorator[A, CC[X] <: SeqOps[X, CC, _]](`this`: CC[A]) {
   def intersperse[B >: A, C](start: B, sep: B, end: B): CC[B] =
     `this`.iterableFactory.from(View.IntersperseSurround(`this`.toIterable, start, sep, end))
 
+  /** Splits this collection into groups according to the given predicate.
+    *
+    * @param p the predicate used to discriminate elements
+    * @return A nested collection with groups of elements,
+    *         opening new groups whenever the predicate
+    *         changes the return type
+    *
+    * @example {{{
+    * // Example 1: Split a list of integers into groups that are even / odd
+    * List(1, 2, 4, 6, 7).splitWith(i => i % 2 == 0) => List(List(1), List(2, 4, 6), List(7))
+    *
+    * // Example 2: Split a list of chars into groups that are upper case or lower case
+    * List('a', 'b', 'C', 'D', 'e', 'f').splitWith(_.isUpper) => List(List('a', 'b'), List('C', 'D'), List('e', 'f'))
+    * }}}
+    */
+  def splitWith(p: A => Boolean): CC[CC[A]] = {
+    def newGroupBuilder() = `this`.iterableFactory.newBuilder[A]()
+
+    val groups = `this`.iterableFactory.newBuilder[CC[A]]()
+    val it = `this`.iterator()
+
+    var currentGroup = newGroupBuilder()
+    var lastTestResult = Option.empty[Boolean]
+
+    while (it.hasNext) {
+      val elem = it.next()
+      val currentTest = p(elem)
+
+      lastTestResult match {
+        case None =>
+          currentGroup.add(elem)
+        case Some(lastTest) if currentTest == lastTest =>
+          currentGroup.add(elem)
+        case Some(_) =>
+          groups.add(currentGroup.result())
+          currentGroup = newGroupBuilder().add(elem)
+      }
+
+      lastTestResult = Some(currentTest)
+    }
+
+    groups.add(currentGroup.result()).result()
+  }
 }

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -18,5 +18,4 @@ package object decorators {
 
   implicit def MutableMapDecorator[K, V](map: mutable.Map[K, V]): MutableMapDecorator[K, V] =
     new MutableMapDecorator[K, V](map)
-
 }

--- a/collections-contrib/src/test/scala/strawman/collection/Generators.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/Generators.scala
@@ -2,12 +2,11 @@ package strawman.collection
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.listOf
-
-import scala.collection.immutable.{List => ScalaList}
-import scala.collection.immutable.{Vector => ScalaVector}
-import strawman.collection.immutable.{List, Vector}
 import org.scalacheck.{Arbitrary, Gen}
+import strawman.collection.immutable.{List, Vector}
+import scala.collection.immutable.{List => ScalaList, Vector => ScalaVector}
 
+// TODO remove once scalacheck subproject is cross compiled
 object Generators {
 
   implicit def arbitraryVector[A](implicit arbitraryOldVector: Arbitrary[ScalaVector[A]]): Arbitrary[Vector[A]] =

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/SeqDecoratorProperties.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/SeqDecoratorProperties.scala
@@ -1,0 +1,12 @@
+package strawman.collection.decorators
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import strawman.collection.Generators._
+import strawman.collection.immutable.List
+
+class SeqDecoratorProperties extends Properties("SeqDecorator") {
+  property("splitWith retains elements") = forAll { seq: List[Char] =>
+    seq.splitWith(_.isUpper).flatten.sameElements(seq)
+  }
+}

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/SeqDecoratorTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/SeqDecoratorTest.scala
@@ -3,8 +3,7 @@ package decorators
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import strawman.collection.immutable.List
+import strawman.collection.immutable.{LazyList, List, Vector}
 
 class SeqDecoratorTest {
 
@@ -15,6 +14,15 @@ class SeqDecoratorTest {
     assertEquals(List(1, 2), List.empty[Int].intersperse(1, 0, 2))
     assertEquals(List(1), List(1).intersperse(0))
     assertEquals(List(0, 1, 2), List(1).intersperse(0, 5, 2))
+  }
+
+  @Test def splitWith(): Unit = {
+    assertEquals(List(List(1), List(2, 4), List(3), List(6)), List(1, 2, 4, 3, 6).splitWith(i => i % 2 == 0))
+    assertEquals(Vector(Vector()), Vector[Int]().splitWith(_ => false))
+    assertEquals(LazyList(LazyList(1, 2 ,3)), LazyList(1, 2, 3).splitWith(_ => true))
+
+    // TODO make it work with Strings
+    // assertEquals(Vector("ab", "CDE", "f"), "abCDEf".splitWith(_.isUpper))
   }
 
 }


### PR DESCRIPTION
Relates to #241. This pull request adds the first of the two proposed methods.

There is still some bikeshedding to do before merging, I will comment when it's ready, but please comment!

Greetings from the Scala Center FLOSS Spree at Scala.io 2017!