### PR TITLE
Upgrade Scalafix to latest (0.5.3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ expected output files:
 > tests/test
 ~~~
 
-Fix the implementation of the rewrite (in the
-`rewrites/src/main/scala/fix/Collectionstrawman_v0.scala` file) until the
+Fix the implementation of the rule (in the
+`rules/src/main/scala/fix/Collectionstrawman_v0.scala` file) until the
 tests are green. You can find more help about the scalafix API in its
-[documentation](https://scalacenter.github.io/scalafix/#Creatingyourownrewrite).
+[documentation](https://scalacenter.github.io/scalafix/docs/rule-authors/setup).

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -7,9 +7,9 @@ inScope(Global)(
 
 lazy val root = project
   .in(file("."))
-  .aggregate(rewrites, input, output, tests)
+  .aggregate(rules, input, output, tests)
 
-lazy val rewrites = project.settings(
+lazy val rules = project.settings(
   libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % scalafixVersion
 )
 
@@ -41,5 +41,5 @@ lazy val tests = project
         classDirectory.in(input, Compile).value
     )
   )
-  .dependsOn(input, rewrites)
+  .dependsOn(input, rules)
   .enablePlugins(BuildInfoPlugin)

--- a/scalafix/input/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/input/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -1,5 +1,5 @@
 /*
-rewrite = "scala:fix.Collectionstrawman_v0"
+rule = "scala:fix.Collectionstrawman_v0"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
+++ b/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
@@ -1,5 +1,5 @@
 /*
-rewrite = "scala:fix.Collectionstrawman_v0"
+rule = "scala:fix.Collectionstrawman_v0"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/ListTest.scala
+++ b/scalafix/input/src/main/scala/fix/ListTest.scala
@@ -1,5 +1,5 @@
 /*
-rewrite = "scala:fix.Collectionstrawman_v0"
+rule = "scala:fix.Collectionstrawman_v0"
 */
 package fix
 

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-M4")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC9")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.3")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-

--- a/scalafix/tests/src/test/scala/fix/Collectionstrawman_Tests.scala
+++ b/scalafix/tests/src/test/scala/fix/Collectionstrawman_Tests.scala
@@ -5,8 +5,8 @@ import scalafix.testkit._
 import scalafix._
 
 class Collectionstrawman_Tests
-  extends SemanticRewriteSuite(
-    SemanticCtx.load(Classpath(AbsolutePath(BuildInfo.inputClassdirectory))),
+  extends SemanticRuleSuite(
+    SemanticdbIndex.load(Classpath(AbsolutePath(BuildInfo.inputClassdirectory))),
     AbsolutePath(BuildInfo.inputSourceroot),
     Seq(AbsolutePath(BuildInfo.outputSourceroot))
   ) {


### PR DESCRIPTION
Upgrading Scalafix from `0.5.0-M4` to `0.5.3`. There were [breaking changes in `0.5.0-RC3`](https://github.com/scalacenter/scalafix/releases/tag/v0.5.0-RC3) as well as in [Scalameta `2.0`](https://github.com/scalameta/scalameta/blob/15a0187501dc8e5a6fe06d0e002ce1d3340968dc/changelog/2.0.0.md#breaking-changes). 

/cc @olafurpg 