### PR TITLE
Scalafix rewrite for lazyZip

### DIFF
--- a/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
+++ b/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
@@ -1,0 +1,36 @@
+/*
+rule = "scala:fix.Collectionstrawman_v0"
+ */
+package fix
+
+import scala.language.postfixOps
+object Collectionstrawman_v0_Tuple2Zipped {
+  def zipped(xs: List[Int], ys: List[Int]): Unit = {
+    (xs, ys).zipped
+    (xs,ys).zipped
+    ((xs, ys) zipped)
+    (((xs)    ,    (ys)).zipped)
+    (xs, // foo
+      ys).zipped
+    /* a */(/* b */ xs /* c */, /* d */ ys /* e */)/* f */./* g */zipped/* h */
+    (coll(1), coll(2)).zipped
+    (List(1, 2, 3), Stream.from(1)).zipped
+  }
+  def coll(x: Int): List[Int] = ???
+}
+
+object Collectionstrawman_v0_Tuple3Zipped {
+  def zipped(xs: List[Int], ys: List[Int], zs: List[Int]): Unit = {
+    (xs, ys, zs).zipped
+    (xs,ys,zs).zipped
+    ((xs, ys, zs) zipped)
+    (((xs)    ,    (ys)    ,    (zs)).zipped)
+    (xs, // foo
+      ys, // bar
+      zs).zipped
+    /* a */(/* b */ xs /* c */, /* d */ ys /* e */, /* f */ zs /* g */)/* h */./* i */zipped/* j */
+    (coll(1), coll(2), coll(3)).zipped
+    (List(1, 2, 3), Set(1, 2, 3), Stream.from(1)).zipped
+  }
+  def coll(x: Int): List[Int] = ???
+}

--- a/scalafix/output/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
+++ b/scalafix/output/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
@@ -1,0 +1,34 @@
+package fix
+
+import scala.language.postfixOps
+import strawman.collection.immutable.{ LazyList, List, Set }
+object Collectionstrawman_v0_Tuple2Zipped {
+  def zipped(xs: List[Int], ys: List[Int]): Unit = {
+    xs.lazyZip(ys)
+    xs.lazyZip(ys)
+    (xs.lazyZip(ys) )
+    ((xs).lazyZip((ys)))
+    xs.lazyZip(// foo
+      ys)
+    /* a *//* b */ xs /* c */.lazyZip(/* d */ ys /* e */)/* f *//* g *//* h */
+    coll(1).lazyZip(coll(2))
+    List(1, 2, 3).lazyZip(LazyList.from(1))
+  }
+  def coll(x: Int): List[Int] = ???
+}
+
+object Collectionstrawman_v0_Tuple3Zipped {
+  def zipped(xs: List[Int], ys: List[Int], zs: List[Int]): Unit = {
+    xs.lazyZip(ys).lazyZip(zs)
+    xs.lazyZip(ys).lazyZip(zs)
+    (xs.lazyZip(ys).lazyZip(zs) )
+    ((xs).lazyZip((ys)).lazyZip((zs)))
+    xs.lazyZip(// foo
+      ys).lazyZip(// bar
+      zs)
+    /* a *//* b */ xs /* c */.lazyZip(/* d */ ys /* e */).lazyZip(/* f */ zs /* g */)/* h *//* i *//* j */
+    coll(1).lazyZip(coll(2)).lazyZip(coll(3))
+    List(1, 2, 3).lazyZip(Set(1, 2, 3)).lazyZip(LazyList.from(1))
+  }
+  def coll(x: Int): List[Int] = ???
+}

--- a/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -116,6 +116,10 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
     Symbol("_root_.scala.collection.LinearSeqLike.iterator."),
     Symbol("_root_.scala.collection.TraversableLike.toIterator.")
   )
+  val tupleZipped = SymbolMatcher.normalized(
+    Symbol("_root_.scala.runtime.Tuple2Zipped.Ops.zipped."),
+    Symbol("_root_.scala.runtime.Tuple3Zipped.Ops.zipped.")
+  )
 
   def replaceToList(ctx: RuleCtx) =
     ctx.tree.collect {
@@ -132,13 +136,55 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
           close <- ctx.matchingParens.close(open.asInstanceOf[Token.LeftBracket])
         } yield
           ctx.replaceToken(open, "(") +
-            ctx.replaceToken(close, ")")).getOrElse(Patch.empty)
+            ctx.replaceToken(close, ")")
+        ).asPatch
+    }.asPatch
+
+  def replaceTupleZipped(ctx: RuleCtx) =
+    ctx.tree.collect {
+      case tupleZipped(Term.Select(Term.Tuple(args), name)) =>
+        val removeTokensPatch =
+          (for {
+            zipped <- name.tokens.headOption
+            closeTuple <- ctx.tokenList.leading(zipped).find(_.is[Token.RightParen])
+            openTuple <- ctx.matchingParens.open(closeTuple.asInstanceOf[Token.RightParen])
+            maybeDot = ctx.tokenList.slice(closeTuple, zipped).find(_.is[Token.Dot])
+          } yield {
+            ctx.removeToken(openTuple) +
+              maybeDot.map(ctx.removeToken).asPatch +
+              ctx.removeToken(zipped)
+          }).asPatch
+
+        def removeSurroundingWhiteSpaces(tk: Token) =
+          (ctx.tokenList.trailing(tk).takeWhile(_.is[Token.Space]).map(ctx.removeToken) ++
+            ctx.tokenList.leading(tk).takeWhile(_.is[Token.Space]).map(ctx.removeToken)).asPatch
+
+        val commas =
+          for {
+            (prev, next) <- args.zip(args.tail)
+            tokensBetweenArgs = ctx.tokenList.slice(prev.tokens.last, next.tokens.head)
+            comma <- tokensBetweenArgs.find(_.is[Token.Comma])
+          } yield comma
+
+        val replaceCommasPatch = commas match {
+          case head :: tail =>
+            ctx.replaceToken(head, ".lazyZip(") +
+              removeSurroundingWhiteSpaces(head) ++
+              tail.map { comma =>
+                ctx.replaceToken(comma, ").lazyZip(") +
+                  removeSurroundingWhiteSpaces(comma)
+              }
+          case _ => Patch.empty
+        }
+
+        removeTokensPatch + replaceCommasPatch
     }.asPatch
 
   override def fix(ctx: RuleCtx): Patch = {
     replaceToList(ctx) +
       replaceSymbols(ctx) +
       replaceExtensionMethods(ctx) +
-      replaceRange(ctx)
+      replaceRange(ctx) +
+      replaceTupleZipped(ctx)
   }
 }


### PR DESCRIPTION
Enhancing the scalafix rule to rewrite `(xs, ys).zipped` to `xs.lazyZip(ys)` (likewise for triples).

There is one caveat here: `LazyZipN.filter` [is not equivalent to](https://github.com/scala/collection-strawman/pull/223#issuecomment-336372816) `TupleNZipped.filter`. This will likely require manual intervention to be fully fixed. Choosing not to rewrite `(xs, ys).zipped.filter(p)` would leave it in a broken state anyway because a `TupleNZipped` cannot be created with iterables from strawman.

/cc @olafurpg 