### PR TITLE
Make foldSomeLeft and lazyFoldRight decorators

### DIFF
--- a/collections-contrib/src/main/scala/strawman/collection/decorators/IterableDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/IterableDecorator.scala
@@ -4,7 +4,30 @@ package decorators
 
 class IterableDecorator[A](val `this`: Iterable[A]) extends AnyVal {
 
+  /**
+    * Left to right fold that stops if the combination function `op`
+    * returns `None`
+    * @param z the start value
+    * @param op the binary operator
+    * @tparam B the result type of the binary operator
+    * @return the result of inserting `op` between consecutive elements of the collection,
+    *         going left to right with the start value `z` on the left, and stopping when
+    *         all the elements have been traversed or earlier if the operator returns `None`
+    */
   def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B =
     `this`.iterator().foldSomeLeft(z)(op)
+
+  /**
+    * Right to left fold that can be interrupted before traversing the whole collection.
+    * @param z the start value
+    * @param op the operator
+    * @tparam B the result type
+    * @return the result of applying the operator between consecutive elements of the collection,
+    *         going right to left, with the start value `z` on the right. The result of the application
+    *         of the function `op` to each element drives the process: if it returns `Left(result)`,
+    *         then `result` is returned without iterating further; if it returns `Right(f)`, the function
+    *         `f` is applied to the previous result to produce the new result and the fold continues.
+    */
+  def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = `this`.iterator().lazyFoldRight(z)(op)
 
 }

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/IterableDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/IterableDecorator.scala
@@ -1,0 +1,10 @@
+package strawman
+package collection
+package decorators
+
+class IterableDecorator[A](val `this`: Iterable[A]) extends AnyVal {
+
+  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B =
+    `this`.iterator().foldSomeLeft(z)(op)
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/IteratorDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/IteratorDecorator.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package decorators
 
-class IteratorDecorator[A](`this`: Iterator[A]) {
+class IteratorDecorator[A](val `this`: Iterator[A]) extends AnyVal {
 
   def intersperse[B >: A](sep: B): Iterator[B] = new Iterator[B] {
     var intersperseNext = false
@@ -37,6 +37,17 @@ class IteratorDecorator[A](`this`: Iterator[A]) {
       } else {
         throw new NoSuchElementException("next on empty iterator")
       }
+  }
+
+  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B = {
+    var result: B = z
+    while (`this`.hasNext) {
+      op(result, `this`.next()) match {
+        case Some(v) => result = v
+        case None => return result
+      }
+    }
+    result
   }
 
 }

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -4,8 +4,11 @@ import scala.language.implicitConversions
 
 package object decorators {
 
-  implicit def IteratorDecorator[A](it: Iterator[A]): IteratorDecorator[A] =
+  implicit def iteratorDecorator[A](it: Iterator[A]): IteratorDecorator[A] =
     new IteratorDecorator[A](it)
+
+  implicit def iterableDecorator[A](it: Iterable[A]): IterableDecorator[A] =
+    new IterableDecorator(it)
 
   implicit def SeqDecorator[A, CC[X] <: SeqOps[X, CC, _]](seq: CC[A]): SeqDecorator[A, CC] =
     new SeqDecorator[A, CC](seq)

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/IterableDecoratorTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/IterableDecoratorTest.scala
@@ -2,7 +2,7 @@ package strawman.collection
 package decorators
 
 import org.junit.{Assert, Test}
-import strawman.collection.immutable.{List, Range}
+import strawman.collection.immutable.{LazyList, List, Range}
 
 class IterableDecoratorTest {
 
@@ -16,5 +16,12 @@ class IterableDecoratorTest {
 
       Assert.assertEquals(10, List[Int]().foldSomeLeft(10)((x, y) => Some(x + y)))
     }
+
+  @Test def lazyFoldRightIsLazy(): Unit = {
+    val xs = LazyList.from(0)
+    def chooseOne(x: Int): Either[Int, Int => Int]= if (x < (1 << 16)) Right(identity) else Left(x)
+
+    Assert.assertEquals(1 << 16, xs.lazyFoldRight(0)(chooseOne))
+  }
 
 }

--- a/collections-contrib/src/test/scala/strawman/collection/decorators/IterableDecoratorTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/decorators/IterableDecoratorTest.scala
@@ -1,0 +1,20 @@
+package strawman.collection
+package decorators
+
+import org.junit.{Assert, Test}
+import strawman.collection.immutable.{List, Range}
+
+class IterableDecoratorTest {
+
+  @Test
+  def foldSomeLeft(): Unit = {
+      val r = Range(0, 100)
+      Assert.assertEquals(0, r.foldSomeLeft(0)((x, y) => None))
+      Assert.assertEquals(10, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(y)))
+      Assert.assertEquals(55, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(x + y)))
+      Assert.assertEquals(4950, r.foldSomeLeft(0)((x, y) => Some(x + y)))
+
+      Assert.assertEquals(10, List[Int]().foldSomeLeft(10)((x, y) => Some(x + y)))
+    }
+
+}

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -152,6 +152,11 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   @deprecated("Use foldRight instead of :\\", "2.13.0")
   @`inline` final def :\ [B](z: B)(op: (A, B) => B): B = foldRight[B](z)(op)
 
+  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B = iterator().foldSomeLeft(z)(op)
+
+  def foldSomeRight[B](z: B)(op: (A, B) => Option[B]): B =
+    reversed.iterator().foldSomeLeft(z)((b, a) => op(a, b))
+
   /** Reduces the elements of this $coll using the specified associative binary operator.
    *
    *  $undefinedorder

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -152,9 +152,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   @deprecated("Use foldRight instead of :\\", "2.13.0")
   @`inline` final def :\ [B](z: B)(op: (A, B) => B): B = foldRight[B](z)(op)
 
-  /** Lazy fold right */
-  def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = toIterable.iterator().lazyFoldRight(z)(op)
-
   /** Reduces the elements of this $coll using the specified associative binary operator.
    *
    *  $undefinedorder

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -4,7 +4,7 @@ package collection
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
-import scala.{Any, Array, Boolean, `inline`, Int, None, Numeric, Option, Ordering, PartialFunction, StringContext, Some, Unit, deprecated, IllegalArgumentException, Function1, AnyRef}
+import scala.{Any, AnyRef, Array, Boolean, Either, `inline`, Int, None, Numeric, Option, Ordering, PartialFunction, StringContext, Some, Unit, deprecated, IllegalArgumentException, Function1}
 import java.lang.{String, UnsupportedOperationException}
 import scala.Predef.<:<
 
@@ -151,6 +151,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
 
   @deprecated("Use foldRight instead of :\\", "2.13.0")
   @`inline` final def :\ [B](z: B)(op: (A, B) => B): B = foldRight[B](z)(op)
+
+  /** Lazy fold right */
+  def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = toIterable.iterator().lazyFoldRight(z)(op)
 
   /** Reduces the elements of this $coll using the specified associative binary operator.
    *

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -152,11 +152,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   @deprecated("Use foldRight instead of :\\", "2.13.0")
   @`inline` final def :\ [B](z: B)(op: (A, B) => B): B = foldRight[B](z)(op)
 
-  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B = iterator().foldSomeLeft(z)(op)
-
-  def foldSomeRight[B](z: B)(op: (A, B) => Option[B]): B =
-    reversed.iterator().foldSomeLeft(z)((b, a) => op(a, b))
-
   /** Reduces the elements of this $coll using the specified associative binary operator.
    *
    *  $undefinedorder

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -352,17 +352,6 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
   def foldRight[B](z: B)(op: (A, B) => B): B =
     if (hasNext) op(next(), foldRight(z)(op)) else z
   
-  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B = {
-    var result: B = z
-    while (hasNext) {
-      op(result, next()) match {
-        case Some(v) => result = v
-        case None => return result
-      }
-    }
-    result
-  }
-
   /** Produces a collection containing cumulative results of applying the
    *  operator going left to right.
    *

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -355,26 +355,6 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     reversed.foldLeft(z)((b, a) => op(a, b))
   }
   
-  def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = {
-    
-    def chainEval(x: B, fs: immutable.List[B => B]): B =
-      fs.foldLeft(x)((x, f) => f(x))
-    
-    @tailrec
-    def loop(fs: immutable.List[B => B]): B = {
-      if (hasNext) {
-        op(next()) match {
-          case Left(v) => chainEval(v, fs)
-          case Right(g) => loop(g :: fs)
-        }
-      } else {
-        chainEval(z, fs)
-      }
-    }
-    
-    loop(immutable.List.empty)
-  }
-
   /** Produces a collection containing cumulative results of applying the
    *  operator going left to right.
    *

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -2,7 +2,7 @@ package strawman.collection
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
-import scala.{Any, Array, Boolean, IllegalArgumentException, Int, NoSuchElementException, None, Nothing, Numeric, Option, Ordering, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, `inline`, math, throws}
+import scala.{Any, Array, Boolean, Either, IllegalArgumentException, Int, Left, NoSuchElementException, None, Nothing, Numeric, Option, Ordering, PartialFunction, Right, Some, StringContext, Unit, UnsupportedOperationException, `inline`, math, throws}
 import scala.Predef.{identity, intWrapper, require, String}
 import strawman.collection.mutable.{ArrayBuffer, StringBuilder}
 
@@ -349,9 +349,32 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     result
   }
 
-  def foldRight[B](z: B)(op: (A, B) => B): B =
-    if (hasNext) op(next(), foldRight(z)(op)) else z
+  def foldRight[B](z: B)(op: (A, B) => B): B = {
+    var reversed: immutable.List[A] = immutable.Nil
+    while (hasNext) reversed = next() :: reversed
+    reversed.foldLeft(z)((b, a) => op(a, b))
+  }
   
+  def lazyFoldRight[B](z: B)(op: A => Either[B, B => B]): B = {
+    
+    def chainEval(x: B, fs: immutable.List[B => B]): B =
+      fs.foldLeft(x)((x, f) => f(x))
+    
+    @tailrec
+    def loop(fs: immutable.List[B => B]): B = {
+      if (hasNext) {
+        op(next()) match {
+          case Left(v) => chainEval(v, fs)
+          case Right(g) => loop(g :: fs)
+        }
+      } else {
+        chainEval(z, fs)
+      }
+    }
+    
+    loop(immutable.List.empty)
+  }
+
   /** Produces a collection containing cumulative results of applying the
    *  operator going left to right.
    *

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -351,6 +351,17 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
 
   def foldRight[B](z: B)(op: (A, B) => B): B =
     if (hasNext) op(next(), foldRight(z)(op)) else z
+  
+  def foldSomeLeft[B](z: B)(op: (B, A) => Option[B]): B = {
+    var result: B = z
+    while (hasNext) {
+      op(result, next()) match {
+        case Some(v) => result = v
+        case None => return result
+      }
+    }
+    result
+  }
 
   /** Produces a collection containing cumulative results of applying the
    *  operator going left to right.

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -170,6 +170,16 @@ class IteratorTest {
     results += LazyList.from(1).iterator().drop(10).to(LazyList).drop(10).iterator().next()
     assertSameElements(List(21), results)
   }
+  
+  @Test def foldSomeLeft(): Unit = {
+    val r = Range(0, 100)
+    assertEquals(0, r.foldSomeLeft(0)((x, y) => None))
+    assertEquals(10, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(y)))
+    assertEquals(55, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(x + y)))
+    assertEquals(4950, r.foldSomeLeft(0)((x, y) => Some(x + y)))
+    
+    assertEquals(10, List[Int]().foldSomeLeft(10)((x, y) => Some(x + y)))
+  }
 
   // scala/bug#8552
   @Test def indexOfShouldWorkForTwoParams(): Unit = {

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -77,11 +77,6 @@ class IteratorTest {
     assertEquals(10000,  View.fromIteratorProvider(() => mk(10000)).sum)
     assertEquals(100000, View.fromIteratorProvider(() => mk(100000)).sum)
   }
-  
-  @Test def lazyFoldRight(): Unit = {
-    assertEquals(true, LazyList.continually(true).lazyFoldRight(false)(x => if (x) Left(true) else Right(identity[Boolean])))
-    assertEquals(55, Iterator.range(0, 11).lazyFoldRight(0)(x => Right(_ + x)))
-  }
 
   @Test def from(): Unit = {
     val it1 = Iterator.from(-1)
@@ -176,13 +171,6 @@ class IteratorTest {
     assertSameElements(List(21), results)
   }
   
-  @Test def lazyFoldRightIsLazy(): Unit = {
-    val xs = LazyList.from(0)
-    def chooseOne(x: Int): Either[Int, Int => Int]= if (x < (1 << 16)) Right(identity) else Left(x)
-    
-    assertEquals(1 << 16, xs.lazyFoldRight(0)(chooseOne))
-  }
-
   // scala/bug#8552
   @Test def indexOfShouldWorkForTwoParams(): Unit = {
     assertEquals(1, List(1, 2, 3).iterator().indexOf(2, 0))

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -171,16 +171,6 @@ class IteratorTest {
     assertSameElements(List(21), results)
   }
   
-  @Test def foldSomeLeft(): Unit = {
-    val r = Range(0, 100)
-    assertEquals(0, r.foldSomeLeft(0)((x, y) => None))
-    assertEquals(10, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(y)))
-    assertEquals(55, r.foldSomeLeft(0)((x, y) => if (y > 10) None else Some(x + y)))
-    assertEquals(4950, r.foldSomeLeft(0)((x, y) => Some(x + y)))
-    
-    assertEquals(10, List[Int]().foldSomeLeft(10)((x, y) => Some(x + y)))
-  }
-
   // scala/bug#8552
   @Test def indexOfShouldWorkForTwoParams(): Unit = {
     assertEquals(1, List(1, 2, 3).iterator().indexOf(2, 0))

--- a/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/IteratorTest.scala
@@ -77,6 +77,11 @@ class IteratorTest {
     assertEquals(10000,  View.fromIteratorProvider(() => mk(10000)).sum)
     assertEquals(100000, View.fromIteratorProvider(() => mk(100000)).sum)
   }
+  
+  @Test def lazyFoldRight(): Unit = {
+    assertEquals(true, LazyList.continually(true).lazyFoldRight(false)(x => if (x) Left(true) else Right(identity[Boolean])))
+    assertEquals(55, Iterator.range(0, 11).lazyFoldRight(0)(x => Right(_ + x)))
+  }
 
   @Test def from(): Unit = {
     val it1 = Iterator.from(-1)
@@ -171,6 +176,13 @@ class IteratorTest {
     assertSameElements(List(21), results)
   }
   
+  @Test def lazyFoldRightIsLazy(): Unit = {
+    val xs = LazyList.from(0)
+    def chooseOne(x: Int): Either[Int, Int => Int]= if (x < (1 << 16)) Right(identity) else Left(x)
+    
+    assertEquals(1 << 16, xs.lazyFoldRight(0)(chooseOne))
+  }
+
   // scala/bug#8552
   @Test def indexOfShouldWorkForTwoParams(): Unit = {
     assertEquals(1, List(1, 2, 3).iterator().indexOf(2, 0))


### PR DESCRIPTION
Fixes #107 and #186. Based on #228 and #225, rebased, squashed and moved to collections-contrib. I removed `foldSomeRight` (I only kept `foldSomeLeft` and `lazyFoldRight`).