### PR TITLE
Remove @SerialVersionUID from traits.

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -27,7 +27,6 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(2L)
 sealed trait HashMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
@@ -181,6 +180,7 @@ object HashMap extends MapFactory[HashMap] {
     */
   @`inline` private def nullToEmpty[A, B](m: HashMap[A, B]): HashMap[A, B] = if (m eq null) empty[A, B] else m
 
+  @SerialVersionUID(3806596116252973913L) // value computed for strawman 0.6.0, scala 2.13.0-M2
   private object EmptyHashMap extends HashMap[Any, Nothing] {
 
     protected def updated0[V1 >: Nothing](key: Any, hash: Int, level: Int, value: V1, kv: (Any, V1), merger: Merger[Any, V1]): HashMap[Any, V1] =
@@ -212,6 +212,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
+  @SerialVersionUID(2971144592070775060L) // value computed for strawman 0.6.0, scala 2.13.0-M2
   final class HashMap1[K, +V](private[collection] val key: K, private[collection] val hash: Int, private[collection] val value: V, private[collection] var kv: (K, V@uV)) extends HashMap[K, V] {
 
     def iterator(): Iterator[(K, V)] = Iterator.single(ensurePair)
@@ -264,7 +265,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
-
+  @SerialVersionUID(-2790842372316477099L) // value computed for strawman 0.6.0, scala 2.13.0-M2
   private[collection] class HashMapCollision1[K, +V](private[collection] val hash: Int, val kvs: ListMap[K, V @uV])
     extends HashMap[K, V @uV] {
     // assert(kvs.size > 1)
@@ -336,6 +337,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
+  @SerialVersionUID(-6145486889358767209L) // value computed for strawman 0.6.0, scala 2.13.0-M2
   final class HashTrieMap[K, +V](
     private[collection] val bitmap: Int,
     private[collection] val elems: Array[HashMap[K, V @uV]],

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -71,7 +71,6 @@ import scala.{Any, AnyRef, Boolean, Function1, IndexOutOfBoundsException, Int, N
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(-6084104484083858598L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 sealed trait List[+A]
   extends LinearSeq[A]
     with LinearSeqOps[A, List, List[A]]
@@ -401,6 +400,7 @@ sealed trait List[+A]
   }
 }
 
+@SerialVersionUID(6493291385232469459L) // value computed for strawman 0.6.0, scala 2.13.0-M2
 case class :: [+A](x: A, private[strawman] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally
   extends List[A] {
   override def isEmpty: Boolean = false
@@ -410,6 +410,7 @@ case class :: [+A](x: A, private[strawman] var next: List[A @uncheckedVariance])
   override def tail: List[A] = next
 }
 
+@SerialVersionUID(-5302509162483950757L) // value computed for strawman 0.6.0, scala 2.13.0-M2
 case object Nil extends List[Nothing] {
   override def isEmpty: Boolean = true
   override def nonEmpty: Boolean = false


### PR DESCRIPTION
...and put them on the subclasses, out of an abundance of caution.

Starting in 2.13.0-M3, the `serialVersionUID` field is emitted as `private`, and so won't be applied to `trait`s, which can't have `private` members. The value didn't have an effect on the Java serialization algorithm, so this changes nothing.

Also, compute the serialVersionUID value for the subtypes of those traits, since evidently it was intended that they have a stable value.

Fixes #296.