### PR TITLE
Add MultiSet and SortedMultiSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ The following operations are provided:
     - `zipByKey` / `join` / `zipByKeyWith`
     - `mergeByKey` / `fullOuterJoin` / `mergeByKeyWith` / `leftOuterJoin` / `rightOuterJoin`
 
+The following collections are provided:
+
+- `MultiSet` (both mutable and immutable)
+- `SortedMultiSet` (both mutable and immutable)
+
 ## Roadmap
 
 1. September 2017: release targeting Scala 2.13 and Dotty.

--- a/collections-contrib/src/main/scala/strawman/collection/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/MultiSet.scala
@@ -1,0 +1,103 @@
+package strawman
+package collection
+
+/**
+  * A multiset is a set that can contain multiple occurrences of a same value.
+  *
+  * @tparam A the element type of the collection
+  */
+trait MultiSet[A]
+  extends Iterable[A]
+    with MultiSetOps[A, MultiSet, MultiSet[A]]
+    with Equals {
+
+  def canEqual(that: Any): Boolean = true
+
+  override def equals(o: Any): Boolean = o match {
+    case that: MultiSet[A] =>
+      (this eq that) ||
+        (that canEqual this) &&
+          (this.size == that.size) && {
+          try {
+            occurrences forall { case (elem, n) => that.get(elem) == n }
+          } catch {
+            case _: ClassCastException => false
+          }
+        }
+    case _ => false
+  }
+
+  override def hashCode(): Int = collection.Set.unorderedHash(occurrences, "MultiSet".##)
+
+}
+
+trait MultiSetOps[A, +CC[X] <: MultiSet[X], +C]
+  extends IterableOps[A, CC, C] {
+
+  protected[this] def fromOccurrences[E](it: Iterable[(E, Int)]): CC[E] =
+    // Note new MultiSet(it.to(Map)) would be more efficient but would also loose duplicates
+    fromIterable(it.flatMap { case (e, n) => View.Fill(n)(e) })
+
+  /**
+    * @return All the elements contained in this multiset and their number of occurrences
+    */
+  def occurrences: Map[A, Int]
+
+  def iterator(): Iterator[A] =
+    occurrences.iterator().flatMap { case (elem, n) => View.Fill(n)(elem) }
+
+  /**
+    * @return The number of occurrences of `elem` in this multiset
+    * @param elem Element to look up
+    */
+  def get(elem: A): Int = occurrences.getOrElse(elem, 0)
+
+  /**
+    * @return Whether `elem` has at least one occurrence in this multiset or not
+    * @param elem the element to test
+    */
+  def contains(elem: A): Boolean = occurrences.contains(elem)
+
+  /**
+    * @return a new multiset summing the occurrences of this multiset
+    *         with the elements of `that`
+    *
+    * @param that the collection of elements to add to this multiset
+    */
+  def concat(that: Iterable[A]): CC[A] =
+    fromIterable(View.Concat(toIterable, that))
+
+  /**
+    * @return a new multiset summing the occurrences of this multiset
+    *         and `that` collection of occurrences
+    *
+    * @param that the collection of occurrences to add to this multiset
+    */
+  def concatOccurrences(that: Iterable[(A, Int)]): CC[A] =
+    fromOccurrences(View.Concat(occurrences, that))
+
+  /**
+    * @return a new multiset resulting from applying the given function `f`
+    *         to each pair of element and its number of occurrences of this
+    *         multiset and collecting the results
+    * @param f the function to apply
+    * @tparam B the element type of the returned collection
+    */
+  def mapOccurrences[B](f: ((A, Int)) => (B, Int)): CC[B] =
+    fromOccurrences(View.Map(occurrences, f))
+
+  /**
+    * @return a new multiset resulting from applying the given function `f`
+    *         to each pair of element and its number of occurrences of this
+    *         multiset and concatenating the results
+    * @param f the function to apply
+    * @tparam B the element type of the returned collection
+    */
+  def flatMapOccurrences[B](f: ((A, Int)) => IterableOnce[(B, Int)]): CC[B] =
+    fromOccurrences(View.FlatMap(occurrences, f))
+
+  // TODO Add more multiset operations like union and intersection
+
+}
+
+object MultiSet extends IterableFactory.Delegate(immutable.MultiSet)

--- a/collections-contrib/src/main/scala/strawman/collection/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/SortedMultiSet.scala
@@ -1,0 +1,160 @@
+package strawman.collection
+
+import scala.annotation.unchecked.uncheckedVariance
+
+/**
+  * Multiset whose elements are sorted
+  * @tparam A Type of elements
+  */
+trait SortedMultiSet[A]
+  extends MultiSet[A]
+    with SortedMultiSetOps[A, SortedMultiSet, SortedMultiSet[A]] {
+
+  def unordered: MultiSet[A] = this
+
+}
+
+trait SortedMultiSetOps[A, +CC[X] <: MultiSet[X], +C <: Iterable[A]]
+  extends MultiSetOps[A, MultiSet, C]
+    with SortedOps[A, C] {
+
+  def iterableFactory: IterableFactoryLike[MultiSet] = MultiSet
+
+  def sortedIterableFactory: SortedIterableFactory[CC]
+
+  protected[this] def sortedFromIterable[B : Ordering](it: Iterable[B]): CC[B]
+  protected[this] def sortedFromOccurrences[B : Ordering](it: Iterable[(B, Int)]): CC[B] =
+    sortedFromIterable(it.flatMap { case (b, n) => View.Fill(n)(b) })
+
+  /** `this` sorted multiset upcasted to an unsorted multiset */
+  def unordered: MultiSet[A]
+
+  def occurrences: SortedMap[A, Int]
+
+  /**
+    * Creates an iterator that contains all values from this collection
+    * greater than or equal to `start` according to the ordering of
+    * this collection. x.iteratorFrom(y) is equivalent to but will usually
+    * be more efficient than x.from(y).iterator
+    *
+    * @param start The lower-bound (inclusive) of the iterator
+    */
+  def iteratorFrom(start: A): Iterator[A] =
+    occurrences.iteratorFrom(start).flatMap { case (elem, n) => View.Fill(n)(elem) }
+
+  def firstKey: A = head
+  def lastKey: A = last
+
+  def rangeTo(to: A): C = {
+    val i = from(to).iterator()
+    if (i.isEmpty) return coll
+    val next = i.next()
+    if (ordering.compare(next, to) == 0)
+      if (i.isEmpty) coll
+      else until(i.next())
+    else
+      until(next)
+  }
+
+  override def withFilter(p: A => Boolean): SortedWithFilter = new SortedWithFilter(p)
+
+  /** Specialize `WithFilter` for sorted collections
+    *
+    * @define coll sorted collection
+    */
+  class SortedWithFilter(p: A => Boolean) extends WithFilter(p) {
+
+    def map[B : Ordering](f: A => B): CC[B] = sortedIterableFactory.from(View.Map(filtered, f))
+
+    def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedIterableFactory.from(View.FlatMap(filtered, f))
+
+    override def withFilter(q: A => Boolean): SortedWithFilter = new SortedWithFilter(a => p(a) && q(a))
+
+  }
+
+  /** Builds a new sorted multiset by applying a function to all elements of this sorted multiset.
+    *
+    *  @param f      the function to apply to each element.
+    *  @tparam B     the element type of the returned collection.
+    *  @return       a new collection resulting from applying the given function
+    *                `f` to each element of this sorted multiset and collecting the results.
+    */
+  def map[B : Ordering](f: A => B): CC[B] = sortedFromIterable(View.Map(toIterable, f))
+
+  /**
+    * Builds a new sorted multiset by applying a function to all pairs of element and its
+    * number of occurrences.
+    *
+    * @param f  the function to apply
+    * @tparam B the element type of the returned collection
+    * @return   a new collection resulting from applying the given function
+    *           `f` to each pair of element and its number of occurrences of this
+    *           sorted multiset and collecting the results.
+    */
+  def mapOccurrences[B : Ordering](f: ((A, Int)) => (B, Int)): CC[B] =
+    sortedFromOccurrences(View.Map(occurrences, f))
+
+  /**
+    * Builds a new collection by applying a function to all elements of this sorted
+    * multiset and using the elements of the resulting collections.
+    *
+    * @param f      the function to apply to each element.
+    * @tparam B     the element type of the returned collection.
+    * @return a new collection resulting from applying the given function `f` to
+    *         each element of this sorted multiset and concatenating the results.
+    */
+  def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = sortedFromIterable(View.FlatMap(toIterable, f))
+
+  /**
+    * Builds a new collection by applying a function to all pairs of element and
+    * its number of occurrences of this sorted multiset and using the elements of
+    * the resulting collections.
+    *
+    * @param f      the function to apply to each element.
+    * @tparam B     the element type of the returned collection.
+    * @return a new collection resulting from applying the given function `f` to
+    *         each pair of element and its number of occurrences of this sorted
+    *         multiset and concatenating the results.
+    */
+  def flatMapOccurrences[B : Ordering](f: ((A, Int)) => IterableOnce[(B, Int)]): CC[B] =
+    sortedFromOccurrences(View.FlatMap(occurrences, f))
+
+  /**
+    * Returns a sorted multiset formed from this sorted multiset and another iterable
+    * collection, by combining corresponding elements in pairs.
+    * @param that The iterable providing the second half of each result pair
+    * @param ev The ordering instance for type `B`
+    * @tparam B the type of the second half of the returned pairs
+    * @return a new sorted multiset containing pairs consisting of corresponding elements
+    *         of this sorted multiset and `that`. The length of the returned collection
+    *         is the minimum of the lengths of `this` and `that`
+    */
+  def zip[B](that: Iterable[B])(implicit ev: Ordering[B]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
+    sortedFromIterable(View.Zip(toIterable, that))
+
+  /**
+    * @return a new collection resulting from applying the given partial
+    *         function `pf` to each element on which it is defined and
+    *         collecting the results
+    * @param pf the partial function which filters and map this sorted multiset
+    * @tparam B the element type of the returned collection
+    */
+  def collect[B : Ordering](pf: scala.PartialFunction[A, B]): CC[B] = flatMap(a =>
+    if (pf.isDefinedAt(a)) View.Single(pf(a))
+    else View.Empty
+  )
+
+  // --- Override return type of methods that return an unsorted MultiSet
+
+  override def zipWithIndex: CC[(A, Int)] =
+    sortedFromIterable(View.ZipWithIndex(toIterable))
+
+  override def concat(that: Iterable[A]): CC[A] =
+    sortedFromIterable(View.Concat(toIterable, that))
+
+  override def concatOccurrences(that: Iterable[(A, Int)]): CC[A] =
+    sortedFromOccurrences(View.Concat(occurrences, that))
+
+}
+
+object SortedMultiSet extends SortedIterableFactory.Delegate(immutable.SortedMultiSet)

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/ImmutableMapDecorator.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/ImmutableMapDecorator.scala
@@ -2,7 +2,7 @@ package strawman
 package collection
 package decorators
 
-class ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.MapOps[X, Y, CC, CC[X, Y]]](`this`: CC[K, V]) {
+class ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.Map[X, Y]](`this`: CC[K, V]) {
 
   /**
     * Updates an existing binding or create a new one according to the
@@ -23,15 +23,15 @@ class ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.MapOps[X, Y, CC, CC[X, 
     *
     * @return A new updated `Map`
     */
-  def updatedWith(key: K)(f: PartialFunction[Option[V], Option[V]]): CC[K, V] = {
+  def updatedWith[C](key: K)(f: PartialFunction[Option[V], Option[V]])(implicit bf: BuildFrom[CC[K, V], (K, V), C]): C = {
     val pf = f.lift
     val previousValue = `this`.get(key)
     pf(previousValue) match {
-      case None => `this`
+      case None => bf.fromSpecificIterable(`this`)(`this`)
       case Some(result) =>
         result match {
-          case None => `this` - key
-          case Some(v) => `this` + (key -> v)
+          case None => bf.fromSpecificIterable(`this`)(`this` - key)
+          case Some(v) => bf.fromSpecificIterable(`this`)(`this` + (key -> v))
         }
     }
   }

--- a/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/decorators/package.scala
@@ -13,7 +13,7 @@ package object decorators {
   implicit def MapDecorator[K, V](map: Map[K, V]): MapDecorator[K, V] { val `this`: map.type } =
     new MapDecorator[K, V] { val `this`: map.type = map }
 
-  implicit def ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.MapOps[X, Y, CC, CC[X, Y]]](map: CC[K, V]): ImmutableMapDecorator[K, V, CC] =
+  implicit def ImmutableMapDecorator[K, V, CC[X, +Y] <: immutable.Map[X, Y]](map: CC[K, V]): ImmutableMapDecorator[K, V, CC] =
     new ImmutableMapDecorator[K, V, CC](map)
 
   implicit def MutableMapDecorator[K, V](map: mutable.Map[K, V]): MutableMapDecorator[K, V] =

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/MultiSet.scala
@@ -1,0 +1,68 @@
+package strawman
+package collection
+package immutable
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
+
+import strawman.collection.decorators.ImmutableMapDecorator
+
+/**
+  * An immutable multiset
+  * @tparam A the element type of the collection
+  */
+class MultiSet[A] private (elems: Map[A, Int])
+  extends collection.MultiSet[A]
+    with Iterable[A]
+    with collection.MultiSetOps[A, MultiSet, MultiSet[A]] {
+
+  def occurrences: Map[A, Int] = elems
+
+  def iterableFactory: IterableFactory[MultiSet] = MultiSet
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): MultiSet[A] = fromIterable(coll)
+  protected[this] def newSpecificBuilder(): Builder[A, MultiSet[A]] = iterableFactory.newBuilder()
+
+  /**
+    * @return an immutable multiset containing all the elements of this multiset
+    *         and one more occurrence of `elem`
+    * @param elem the element to add
+    */
+  def incl(elem: A): MultiSet[A] =
+    new MultiSet(elems.updatedWith(elem) {
+      case None    => Some(1)
+      case Some(n) => Some(n + 1)
+    })
+
+  /** Alias for `incl` */
+  @`inline` final def + (elem: A): MultiSet[A] = incl(elem)
+
+  /**
+    * @return an immutable multiset containing all the elements of this multiset
+    *         and one occurrence less of `elem`
+    *
+    * @param elem the element to remove
+    */
+  def excl(elem: A): MultiSet[A] =
+    new MultiSet(elems.updatedWith(elem) {
+      case Some(n) => if (n > 1) Some(n - 1) else None
+    })
+
+  /** Alias for `excl` */
+  @`inline` final def - (elem: A): MultiSet[A] = excl(elem)
+
+}
+
+object MultiSet extends IterableFactory[MultiSet] {
+
+  def from[A](source: IterableOnce[A]): MultiSet[A] =
+    source match {
+      case ms: MultiSet[A] => ms
+      case _ => (newBuilder[A]() ++= source).result()
+    }
+
+  def empty[A] = new MultiSet[A](Map.empty)
+
+  def newBuilder[A](): Builder[A, MultiSet[A]] =
+    new ImmutableBuilder[A, MultiSet[A]](empty[A]) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiSet.scala
@@ -1,0 +1,72 @@
+package strawman
+package collection
+package immutable
+
+import strawman.collection.decorators.ImmutableMapDecorator
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
+
+/**
+  * An immutable multiset whose elements are sorted.
+  * @tparam A Type of elements
+  */
+class SortedMultiSet[A] private (elems: SortedMap[A, Int])(implicit val ordering: Ordering[A])
+  extends collection.SortedMultiSet[A]
+    with collection.SortedMultiSetOps[A, SortedMultiSet, SortedMultiSet[A]] {
+
+  def occurrences: SortedMap[A, Int] = elems
+
+  def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
+
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): SortedMultiSet[A] = sortedFromIterable(coll)
+  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedMultiSet[B] = sortedIterableFactory.from(it)
+  protected[this] def newSpecificBuilder(): Builder[A, SortedMultiSet[A]] = sortedIterableFactory.newBuilder()
+
+  def rangeImpl(from: Option[A], until: Option[A]): SortedMultiSet[A] =
+    new SortedMultiSet(elems.rangeImpl(from, until))
+
+  /**
+    * @return an immutable sorted multiset containing all the elements of
+    *         this multiset and one more occurrence of `elem`
+    * @param elem the element to add
+    */
+  def incl(elem: A): SortedMultiSet[A] =
+    new SortedMultiSet(elems.updatedWith(elem) {
+      case None    => Some(1)
+      case Some(n) => Some(n + 1)
+    })
+
+  /** Alias for `incl` */
+  @`inline` final def + (elem: A): SortedMultiSet[A] = incl(elem)
+
+  /**
+    * @return an immutable sorted multiset containing all the elements of
+    *         this multiset and one occurrence less of `elem`
+    *
+    * @param elem the element to remove
+    */
+  def excl(elem: A): SortedMultiSet[A] =
+    new SortedMultiSet(elems.updatedWith(elem) {
+      case Some(n) => if (n > 1) Some(n - 1) else None
+    })
+
+  /** Alias for `excl` */
+  @`inline` final def - (elem: A): SortedMultiSet[A] = excl(elem)
+
+}
+
+object SortedMultiSet extends SortedIterableFactory[SortedMultiSet] {
+
+  def from[A: Ordering](source: IterableOnce[A]): SortedMultiSet[A] =
+    source match {
+      case sms: SortedMultiSet[A] => sms
+      case _ => (newBuilder[A]() ++= source).result()
+    }
+
+  def empty[A: Ordering]: SortedMultiSet[A] = new SortedMultiSet[A](TreeMap.empty)
+
+  def newBuilder[A: Ordering](): Builder[A, SortedMultiSet[A]] =
+    new ImmutableBuilder[A, SortedMultiSet[A]](empty) {
+      def add(elem: A): this.type = { elems = elems + elem; this }
+    }
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
@@ -1,0 +1,48 @@
+package strawman
+package collection
+package mutable
+
+import strawman.collection.decorators.MutableMapDecorator
+
+/**
+  * A mutable multiset.
+  */
+class MultiSet[A] private (val elems: Map[A, Int])
+  extends collection.MultiSet[A]
+    with collection.MultiSetOps[A, MultiSet, MultiSet[A]]
+    with Growable[A]
+    with Shrinkable [A] {
+
+  def iterableFactory: IterableFactory[MultiSet] = MultiSet
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): MultiSet[A] = fromIterable(coll)
+  protected[this] def newSpecificBuilder(): Builder[A, MultiSet[A]] = iterableFactory.newBuilder()
+
+  def occurrences: collection.Map[A, Int] = elems
+
+  def add(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case None    => Some(1)
+      case Some(n) => Some(n + 1)
+    }
+    this
+  }
+
+  def subtract(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case Some(n) => if (n > 1) Some(n - 1) else None
+    }
+    this
+  }
+
+  def clear(): Unit = elems.clear()
+}
+
+object MultiSet extends IterableFactory[MultiSet] {
+
+  def from[A](source: IterableOnce[A]): MultiSet[A] = (newBuilder[A]() ++= source).result()
+
+  def empty[A]: MultiSet[A] = new MultiSet[A](Map.empty)
+
+  def newBuilder[A](): Builder[A, MultiSet[A]] = new GrowableBuilder[A, MultiSet[A]](empty)
+
+}

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiSet.scala
@@ -1,0 +1,56 @@
+package strawman
+package collection
+package mutable
+
+import strawman.collection.decorators.MutableMapDecorator
+
+/**
+  * A mutable multiset whose elements are sorted according to a given ordering.
+  *
+  * @tparam A Type of elements
+  */
+class SortedMultiSet[A] private (elems: SortedMap[A, Int])(implicit val ordering: Ordering[A])
+  extends collection.SortedMultiSet[A]
+    with collection.SortedMultiSetOps[A, SortedMultiSet, SortedMultiSet[A]]
+    with Growable[A]
+    with Shrinkable[A] {
+
+  def occurrences: collection.SortedMap[A, Int] = elems
+
+  def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
+
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): SortedMultiSet[A] = sortedFromIterable(coll)
+  protected[this] def sortedFromIterable[B: Ordering](it: collection.Iterable[B]): SortedMultiSet[B] = sortedIterableFactory.from(it)
+  protected[this] def newSpecificBuilder(): Builder[A, SortedMultiSet[A]] = sortedIterableFactory.newBuilder()
+
+  def rangeImpl(from: Option[A], until: Option[A]): SortedMultiSet[A] =
+    new SortedMultiSet(elems.rangeImpl(from, until))
+
+  def add(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case None    => Some(1)
+      case Some(n) => Some(n + 1)
+    }
+    this
+  }
+
+  def subtract(elem: A): this.type = {
+    elems.updateWith(elem) {
+      case Some(n) => if (n > 1) Some(n - 1) else None
+    }
+    this
+  }
+
+  def clear(): Unit = elems.clear()
+
+}
+
+object SortedMultiSet extends SortedIterableFactory[SortedMultiSet] {
+
+  def from[E: Ordering](it: IterableOnce[E]): SortedMultiSet[E] = (newBuilder[E]() ++= it).result()
+
+  def empty[A: Ordering]: SortedMultiSet[A] = new SortedMultiSet[A](SortedMap.empty[A, Int])
+
+  def newBuilder[A: Ordering](): Builder[A, SortedMultiSet[A]] = new GrowableBuilder[A, SortedMultiSet[A]](empty)
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/MultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/MultiSetTest.scala
@@ -1,0 +1,49 @@
+package strawman.collection
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.immutable.List
+import org.junit.{Assert, Test}
+
+@RunWith(classOf[JUnit4])
+class MultiSetTest {
+
+  @Test
+  def equality(): Unit = {
+    val mm1 = MultiSet("a", "b", "b", "c")
+    val mm2 = MultiSet("a", "b", "b", "c")
+
+    Assert.assertEquals(mm2, mm1)
+    Assert.assertEquals(mm1, mm2)
+    Assert.assertEquals(mm1.##, mm2.##)
+  }
+
+  @Test
+  def concat(): Unit = {
+    Assert.assertEquals(
+      MultiSet(1, 1),
+      MultiSet(1).concat(MultiSet(1))
+    )
+    Assert.assertEquals(
+      MultiSet("a", "a", "a"),
+      MultiSet("a").concatOccurrences(List(("a", 2)))
+    )
+  }
+
+  @Test
+  def map(): Unit = {
+    Assert.assertEquals(
+      MultiSet("A", "B", "B"),
+      MultiSet("a", "b", "b").map(_.toUpperCase)
+    )
+    Assert.assertEquals(
+      MultiSet(1, 1),
+      MultiSet("a", "b").map(_ => 1)
+    )
+    Assert.assertEquals(
+      MultiSet("c", "c", "c", "c"),
+      MultiSet("a", "b", "b").mapOccurrences { _ => ("c", 2) }
+    )
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/SortedMultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/SortedMultiSetTest.scala
@@ -1,0 +1,24 @@
+package strawman.collection
+
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SortedMultiSetTest {
+
+  def sortedMultiSet(sms: SortedMultiSet[Int]): Unit = {
+    Assert.assertEquals(1, sms.get(1))
+    Assert.assertEquals(2, sms.get(2))
+    Assert.assertEquals(1, sms.firstKey)
+    Assert.assertEquals(3, sms.lastKey)
+    Assert.assertEquals(SortedMultiSet(3, 2, 2), sms.from(2))
+  }
+
+  @Test def run(): Unit = {
+    sortedMultiSet(immutable.SortedMultiSet(2, 1, 3, 2))
+    sortedMultiSet(mutable.SortedMultiSet(2, 1, 3, 2))
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/immutable/MultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/immutable/MultiSetTest.scala
@@ -1,0 +1,29 @@
+package strawman.collection.immutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MultiSetTest {
+
+  @Test
+  def multiSet(): Unit = {
+    val ms = MultiSet("a", "b", "b", "c")
+    val m = Map("a" -> 1, "b" -> 2, "c" -> 1)
+    Assert.assertEquals(m, ms.occurrences)
+    Assert.assertEquals(ms.occurrences, m)
+
+    Assert.assertEquals(1, ms.get("a"))
+    Assert.assertEquals(2, ms.get("b"))
+
+    val ms2 = ms + "a"
+    Assert.assertEquals(2, ms2.get("a"))
+    val ms3 = ms2 - "a"
+    Assert.assertEquals(1, ms3.get("a"))
+    Assert.assertTrue(ms3.contains("a"))
+    val ms4 = ms3 - "a"
+    Assert.assertFalse(ms4.contains("a"))
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/immutable/SortedMultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/immutable/SortedMultiSetTest.scala
@@ -1,0 +1,24 @@
+package strawman.collection.immutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SortedMultiSetTest {
+
+  @Test
+  def sortedMultiSet(): Unit = {
+    val sms = SortedMultiSet(2, 1, 3, 2)
+    Assert.assertEquals(1, sms.get(1))
+    Assert.assertEquals(2, sms.get(2))
+    Assert.assertEquals(1, sms.firstKey)
+    Assert.assertEquals(3, sms.lastKey)
+    Assert.assertEquals(SortedMultiSet(3, 2, 2), sms.from(2))
+    val sms2 = sms + 2
+    Assert.assertEquals(3, sms2.get(2))
+    val sms3 = sms2 - 3
+    Assert.assertFalse(sms3.contains(3))
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/mutable/MultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/mutable/MultiSetTest.scala
@@ -1,0 +1,34 @@
+package strawman
+package collection
+package mutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class MultiSetTest {
+
+  @Test
+  def multiSet(): Unit = {
+    val ms = MultiSet.empty[String]
+
+    ms += "a"
+    ms += "a"
+    ms += "b"
+
+    val m = Map("a" -> 2, "b" -> 1)
+    Assert.assertEquals(m, ms.occurrences)
+
+    Assert.assertTrue(ms.contains("a"))
+    Assert.assertTrue(ms.contains("b"))
+    Assert.assertEquals(2, ms.get("a"))
+    Assert.assertEquals(1, ms.get("b"))
+
+    ms -= "b"
+    Assert.assertFalse(ms.contains("b"))
+    Assert.assertEquals(0, ms.get("b"))
+
+  }
+
+}

--- a/collections-contrib/src/test/scala/strawman/collection/mutable/SortedMultiSetTest.scala
+++ b/collections-contrib/src/test/scala/strawman/collection/mutable/SortedMultiSetTest.scala
@@ -1,0 +1,23 @@
+package strawman.collection.mutable
+
+import org.junit.{Assert, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SortedMultiSetTest {
+
+  @Test
+  def sortedMultiSet(): Unit = {
+    val sms = SortedMultiSet(2, 1, 3, 2)
+    Assert.assertEquals(1, sms.get(1))
+    Assert.assertEquals(2, sms.get(2))
+    Assert.assertEquals(1, sms.firstKey)
+    Assert.assertEquals(3, sms.lastKey)
+    sms += 2
+    Assert.assertEquals(3, sms.get(2))
+    sms -= 3
+    Assert.assertFalse(sms.contains(3))
+  }
+
+}

--- a/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -1,6 +1,8 @@
 package strawman
 package collection.mutable
 
+import strawman.collection.SortedMapFactory
+
 /**
   * Base type for mutable sorted map collections
   */
@@ -16,3 +18,5 @@ trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], 
   def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = Map.from(it)
 
 }
+
+object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap)


### PR DESCRIPTION
Fixes #133.

Add `MultiSet` (both mutable and immutable), and `SortedMultiSet` (both mutable and immutable).
A `SortedMultiSet` can be used as a `SortedSeq` (since a multiset can contain duplicates). Therefore, this PR is also a solution to #132.

I took a different approach from #263: in this pull request `MultiSet` creates a new branch in the hierarchy (it doesn’t inherit from `Set`).
Here is an overview of the hierarchy and its relation with `Iterable`:

![image](https://user-images.githubusercontent.com/332812/33012806-496fddd4-cde2-11e7-85dc-d8822bc7f245.png)

I put everything in the `collections-contrib` project. I don’t think we need these collections in the core.