### PR TITLE
Rename TreeMapView and TreeSetView to avoid confusion with Views.

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -76,7 +76,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
     *              bound.
     */
-  def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapView(from, until)
+  def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
 
@@ -107,7 +107,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     *              bound.
     */
   @SerialVersionUID(2219159283273389116L)
-  private[this] final class TreeMapView(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
+  private[this] final class TreeMapProjection(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
 
     /**
       * Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
@@ -137,7 +137,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     }
 
     override def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] =
-      new TreeMapView(pickLowerBound(from), pickUpperBound(until))
+      new TreeMapProjection(pickLowerBound(from), pickUpperBound(until))
 
     override def get(key: K) = if (isInsideViewBounds(key)) RB.get(tree, key) else None
 

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -72,7 +72,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def unconstrained: collection.Set[A] = this
 
-  def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = new TreeSetView(from, until)
+  def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = new TreeSetProjection(from, until)
 
   override def className: String = "TreeSet"
 
@@ -101,7 +101,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     *              bound.
     */
   @SerialVersionUID(7087824939194006086L)
-  private[this] final class TreeSetView(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
+  private[this] final class TreeSetProjection(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
 
     /**
       * Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
@@ -131,7 +131,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     }
 
     override def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] =
-      new TreeSetView(pickLowerBound(from), pickUpperBound(until))
+      new TreeSetProjection(pickLowerBound(from), pickUpperBound(until))
 
     override def contains(key: A) = isInsideViewBounds(key) && RB.contains(tree, key)
 

--- a/test/scalacheck/src/test/scala/strawman/collection/mutable/MutableTreeMap.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/mutable/MutableTreeMap.scala
@@ -195,7 +195,7 @@ object MutableTreeMapProperties extends Properties("mutable.TreeMap") with Gener
   }
 }
 
-object MutableTreeMapViewProperties extends Properties("mutable.TreeMapView") with Generators {
+object MutableTreeMapProjectionProperties extends Properties("mutable.TreeMapProjection") with Generators {
   type K = String
   type V = Int
 

--- a/test/scalacheck/src/test/scala/strawman/collection/mutable/MutableTreeSet.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/mutable/MutableTreeSet.scala
@@ -104,7 +104,7 @@ object MutableTreeSetProperties extends Properties("mutable.TreeSet") {
   }
 }
 
-object MutableTreeSetViewProperties extends Properties("mutable.TreeSetView") {
+object MutableTreeSetProjectionProperties extends Properties("mutable.TreeSetProjection") {
   type K = String
 
   implicit val ord = implicitly[Ordering[K]]


### PR DESCRIPTION
Fix #301. 
There is one thing I am not so sure. I didn't rename values' name that declares in each test. For example, I still kept `mapView` instead of `mapProjection`. As far as I know, those two words could be interchange. If it's better to keep the same suffix for values' name in each test, please let me know. Thanks! :)