### PR TITLE
First batch of performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 jdk: oraclejdk8
 script:
-  - sbt memoryBenchmark/compile timeBenchmark/compile +test ++2.13.0-M2 junit/test scalacheck/test
-  - sbt ++2.12.3 collectionsJS/test ++2.13.0-M2 collectionsJS/test
+  - sbt ++2.12.4 memoryBenchmark/compile +test ++2.13.0-M2 timeBenchmark/compile junit/test scalacheck/test
+  - sbt ++2.12.4 collectionsJS/test ++2.13.0-M2 collectionsJS/test
 before_script:
   - ./checkCLA.sh
 after_succes:

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class HashSetBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ImmutableArrayBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/LazyListBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class LazyListBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ListBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ListBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
@@ -49,18 +49,18 @@ class ListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependTail(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = i :: ys
-      i += 1
-      ys = ys.tail
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = i :: ys
+//      i += 1
+//      ys = ys.tail
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -74,31 +74,31 @@ class ListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_appendInit(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = ys :+ i
-      i += 1
-      ys = ys.init
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_appendInit(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = ys :+ i
+//      i += 1
+//      ys = ys.init
+//    }
+//    bh.consume(ys)
+//  }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAppend(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :+ i
-      else ys = i :: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAppend(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :+ i
+//      else ys = i :: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -124,18 +124,18 @@ class ListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :++ zs
-      else ys = zs ++: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :++ zs
+//      else ys = zs ++: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
@@ -143,23 +143,23 @@ class ListBenchmark {
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
 
-  @Benchmark
-  def traverse_headTail(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.head)
-      ys = ys.tail
-    }
-  }
-
-  @Benchmark
-  def traverse_initLast(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.last)
-      ys = ys.init
-    }
-  }
+//  @Benchmark
+//  def traverse_headTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.head)
+//      ys = ys.tail
+//    }
+//  }
+//
+//  @Benchmark
+//  def traverse_initLast(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.last)
+//      ys = ys.init
+//    }
+//  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
@@ -255,8 +255,8 @@ class ListBenchmark {
   @Benchmark
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
-  @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+//  @Benchmark
+//  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
@@ -276,17 +276,17 @@ class ListBenchmark {
   @Benchmark
   def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
 
-  @Benchmark
-  def transform_zipMapTupled(bh: Blackhole): Unit = {
-    val f = (a: Long, b: Long) => (a, b)
-    bh.consume(xs.zip(xs).map(f.tupled))
-  }
-
-  @Benchmark
-  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
-
-  @Benchmark
-  def transform_lazyZip(bh: Blackhole): Unit = bh.consume(xs.lazyZip(xs).map((_, _)))
+//  @Benchmark
+//  def transform_zipMapTupled(bh: Blackhole): Unit = {
+//    val f = (a: Long, b: Long) => (a, b)
+//    bh.consume(xs.zip(xs).map(f.tupled))
+//  }
+//
+//  @Benchmark
+//  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+//
+//  @Benchmark
+//  def transform_lazyZip(bh: Blackhole): Unit = bh.consume(xs.lazyZip(xs).map((_, _)))
 
   @Benchmark
   def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
@@ -299,4 +299,8 @@ class ListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  def access_find(bh: Blackhole): Unit =
+    xs.find(x => x > size / 2)
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/NumericRangeBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class NumericRangeBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/RangeBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class RangeBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaHashSetBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ScalaHashSetBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaListBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ScalaListBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
@@ -49,18 +49,18 @@ class ScalaListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependTail(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = i :: ys
-      i += 1
-      ys = ys.tail
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = i :: ys
+//      i += 1
+//      ys = ys.tail
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -74,31 +74,31 @@ class ScalaListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_appendInit(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = ys :+ i
-      i += 1
-      ys = ys.init
-    }
-    bh.consume(ys)
-  }
-
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAppend(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :+ i
-      else ys = i :: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_appendInit(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = ys :+ i
+//      i += 1
+//      ys = ys.init
+//    }
+//    bh.consume(ys)
+//  }
+//
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAppend(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :+ i
+//      else ys = i :: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -124,18 +124,18 @@ class ScalaListBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys ++ zs
-      else ys = zs ++: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys ++ zs
+//      else ys = zs ++: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
@@ -143,23 +143,23 @@ class ScalaListBenchmark {
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
 
-  @Benchmark
-  def traverse_headTail(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.head)
-      ys = ys.tail
-    }
-  }
-
-  @Benchmark
-  def traverse_initLast(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.last)
-      ys = ys.init
-    }
-  }
+//  @Benchmark
+//  def traverse_headTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.head)
+//      ys = ys.tail
+//    }
+//  }
+//
+//  @Benchmark
+//  def traverse_initLast(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.last)
+//      ys = ys.init
+//    }
+//  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
@@ -273,17 +273,17 @@ class ScalaListBenchmark {
   @Benchmark
   def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
 
-  @Benchmark
-  def transform_zipMapTupled(bh: Blackhole): Unit = {
-    val f = (a: Long, b: Long) => (a, b)
-    bh.consume(xs.zip(xs).map(f.tupled))
-  }
-
-  @Benchmark
-  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
-
-  @Benchmark
-  def transform_lazyZip(bh: Blackhole): Unit = bh.consume((xs, xs).zipped.map((_, _)))
+//  @Benchmark
+//  def transform_zipMapTupled(bh: Blackhole): Unit = {
+//    val f = (a: Long, b: Long) => (a, b)
+//    bh.consume(xs.zip(xs).map(f.tupled))
+//  }
+//
+//  @Benchmark
+//  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+//
+//  @Benchmark
+//  def transform_lazyZip(bh: Blackhole): Unit = bh.consume((xs, xs).zipped.map((_, _)))
 
   @Benchmark
   def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
@@ -296,4 +296,8 @@ class ScalaListBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  def access_find(bh: Blackhole): Unit =
+    xs.find(x => x > size / 2)
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeMapBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeMapBenchmark.scala
@@ -1,0 +1,121 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit, math}
+import scala.Predef.{intWrapper, ArrowAssoc}
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@State(Scope.Benchmark)
+class ScalaTreeMapBenchmark {
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  var size: Int = _
+
+  var xs: scala.collection.immutable.TreeMap[Long, Long] = _
+  var zs: scala.collection.immutable.TreeMap[Long, Long] = _
+  var zipped: scala.collection.immutable.TreeMap[Long, (Long, Long)] = _
+  var randomKeys: scala.Array[Long] = _
+  def fresh(n: Int) = scala.collection.immutable.TreeMap((1 to n).map(x => (x.toLong, x.toLong)): _*)
+
+  @Setup(Level.Trial)
+  def initTrial(): Unit = {
+    xs = fresh(size)
+    zs = fresh((size / 1000) max 2).map { case (k, v) => (k, -v) }
+    zipped = xs.map { case (k, v) => (k, (v, v)) }
+    if (size > 0) {
+      randomKeys = scala.Array.fill(1000)(scala.util.Random.nextInt(size).toLong)
+    }
+  }
+
+  @Benchmark
+  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def expand_updated(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0L
+    while (i < 1000) {
+      ys = ys + (i -> -i)
+      i += 1
+    }
+    bh.consume(ys)
+  }
+
+  @Benchmark
+  def expand_concat(bh: Blackhole): Unit = bh.consume(xs ++ zs)
+
+  @Benchmark
+  def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
+
+  @Benchmark
+  def traverse_iterator(bh: Blackhole): Unit = {
+    val it = xs.iterator
+    while (it.hasNext) {
+      bh.consume(it.next())
+    }
+  }
+
+  @Benchmark
+  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+    case (acc, n) =>
+      bh.consume(n)
+      acc + 1
+  })
+
+  @Benchmark
+  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+    case (n, acc) =>
+      bh.consume(n)
+      acc - 1
+  })
+  @Benchmark
+  def access_tail(bh: Blackhole): Unit = bh.consume(xs.tail)
+
+  @Benchmark
+  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def access_contains(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 1000) {
+      bh.consume(xs.contains(i))
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map { case (k, v) => (k, v + 1) })
+
+  @Benchmark
+  @OperationsPerInvocation(100)
+  def transform_span(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      val (xs1, xs2) = xs.span { case (k, _) => k < randomKeys(i) }
+      bh.consume(xs1)
+      bh.consume(xs2)
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
+
+  @Benchmark
+  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+
+  @Benchmark
+  def transform_groupBy(bh: Blackhole): Unit = {
+    val result = xs.groupBy(_._1 % 5)
+    bh.consume(result)
+  }
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaTreeSetBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.{intWrapper, tuple2ToZippedOps, $conforms}
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ScalaTreeSetBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ScalaVectorBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ScalaVectorBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
@@ -49,18 +49,18 @@ class ScalaVectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependTail(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = i +: ys
-      i += 1
-      ys = ys.tail
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = i +: ys
+//      i += 1
+//      ys = ys.tail
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -74,31 +74,31 @@ class ScalaVectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_appendInit(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = ys :+ i
-      i += 1
-      ys = ys.init
-    }
-    bh.consume(ys)
-  }
-
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAppend(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :+ i
-      else ys = i +: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_appendInit(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = ys :+ i
+//      i += 1
+//      ys = ys.init
+//    }
+//    bh.consume(ys)
+//  }
+//
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAppend(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :+ i
+//      else ys = i +: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -124,18 +124,18 @@ class ScalaVectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys ++ zs
-      else ys = zs ++: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys ++ zs
+//      else ys = zs ++: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
@@ -143,23 +143,23 @@ class ScalaVectorBenchmark {
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
 
-  @Benchmark
-  def traverse_headTail(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.head)
-      ys = ys.tail
-    }
-  }
-
-  @Benchmark
-  def traverse_initLast(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.last)
-      ys = ys.init
-    }
-  }
+//  @Benchmark
+//  def traverse_headTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.head)
+//      ys = ys.tail
+//    }
+//  }
+//
+//  @Benchmark
+//  def traverse_initLast(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.last)
+//      ys = ys.init
+//    }
+//  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
@@ -273,17 +273,17 @@ class ScalaVectorBenchmark {
   @Benchmark
   def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
 
-  @Benchmark
-  def transform_zipMapTupled(bh: Blackhole): Unit = {
-    val f = (a: Long, b: Long) => (a, b)
-    bh.consume(xs.zip(xs).map(f.tupled))
-  }
-
-  @Benchmark
-  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
-
-  @Benchmark
-  def transform_lazyZip(bh: Blackhole): Unit = bh.consume((xs, xs).zipped.map((_, _)))
+//  @Benchmark
+//  def transform_zipMapTupled(bh: Blackhole): Unit = {
+//    val f = (a: Long, b: Long) => (a, b)
+//    bh.consume(xs.zip(xs).map(f.tupled))
+//  }
+//
+//  @Benchmark
+//  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+//
+//  @Benchmark
+//  def transform_lazyZip(bh: Blackhole): Unit = bh.consume((xs, xs).zipped.map((_, _)))
 
   @Benchmark
   def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeMapBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeMapBenchmark.scala
@@ -1,0 +1,121 @@
+package strawman.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import scala.{Any, AnyRef, Int, Long, Unit, math}
+import scala.Predef.{intWrapper, ArrowAssoc}
+
+@BenchmarkMode(scala.Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@State(Scope.Benchmark)
+class TreeMapBenchmark {
+  @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
+  var size: Int = _
+
+  var xs: TreeMap[Long, Long] = _
+  var zs: TreeMap[Long, Long] = _
+  var zipped: TreeMap[Long, (Long, Long)] = _
+  var randomKeys: scala.Array[Long] = _
+  def fresh(n: Int) = TreeMap((1 to n).map(x => (x.toLong, x.toLong)): _*)
+
+  @Setup(Level.Trial)
+  def initTrial(): Unit = {
+    xs = fresh(size)
+    zs = fresh((size / 1000) max 2).map { case (k, v) => (k, -v) }
+    zipped = xs.map { case (k, v) => (k, (v, v)) }
+    if (size > 0) {
+      randomKeys = scala.Array.fill(1000)(scala.util.Random.nextInt(size).toLong)
+    }
+  }
+
+//  @Benchmark
+//  def create(bh: Blackhole): Unit = bh.consume(fresh(size))
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def expand_updated(bh: Blackhole): Unit = {
+    var ys = xs
+    var i = 0L
+    while (i < 1000) {
+      ys = ys + (i -> -i)
+      i += 1
+    }
+    bh.consume(ys)
+  }
+
+//  @Benchmark
+//  def expand_concat(bh: Blackhole): Unit = bh.consume(xs ++ zs)
+
+//  @Benchmark
+//  def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
+
+//  @Benchmark
+//  def traverse_iterator(bh: Blackhole): Unit = {
+//    val it = xs.iterator()
+//    while (it.hasNext) {
+//      bh.consume(it.next())
+//    }
+//  }
+//
+//  @Benchmark
+//  def traverse_foldLeft(bh: Blackhole): Unit = bh.consume(xs.foldLeft(0) {
+//    case (acc, n) =>
+//      bh.consume(n)
+//      acc + 1
+//  })
+//
+//  @Benchmark
+//  def traverse_foldRight(bh: Blackhole): Unit = bh.consume(xs.foldRight(0) {
+//    case (n, acc) =>
+//      bh.consume(n)
+//      acc - 1
+//  })
+//  @Benchmark
+//  def access_tail(bh: Blackhole): Unit = bh.consume(xs.tail)
+//
+//  @Benchmark
+//  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)
+//
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def access_contains(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < 1000) {
+//      bh.consume(xs.contains(i))
+//      i += 1
+//    }
+//  }
+
+//  @Benchmark
+//  def transform_map(bh: Blackhole): Unit = bh.consume(xs.map ({ case (k, v) => (k, v + 1) }: ((Long, Long) PartialFunction (Long, Long))))
+//
+//  @Benchmark
+//  @OperationsPerInvocation(100)
+//  def transform_span(bh: Blackhole): Unit = {
+//    var i = 0
+//    while (i < 100) {
+//      val (xs1, xs2) = xs.span { case (k, _) => k < randomKeys(i) }
+//      bh.consume(xs1)
+//      bh.consume(xs2)
+//      i += 1
+//    }
+//  }
+
+//  @Benchmark
+//  def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
+
+//  @Benchmark
+//  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+//
+//  @Benchmark
+//  def transform_groupBy(bh: Blackhole): Unit = {
+//    val result = xs.groupBy(_._1 % 5)
+//    bh.consume(result)
+//  }
+}

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/TreeSetBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class TreeSetBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/VectorBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class VectorBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
@@ -49,18 +49,18 @@ class VectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependTail(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = i +: ys
-      i += 1
-      ys = ys.tail
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = i +: ys
+//      i += 1
+//      ys = ys.tail
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -74,31 +74,31 @@ class VectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_appendInit(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      ys = ys :+ i
-      i += 1
-      ys = ys.init
-    }
-    bh.consume(ys)
-  }
-
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAppend(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :+ i
-      else ys = i +: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_appendInit(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      ys = ys :+ i
+//      i += 1
+//      ys = ys.init
+//    }
+//    bh.consume(ys)
+//  }
+//
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAppend(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :+ i
+//      else ys = i +: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -124,18 +124,18 @@ class VectorBenchmark {
     bh.consume(ys)
   }
 
-  @Benchmark
-  @OperationsPerInvocation(1000)
-  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
-    var ys = xs
-    var i = 0L
-    while (i < 1000) {
-      if ((i & 1) == 1) ys = ys :++ zs
-      else ys = zs ++: ys
-      i += 1
-    }
-    bh.consume(ys)
-  }
+//  @Benchmark
+//  @OperationsPerInvocation(1000)
+//  def expand_prependAllAppendAll(bh: Blackhole): Unit = {
+//    var ys = xs
+//    var i = 0L
+//    while (i < 1000) {
+//      if ((i & 1) == 1) ys = ys :++ zs
+//      else ys = zs ++: ys
+//      i += 1
+//    }
+//    bh.consume(ys)
+//  }
 
   @Benchmark
   def expand_padTo(bh: Blackhole): Unit = bh.consume(xs.padTo(size * 2, 42))
@@ -143,23 +143,23 @@ class VectorBenchmark {
   @Benchmark
   def traverse_foreach(bh: Blackhole): Unit = xs.foreach(x => bh.consume(x))
 
-  @Benchmark
-  def traverse_headTail(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.head)
-      ys = ys.tail
-    }
-  }
-
-  @Benchmark
-  def traverse_initLast(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.last)
-      ys = ys.init
-    }
-  }
+//  @Benchmark
+//  def traverse_headTail(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.head)
+//      ys = ys.tail
+//    }
+//  }
+//
+//  @Benchmark
+//  def traverse_initLast(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.last)
+//      ys = ys.init
+//    }
+//  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
@@ -255,8 +255,8 @@ class VectorBenchmark {
   @Benchmark
   def transform_distinct(bh: Blackhole): Unit = bh.consume(xs.distinct)
 
-  @Benchmark
-  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
+//  @Benchmark
+//  def transform_distinctBy(bh: Blackhole): Unit = bh.consume(xs.distinctBy(_ % 2))
 
   @Benchmark
   def transform_map(bh: Blackhole): Unit = bh.consume(xs.map(x => x + 1))
@@ -276,17 +276,17 @@ class VectorBenchmark {
   @Benchmark
   def transform_zip(bh: Blackhole): Unit = bh.consume(xs.zip(xs))
 
-  @Benchmark
-  def transform_zipMapTupled(bh: Blackhole): Unit = {
-    val f = (a: Long, b: Long) => (a, b)
-    bh.consume(xs.zip(xs).map(f.tupled))
-  }
-
-  @Benchmark
-  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
-
-  @Benchmark
-  def transform_lazyZip(bh: Blackhole): Unit = bh.consume(xs.lazyZip(xs).map((_, _)))
+//  @Benchmark
+//  def transform_zipMapTupled(bh: Blackhole): Unit = {
+//    val f = (a: Long, b: Long) => (a, b)
+//    bh.consume(xs.zip(xs).map(f.tupled))
+//  }
+//
+//  @Benchmark
+//  def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
+//
+//  @Benchmark
+//  def transform_lazyZip(bh: Blackhole): Unit = bh.consume(xs.lazyZip(xs).map((_, _)))
 
   @Benchmark
   def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ArrayBufferBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -11,8 +11,8 @@ import scala.Predef.intWrapper
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ListBufferBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ScalaArrayBenchmark.scala
@@ -13,8 +13,8 @@ import scala.Predef.{intWrapper, longArrayOps}
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
-@Warmup(iterations = 12)
-@Measurement(iterations = 12)
+@Warmup(iterations = 8)
+@Measurement(iterations = 8)
 @State(Scope.Benchmark)
 class ScalaArrayBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ dotty in ThisBuild := "0.4.0-RC1"
 
 val commonSettings = Seq(
   organization := "ch.epfl.scala",
-  version := "0.6.0",
-  scalaVersion := "2.12.3",
-  crossScalaVersions := scalaVersion.value :: "2.13.0-M2" :: dotty.value :: Nil,
+  version := "0.6.0-SNAPSHOT",
+  scalaVersion := "2.13.0-M2",
+  crossScalaVersions := scalaVersion.value :: "2.12.4" :: dotty.value :: Nil,
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds"/*, "-opt:l:classpath"*/),
   scalacOptions ++= {
     if (!isDotty.value)

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -733,14 +733,18 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
     */
   def groupBy[K](f: A => K): immutable.Map[K, C] = {
     val m = mutable.Map.empty[K, Builder[A, C]]
-    for (elem <- this) {
+    val it = iterator()
+    while (it.hasNext) {
+      val elem = it.next()
       val key = f(elem)
       val bldr = m.getOrElseUpdate(key, newSpecificBuilder())
       bldr += elem
     }
-    var result = immutable.Map.empty[K, C]
-    m.foreach { case (k, v) =>
-      result = result + ((k, v.result()))
+    var result = immutable.HashMap.empty[K, C]
+    val mapIt = m.iterator()
+    while (mapIt.hasNext) {
+      val (k, v) = mapIt.next()
+      result = result.updated(k, v.result())
     }
     result
   }

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -484,7 +484,8 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
     var first = true
     var acc: B = 0.asInstanceOf[B]
 
-    for (x <- this) {
+    while (hasNext) {
+      val x = next()
       if (first) {
         acc = x
         first = false

--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, IndexOutOfBoundsException, Int, throws}
+import scala.{Any, Boolean, IndexOutOfBoundsException, Int, None, Option, Some, math, throws}
 import scala.annotation.tailrec
 
 /** Base trait for linearly accessed sequences that have efficient `head` and
@@ -13,12 +13,12 @@ trait LinearSeq[+A] extends Seq[A] with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
 /** Base trait for linear Seq operations */
 trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any with SeqOps[A, CC, C] {
 
-  /** To be overridden in implementations: */
+  // To be overridden in implementations:
   def isEmpty: Boolean
   def head: A
   def tail: LinearSeq[A]
 
-  /** `iterator` is implemented in terms of `head` and `tail` */
+  // `iterator` is implemented in terms of `head` and `tail`
   def iterator() = new Iterator[A] {
     private[this] var current: Iterable[A] = toIterable
     def hasNext = !current.isEmpty
@@ -50,13 +50,10 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     else loop(0, coll)
   }
 
-  /** Optimized version of `drop` that avoids copying
-    *  Note: `drop` is defined here, rather than in a trait like `LinearSeqMonoTransforms`,
-    *  because the `...MonoTransforms` traits make no assumption about the type of `Repr`
-    *  whereas we need to assume here that `Repr` is the same as the underlying
-    *  collection type.
-    */
-  override def drop(n: Int): C = { // sound bcs of VarianceNote
+  override def isDefinedAt(x: Int): Boolean = x >= 0 && lengthCompare(x) > 0
+
+  // Optimized version of `drop` that avoids copying
+  override def drop(n: Int): C = {
     def loop(n: Int, s: Iterable[A]): C =
       if (n <= 0) s.asInstanceOf[C]
       // implicit contract to guarantee success of asInstanceOf:
@@ -68,14 +65,110 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     loop(n, toIterable)
   }
 
-  /** `apply` is defined in terms of `drop`, which is in turn defined in
-    *  terms of `tail`.
-    */
+  // `apply` is defined in terms of `drop`, which is in turn defined in
+  //  terms of `tail`.
   @throws[IndexOutOfBoundsException]
   override def apply(n: Int): A = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val skipped = drop(n)
     if (skipped.isEmpty) throw new IndexOutOfBoundsException(n.toString)
     skipped.head
+  }
+
+  override def foreach[U](f: A => U) {
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      f(these.head)
+      these = these.tail
+    }
+  }
+
+
+  override def forall(p: A => Boolean): Boolean = {
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      if (!p(these.head)) return false
+      these = these.tail
+    }
+    true
+  }
+
+  override def exists(p: A => Boolean): Boolean = {
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      if (p(these.head)) return true
+      these = these.tail
+    }
+    false
+  }
+
+  override def contains[A1 >: A](elem: A1): Boolean = {
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      if (these.head == elem) return true
+      these = these.tail
+    }
+    false
+  }
+
+  override def find(p: A => Boolean): Option[A] = {
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      if (p(these.head)) return Some(these.head)
+      these = these.tail
+    }
+    None
+  }
+
+  override def foldLeft[B](z: B)(op: (B, A) => B): B = {
+    var acc = z
+    var these: LinearSeq[A] = coll
+    while (!these.isEmpty) {
+      acc = op(acc, these.head)
+      these = these.tail
+    }
+    acc
+  }
+
+  override def sameElements[B >: A](that: IterableOnce[B]): Boolean = that match {
+    case that1: LinearSeq[B] =>
+      // Probably immutable, so check reference identity first (it's quick anyway)
+      (coll eq that1) || {
+        var these: LinearSeq[A] = coll
+        var those: LinearSeq[B] = that1
+        while (!these.isEmpty && !those.isEmpty && these.head == those.head) {
+          these = these.tail
+          those = those.tail
+        }
+        these.isEmpty && those.isEmpty
+      }
+    case _ =>
+      super.sameElements(that)
+  }
+
+
+  override def indexWhere(p: A => Boolean, from: Int): Int = {
+    var i = math.max(from, 0)
+    var these: LinearSeq[A] = this drop from
+    while (these.nonEmpty) {
+      if (p(these.head))
+        return i
+
+      i += 1
+      these = these.tail
+    }
+    -1
+  }
+
+  override def lastIndexWhere(p: A => Boolean, end: Int): Int = {
+    var i = 0
+    var these: LinearSeq[A] = coll
+    var last = -1
+    while (!these.isEmpty && i <= end) {
+      if (p(these.head)) last = i
+      these = these.tail
+      i += 1
+    }
+    last
   }
 }

--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean, IndexOutOfBoundsException, Int, None, Option, Some, math, throws}
+import scala.{Any, Boolean, IndexOutOfBoundsException, Int, None, Option, Some, Unit, math, throws}
 import scala.annotation.tailrec
 
 /** Base trait for linearly accessed sequences that have efficient `head` and
@@ -75,14 +75,13 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     skipped.head
   }
 
-  override def foreach[U](f: A => U) {
+  override def foreach[U](f: A => U): Unit = {
     var these: LinearSeq[A] = coll
     while (!these.isEmpty) {
       f(these.head)
       these = these.tail
     }
   }
-
 
   override def forall(p: A => Boolean): Boolean = {
     var these: LinearSeq[A] = coll

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -87,11 +87,11 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     b.result()
   }
 
-  override def flatten[B](implicit ev: A => IterableOnce[B]): CC[B] = {
+  override def flatten[B](implicit toIterableOnce: A => IterableOnce[B]): CC[B] = {
     val b = iterableFactory.newBuilder[B]()
     val it = iterator()
     while (it.hasNext) {
-      b ++= it.next()
+      b ++= toIterableOnce(it.next())
     }
     b.result()
   }

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedIterableOps.scala
@@ -1,8 +1,9 @@
 package strawman
 package collection
 
-import scala.{Any, Boolean}
+import scala.{Any, Boolean, Int, PartialFunction}
 import scala.Predef.<:<
+import scala.annotation.unchecked.uncheckedVariance
 
 /**
   * Trait that overrides operations to take advantage of strict builders.
@@ -14,7 +15,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   extends Any
     with IterableOps[A, CC, C] {
 
-  /** Optimized, push-based version of `partition`. */
+  // Optimized, push-based version of `partition`
   override def partition(p: A => Boolean): (C, C) = {
     val l, r = newSpecificBuilder()
     iterator().foreach(x => (if (p(x)) l else r) += x)
@@ -50,6 +51,99 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
       second += a2
     }
     (first.result(), second.result())
+  }
+
+  // The implementations of the following operations are not fundamentally different from
+  // the view-based implementations, but they turn out to be slightly faster because
+  // a couple of indirection levels are removed
+
+  override def map[B](f: A => B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      b += f(it.next())
+    }
+    b.result()
+  }
+
+  override def flatMap[B](f: A => IterableOnce[B]): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      b ++= f(it.next())
+    }
+    b.result()
+  }
+
+  override def collect[B](pf: PartialFunction[A, B]): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      val elem = it.next()
+      if (pf.isDefinedAt(elem)) {
+        b += pf.apply(elem)
+      }
+    }
+    b.result()
+  }
+
+  override def flatten[B](implicit ev: A => IterableOnce[B]): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      b ++= it.next()
+    }
+    b.result()
+  }
+
+  override def zip[B](that: Iterable[B]): CC[(A @uncheckedVariance, B)] = {
+    val b = iterableFactory.newBuilder[(A, B)]()
+    val it1 = iterator()
+    val it2 = that.iterator()
+    while (it1.hasNext && it2.hasNext) {
+      b += ((it1.next(), it2.next()))
+    }
+    b.result()
+  }
+
+  override def zipWithIndex: CC[(A @uncheckedVariance, Int)] = {
+    val b = iterableFactory.newBuilder[(A, Int)]()
+    var i = 0
+    val it = iterator()
+    while (it.hasNext) {
+      b += ((it.next(), i))
+      i += 1
+    }
+    b.result()
+  }
+
+  override def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    b.sizeHint(toIterable, delta = 0)
+    var acc = z
+    b += acc
+    val it = iterator()
+    while (it.hasNext) {
+      acc = op(acc, it.next())
+      b += acc
+    }
+    b.result()
+  }
+
+  override def filter(pred: A => Boolean): C = filterImpl(pred, isFlipped = false)
+
+  override def filterNot(pred: A => Boolean): C = filterImpl(pred, isFlipped = true)
+
+  protected[collection] def filterImpl(pred: A => Boolean, isFlipped: Boolean): C = {
+    val b = newSpecificBuilder()
+    val it = iterator()
+    while (it.hasNext) {
+      val elem = it.next()
+      if (pred(elem) != isFlipped) {
+        b += elem
+      }
+    }
+    b.result()
   }
 
 }

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedSeqOps.scala
@@ -1,5 +1,7 @@
 package strawman.collection
 
+import scala.{Int, math}
+
 /**
   * Trait that overrides operations on sequences in order
   * to take advantage of strict builders.
@@ -21,4 +23,52 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
     }
     builder.result()
   }
+
+  override def prepended[B >: A](elem: B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    if (knownSize >= 0) {
+      b.sizeHint(size + 1)
+    }
+    b += elem
+    b ++= this
+    b.result()
+  }
+
+  override def appended[B >: A](elem: B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    if (knownSize >= 0) {
+      b.sizeHint(size + 1)
+    }
+    b ++= this
+    b += elem
+    b.result()
+  }
+
+  override def appendedAll[B >: A](suffix: Iterable[B]): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    b ++= this
+    b ++= suffix
+    b.result()
+  }
+
+  override def prependedAll[B >: A](prefix: Iterable[B]): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    b ++= prefix
+    b ++= this
+    b.result()
+  }
+
+  override def padTo[B >: A](len: Int, elem: B): CC[B] = {
+    val b = iterableFactory.newBuilder[B]()
+    val L = size
+    b.sizeHint(math.max(L, len))
+    var diff = len - L
+    b ++= this
+    while (diff > 0) {
+      b += elem
+      diff -= 1
+    }
+    b.result()
+  }
+
 }

--- a/collections/src/main/scala/strawman/collection/StrictOptimizedSortedSetOps.scala
+++ b/collections/src/main/scala/strawman/collection/StrictOptimizedSortedSetOps.scala
@@ -1,0 +1,52 @@
+package strawman
+package collection
+
+import scala.{Ordering, PartialFunction}
+
+import scala.annotation.unchecked.uncheckedVariance
+
+trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+  extends SortedSetOps[A, CC, C]
+    with StrictOptimizedIterableOps[A, Set, C] {
+
+  override def map[B : Ordering](f: A => B): CC[B] = {
+    val b = sortedIterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      b += f(it.next())
+    }
+    b.result()
+  }
+
+  override def flatMap[B : Ordering](f: A => IterableOnce[B]): CC[B] = {
+    val b = sortedIterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      b ++= f(it.next())
+    }
+    b.result()
+  }
+
+  override def zip[B](that: Iterable[B])(implicit ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = { // sound bcs of VarianceNot
+    val b = sortedIterableFactory.newBuilder[(A, B)]()
+    val it1 = iterator()
+    val it2 = that.iterator()
+    while (it1.hasNext && it2.hasNext) {
+      b += ((it1.next(), it2.next()))
+    }
+    b.result()
+  }
+
+  override def collect[B : Ordering](pf: PartialFunction[A, B]): CC[B] = {
+    val b = sortedIterableFactory.newBuilder[B]()
+    val it = iterator()
+    while (it.hasNext) {
+      val elem = it.next()
+      if (pf.isDefinedAt(elem)) {
+        b += pf.apply(elem)
+      }
+    }
+    b.result()
+  }
+
+}

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -47,8 +47,10 @@ sealed trait HashMap[K, +V]
 
   def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
-  def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] =
+  final def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] =
     updated0(key, computeHash(key), 0, value, null, null)
+
+  @`inline` override final def +[V1 >: V](kv: (K, V1)): HashMap[K, V1] = updated(kv._1, kv._2)
 
   def empty: HashMap[K, V] = HashMap.empty[K, V]
 

--- a/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.mutable.Builder
 
-import scala.{Boolean, Int, Option, Ordering, Serializable}
+import scala.{Boolean, `inline`, Int, Option, Ordering, Serializable}
 
 trait SortedMap[K, +V]
   extends Map[K, V]
@@ -40,7 +40,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
 
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]
-    override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
+    @`inline` final override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
     override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = {
         var result: CC[K, V2] = coll

--- a/collections/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/StrictOptimizedSeqOps.scala
@@ -11,26 +11,6 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   extends SeqOps[A, CC, C]
     with collection.StrictOptimizedSeqOps[A, CC, C] {
 
-  override def prepended[B >: A](elem: B): CC[B] = {
-    val b = iterableFactory.newBuilder[B]()
-    if (knownSize >= 0) {
-      b.sizeHint(size + 1)
-    }
-    b += elem
-    b ++= this
-    b.result()
-  }
-
-  override def appended[B >: A](elem: B): CC[B] = {
-    val b = iterableFactory.newBuilder[B]()
-    if (knownSize >= 0) {
-      b.sizeHint(size + 1)
-    }
-    b ++= this
-    b += elem
-    b.result()
-  }
-
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
     if (index < 0) throw new IndexOutOfBoundsException(index.toString)
     val b = iterableFactory.newBuilder[B]()

--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -28,7 +28,8 @@ import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Some, 
 final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
-    with StrictOptimizedIterableOps[A, Set, TreeSet[A]] {
+    with StrictOptimizedIterableOps[A, Set, TreeSet[A]]
+    with StrictOptimizedSortedSetOps[A, TreeSet, TreeSet[A]] {
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")
 

--- a/collections/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -46,18 +46,10 @@ trait Growable[-A] extends Clearable {
    *  @return  the $coll itself.
    */
   def addAll(xs: IterableOnce[A]): this.type = {
-    @tailrec def loop(xs: collection.LinearSeq[A]): Unit = {
-      if (xs.nonEmpty) {
-        this += xs.head
-        loop(xs.tail)
-      }
+    val it = xs.iterator()
+    while (it.hasNext) {
+      add(it.next())
     }
-    xs match {
-      case xs: collection.LinearSeq[A] => loop(xs)
-      case xs => xs.iterator() foreach += // Deviation: IterableOnce does not define `foreach`.
-    }
-    // @ichoran writes: Right now, this actually isn't any faster than using an iterator
-    // for List. Maybe we should just simplify the code by deferring to iterator foreach?
     this
   }
 

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -55,7 +55,7 @@ class ListBuffer[A]
 
   /** Convert to list; avoids copying where possible. */
   override def toList: List[A] = {
-    aliased = true
+    aliased = nonEmpty
     first
   }
 

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -1,7 +1,7 @@
 package strawman
 package collection.mutable
 
-import collection.{SortedIterableFactory, StrictOptimizedIterableOps}
+import collection.{SortedIterableFactory, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps}
 import collection.mutable.{RedBlackTree => RB}
 
 import scala.{Boolean, Int, None, Null, NullPointerException, Option, Ordering, SerialVersionUID, Serializable, Some, Unit}
@@ -26,6 +26,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
     with StrictOptimizedIterableOps[A, Set, TreeSet[A]]
+    with StrictOptimizedSortedSetOps[A, TreeSet, TreeSet[A]]
     with Serializable {
 
   if (ordering eq null)


### PR DESCRIPTION
The view-based design often gives a small performance penalty. For instance, in the case of `zip`, the view-based version is often 1.7x slower (up to 3x slower for small number of elements):

![transform_zip](https://user-images.githubusercontent.com/332812/33256929-82399372-d354-11e7-967f-7c1cac985b61.png)

(sorry for the last point, which was to big and appears as a negative number…)

Thankfully we can fix this by overriding the default implementation with a builder-based one, in strict collections. That’s what this PR does.

![transform_zip](https://user-images.githubusercontent.com/332812/33256987-bb85445a-d354-11e7-8342-c3b950932f05.png)

We still see some variations (in the case of `zip`, we are sometimes up to 1.6x faster and sometimes up to 1.3x slower). During my experiments I’ve also found cases where we observe a performance regression which is not due to the view-based design. I will investigate more to find out where it comes from.