### PR TITLE
Add more migration rules

### DIFF
--- a/scalafix/input/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/input/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -43,7 +43,7 @@ object Collectionstrawman_v0_ArrayBuffer {
 object Collectionstrawman_v0_ArrayAndString {
   def foo(xs: Array[Int], ys: String): Unit = {
     xs.map(x => x + 1)
-    ys.map(c => c.toUpper)
+    ys.map(c => c.toUpper).map(_.toLower)
   }
 }
 

--- a/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
+++ b/scalafix/input/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
@@ -5,12 +5,8 @@ package fix
 
 object Collectionstrawman_v0_Traversable {
   def foo(xs: Traversable[(Int, String)], ys: List[Int]): Unit = {
-    xs.toList
-    xs.toSet
-    ys.toSeq
     xs.to[List]
     xs.to[Set]
-    xs.toMap
     xs.toIterator
     ys.iterator
   }

--- a/scalafix/input/src/main/scala/fix/ConvertersTest.scala
+++ b/scalafix/input/src/main/scala/fix/ConvertersTest.scala
@@ -1,0 +1,13 @@
+/*
+rule = "scala:fix.Collectionstrawman_v0"
+ */
+package fix
+
+import collection.JavaConverters._
+
+class ConvertersTest {
+  def foo(xs: java.util.List[Int]): List[Int] = xs.asScala.toList
+  def bar(xs: java.util.Map[Int, String]): Map[Int, String] = xs.asScala.toMap
+  def baz(xs: List[Int]): java.util.List[Int] = xs.asJava
+  def bah(xs: Map[Int, String]): java.util.Map[Int, String] = xs.asJava
+}

--- a/scalafix/output/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/output/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -43,7 +43,7 @@ object Collectionstrawman_v0_ArrayBuffer {
 object Collectionstrawman_v0_ArrayAndString {
   def foo(xs: Array[Int], ys: String): Unit = {
     xs.map(x => x + 1)
-    ys.map(c => c.toUpper)
+    ys.map(c => c.toUpper).map(_.toLower)
   }
 }
 

--- a/scalafix/output/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
+++ b/scalafix/output/src/main/scala/fix/Collectionstrawman_v0_Traversable.scala
@@ -4,12 +4,8 @@ import strawman.collection.Iterable
 import strawman.collection.immutable.{ List, Set }
 object Collectionstrawman_v0_Traversable {
   def foo(xs: Iterable[(Int, String)], ys: List[Int]): Unit = {
-    xs.to(strawman.collection.immutable.List)
-    xs.to(strawman.collection.immutable.Set)
-    ys.toSeq
     xs.to(List)
     xs.to(Set)
-    xs.to(strawman.collection.Map)
     xs.iterator()
     ys.iterator()
   }

--- a/scalafix/output/src/main/scala/fix/ConvertersTest.scala
+++ b/scalafix/output/src/main/scala/fix/ConvertersTest.scala
@@ -1,0 +1,11 @@
+package fix
+
+import strawman.collection.JavaConverters._
+import strawman.collection.immutable.{ List, Map }
+
+class ConvertersTest {
+  def foo(xs: java.util.List[Int]): List[Int] = xs.asScala.toList
+  def bar(xs: java.util.Map[Int, String]): Map[Int, String] = xs.asScala.toMap
+  def baz(xs: List[Int]): java.util.List[Int] = xs.asJava
+  def bah(xs: Map[Int, String]): java.util.Map[Int, String] = xs.asJava
+}

--- a/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -180,11 +180,19 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
         removeTokensPatch + replaceCommasPatch
     }.asPatch
 
+  def replaceJavaConverters(ctx: RuleCtx): Patch = {
+    ctx.tree.collect {
+      case Import(List(importer)) if importer.syntax.containsSlice("collection.JavaConverters._") =>
+        ctx.replaceTree(importer, "strawman.collection.JavaConverters._")
+    }.asPatch
+  }
+
   override def fix(ctx: RuleCtx): Patch = {
     replaceToList(ctx) +
       replaceSymbols(ctx) +
       replaceExtensionMethods(ctx) +
       replaceRange(ctx) +
-      replaceTupleZipped(ctx)
+      replaceTupleZipped(ctx) +
+      replaceJavaConverters(ctx)
   }
 }

--- a/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -102,13 +102,6 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
     )
   }
 
-  val toGenericX = SymbolMatcher.normalized(
-    Symbol("_root_.scala.collection.TraversableOnce.toMap.")
-  )
-  val toImmutableX = SymbolMatcher.normalized(
-    Symbol("_root_.scala.collection.TraversableOnce.toList."),
-    Symbol("_root_.scala.collection.TraversableOnce.toSet.")
-  )
   val toTpe = SymbolMatcher.normalized(
     Symbol("_root_.scala.collection.TraversableLike.to.")
   )
@@ -125,10 +118,6 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
     ctx.tree.collect {
       case iterator(t: Name) =>
         ctx.replaceTree(t, "iterator()")
-      case toImmutableX(t @ Name(n)) =>
-        ctx.replaceTree(t, s"to(strawman.collection.immutable.${n.stripPrefix("to")})")
-      case toGenericX(t @ Name(n)) =>
-        ctx.replaceTree(t, s"to(strawman.collection.${n.stripPrefix("to")})")
       case toTpe(n: Name) =>
         (for {
           name <- n.tokens.lastOption


### PR DESCRIPTION
- Fix the current migration rules to deduplicate unimports (see scalacenter/scalafix#478) ;
- Add a migration rule for “import scala.collection.JavaConverters._”.