### PR TITLE
Fix inconsistencies between size and length implementations

### DIFF
--- a/collections/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/collections/src/main/scala/strawman/collection/ArrayOps.scala
@@ -2,7 +2,6 @@ package strawman
 package collection
 
 import scala.{AnyVal, Array, ArrayIndexOutOfBoundsException, Char, Int, throws}
-import scala.Predef.???
 import mutable.{ArrayBuffer, GrowableBuilder}
 
 import scala.reflect.ClassTag
@@ -32,8 +31,6 @@ class ArrayOps[A](val xs: Array[A])
   protected[this] def fromSpecificIterable(coll: Iterable[A]): Array[A] = coll.toArray[A](elemTag)
 
   protected[this] def newSpecificBuilder() = ArrayBuffer.newBuilder[A]().mapResult(_.toArray(elemTag))
-
-  override def knownSize = xs.length
 
   override def className = "Array"
 

--- a/collections/src/main/scala/strawman/collection/IndexedSeq.scala
+++ b/collections/src/main/scala/strawman/collection/IndexedSeq.scala
@@ -29,4 +29,6 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
 
   override def lengthCompare(len: Int): Int = length - len
 
+  final override def knownSize: Int = length
+
 }

--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -25,7 +25,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     def next() = { val r = current.head; current = current.tail; r }
   }
 
-  override def size: Int = {
+  def length: Int = {
     var these = toIterable
     var len = 0
     while (!these.isEmpty) {
@@ -34,8 +34,6 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     }
     len
   }
-
-  final def length: Int = size
 
   override def lengthCompare(len: Int): Int = {
     @tailrec def loop(i: Int, xs: LinearSeq[A]): Int = {

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -186,6 +186,8 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   // overrides of this method
   @`inline` final override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
 
+  final override def size: Int = length
+
   /** Selects all the elements of this $coll ignoring the duplicates.
     *
     * @return a new $coll consisting of all the elements of this $coll without duplicates.

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -639,6 +639,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     }
   }
 
+  override def isEmpty: Boolean = lengthCompare(0) == 0
+  override def nonEmpty: Boolean = lengthCompare(0) != 0
+
   /** Are the elements of this collection the same (and in the same order)
     * as those of `that`?
     */

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -48,8 +48,6 @@ class StringOps(val s: String)
   @throws[StringIndexOutOfBoundsException]
   def apply(i: Int) = s.charAt(i)
 
-  override def knownSize = s.length
-
   override def className = "String"
 
   /** Overloaded version of `map` that gives back a string, where the inherited

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -27,7 +27,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-sealed trait HashMap[K, +V]
+sealed abstract class HashMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]
     with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -29,8 +29,6 @@ class ImmutableArray[+A] private[collection] (private val elements: scala.Array[
 
   def length: Int = elements.length
 
-  override def knownSize: Int = elements.length
-
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A = ScalaRunTime.array_apply(elements, i).asInstanceOf[A]
 

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -71,7 +71,7 @@ import scala.{Any, AnyRef, Boolean, Function1, IndexOutOfBoundsException, Int, N
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-sealed trait List[+A]
+sealed abstract class List[+A]
   extends LinearSeq[A]
     with LinearSeqOps[A, List, List[A]]
     with StrictOptimizedSeqOps[A, List, List[A]]
@@ -326,7 +326,7 @@ sealed trait List[+A]
     }
   }
 
-  override def reverse: List[A] = {
+  final override def reverse: List[A] = {
     var result: List[A] = Nil
     var these = this
     while (!these.isEmpty) {
@@ -336,8 +336,15 @@ sealed trait List[+A]
     result
   }
 
-  override def foldRight[B](z: B)(op: (A, B) => B): B =
-    reverse.foldLeft(z)((right, left) => op(left, right))
+  final override def foldRight[B](z: B)(op: (A, B) => B): B = {
+    var acc = z
+    var these: List[A] = reverse
+    while (!these.isEmpty) {
+      acc = op(these.head, acc)
+      these = these.tail
+    }
+    acc
+  }
 
   // Create a proxy for Java serialization that allows us to avoid mutation
   // during deserialization.  This is the Serialization Proxy Pattern.

--- a/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -70,7 +70,6 @@ sealed class NumericRange[T](
 
   // See comment in Range for why this must be lazy.
   override lazy val length: Int = NumericRange.count(start, end, step, isInclusive)
-  override def size: Int = length
   override def isEmpty = length == 0
   override def last: T =
     if (length == 0) Nil.head

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -146,9 +146,6 @@ sealed abstract class Range(
     */
   def by(step: Int): Range = copy(start, end, step)
 
-  // Override for performance
-  override def size: Int = length
-
   // Check cannot be evaluated eagerly because we have a pattern where
   // ranges are constructed like: "x to y by z" The "x to y" piece
   // should not trigger an exception. So the calculation is delayed,

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -80,6 +80,8 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 
   def length: Int = endIndex - startIndex
 
+  override def lengthCompare(len: Int): Int = length - len
+
   private[collection] def initIterator[B >: A](s: VectorIterator[B]): Unit = {
     s.initFrom(this)
     if (dirty) s.stabilize(focus)
@@ -573,7 +575,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 }
 
 class VectorIterator[+A](_startIndex: Int, endIndex: Int)
-  extends Iterator[A]
+  extends AbstractIterator[A]
     with VectorPointer[A @uncheckedVariance] {
 
   private var blockIndex: Int = _startIndex & ~31
@@ -642,8 +644,6 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
     lo += 1
     this
   }
-
-//  override def addAll(xs: IterableOnce[A]): this.type = super.addAll(xs)
 
   def result(): Vector[A] = {
     val size = blockIndex + lo

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -53,7 +53,6 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def update(n: Int, elem: A): Unit = array(n) = elem.asInstanceOf[AnyRef]
 
   def length = end
-  override def knownSize = length
 
   override def view: ArrayBufferView[A] = new ArrayBufferView(array, end)
 

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -87,7 +87,7 @@ class ListBuffer[A]
     this
   }
 
-  def subtract(elem: A): ListBuffer.this.type = {
+  def subtract(elem: A): this.type = {
     ensureUnaliased()
     if (isEmpty) {}
     else if (first.head == elem) {


### PR DESCRIPTION
Fixes #290.

The implementation of `size` was O(n) in `Vector` instead of O(1) (only `length` was O(1)), which was at the origin of the severe regression observed in #290.

I fixed that by making `size` a `final` forwarder to `length`. We could also remove `length` at all, as suggested in #147, however I found convenient to have `length` as an abstract member in `Indexed` collections so that I couldn’t forget to implement it.

I will post the benchmark results as soon as they have finished to run… (so, not before tomorrow…)
