### PR TITLE
Various Map implementations ported from Scala 2.12

### DIFF
--- a/collections/src/main/scala/strawman/collection/DefaultMap.scala
+++ b/collections/src/main/scala/strawman/collection/DefaultMap.scala
@@ -1,0 +1,37 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+
+/** A default map which builds a default `immutable.Map` implementation for all
+  * transformations.
+  *
+  *  Instances that inherit from `DefaultMap[K, V]` still have to define:
+  *  {{{
+  *    def get(key: K): Option[V]
+  *    def iterator(): Iterator[(K, V)]
+  *  }}}
+  *
+  *  It might also be advisable to override `foreach` or `size` if efficient
+  *  implementations can be found.
+  *
+  *  @since 2.8
+  */
+trait DefaultMap[K, +V] extends Map[K, V] { self =>
+
+  // Members declared in IterableOps
+  def iterableFactory: IterableFactory[Iterable] = Iterable
+  protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]): Map[K,V] = mapFactory.from(coll)
+  protected[this] def newSpecificBuilder(): mutable.Builder[(K, V), Map[K,V]] = mapFactory.newBuilder()
+
+  // Members declared in MapOps
+  def mapFactory: MapFactory[Map] = Map
+  def empty: Map[K,V] = mapFactory.empty
+  protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
+}

--- a/collections/src/main/scala/strawman/collection/generic/BitOperations.scala
+++ b/collections/src/main/scala/strawman/collection/generic/BitOperations.scala
@@ -1,0 +1,47 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package generic
+
+import scala.Predef.{String, intWrapper, longWrapper}
+
+/** Some bit operations.
+  *
+  *  See http://www.drmaciver.com/2008/08/unsigned-comparison-in-javascala/ for
+  *  an explanation of unsignedCompare.
+  */
+private[collection] object BitOperations {
+  trait Int {
+    type Int = scala.Int
+    def zero(i: Int, mask: Int)                 = (i & mask) == 0
+    def mask(i: Int, mask: Int)                 = i & (complement(mask - 1) ^ mask)
+    def hasMatch(key: Int, prefix: Int, m: Int) = mask(key, m) == prefix
+    def unsignedCompare(i: Int, j: Int)         = (i < j) ^ (i < 0) ^ (j < 0)
+    def shorter(m1: Int, m2: Int)               = unsignedCompare(m2, m1)
+    def complement(i: Int)                      = (-1) ^ i
+    def bits(num: Int)                          = 31 to 0 by -1 map (i => (num >>> i & 1) != 0)
+    def bitString(num: Int, sep: String = "")   = bits(num) map (b => if (b) "1" else "0") mkString sep
+    def highestOneBit(j: Int)                   = java.lang.Integer.highestOneBit(j)
+  }
+  object Int extends Int
+
+  trait Long {
+    type Long = scala.Long
+    def zero(i: Long, mask: Long)                  = (i & mask) == 0L
+    def mask(i: Long, mask: Long)                  = i & (complement(mask - 1) ^ mask)
+    def hasMatch(key: Long, prefix: Long, m: Long) = mask(key, m) == prefix
+    def unsignedCompare(i: Long, j: Long)          = (i < j) ^ (i < 0L) ^ (j < 0L)
+    def shorter(m1: Long, m2: Long)                = unsignedCompare(m2, m1)
+    def complement(i: Long)                        = (-1L) ^ i
+    def bits(num: Long)                            = 63L to 0L by -1L map (i => (num >>> i & 1L) != 0L)
+    def bitString(num: Long, sep: String = "")     = bits(num) map (b => if (b) "1" else "0") mkString sep
+    def highestOneBit(j: Long)                     = java.lang.Long.highestOneBit(j)
+  }
+  object Long extends Long
+}

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -1,0 +1,469 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package immutable
+
+import scala.{Int, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Some, IllegalArgumentException, `inline`}
+import java.lang.IllegalStateException
+import strawman.collection
+import strawman.collection.generic.BitOperations
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
+import scala.annotation.tailrec
+
+/** Utility class for integer maps.
+  *  @author David MacIver
+  */
+private[immutable] object IntMapUtils extends BitOperations.Int {
+  def branchMask(i: Int, j: Int) = highestOneBit(i ^ j)
+
+  def join[T](p1: Int, t1: IntMap[T], p2: Int, t2: IntMap[T]): IntMap[T] = {
+    val m = branchMask(p1, p2)
+    val p = mask(p1, m)
+    if (zero(p1, m)) IntMap.Bin(p, m, t1, t2)
+    else IntMap.Bin(p, m, t2, t1)
+  }
+
+  def bin[T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]): IntMap[T] = (left, right) match {
+    case (left, IntMap.Nil) => left
+    case (IntMap.Nil, right) => right
+    case (left, right) => IntMap.Bin(prefix, mask, left, right)
+  }
+}
+
+import IntMapUtils._
+
+/** A companion object for integer maps.
+  *
+  *  @define Coll  `IntMap`
+  *  @since 2.7
+  */
+object IntMap {
+  def empty[T] : IntMap[T]  = IntMap.Nil
+
+  def singleton[T](key: Int, value: T): IntMap[T] = IntMap.Tip(key, value)
+
+  def apply[T](elems: (Int, T)*): IntMap[T] =
+    elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
+
+  private[immutable] case object Nil extends IntMap[Nothing] {
+    // Important! Without this equals method in place, an infinite
+    // loop from Map.equals => size => pattern-match-on-Nil => equals
+    // develops.  Case objects and custom equality don't mix without
+    // careful handling.
+    override def equals(that : Any) = that match {
+      case _: this.type => true
+      case _: IntMap[_] => false // The only empty IntMaps are eq Nil
+      case _            => super.equals(that)
+    }
+  }
+
+  private[immutable] case class Tip[+T](key: Int, value: T) extends IntMap[T]{
+    def withValue[S](s: S) =
+      if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[IntMap.Tip[S]]
+      else IntMap.Tip(key, s)
+  }
+  private[immutable] case class Bin[+T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]) extends IntMap[T] {
+    def bin[S](left: IntMap[S], right: IntMap[S]): IntMap[S] = {
+      if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[IntMap.Bin[S]]
+      else IntMap.Bin[S](prefix, mask, left, right)
+    }
+  }
+
+  def newBuilder[V](): Builder[(Int, V), IntMap[V]] =
+    new ImmutableBuilder[(Int, V), IntMap[V]](empty) {
+      def add(elem: (Int, V)): this.type = { elems = elems + elem; this }
+    }
+}
+
+import IntMap._
+
+// Iterator over a non-empty IntMap.
+private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends AbstractIterator[T] {
+
+  // Basically this uses a simple stack to emulate conversion over the tree. However
+  // because we know that Ints are at least 32 bits we can have at most 32 IntMap.Bins and
+  // one IntMap.Tip sitting on the tree at any point. Therefore we know the maximum stack
+  // depth is 33 and
+  var index = 0
+  var buffer = new Array[AnyRef](33)
+
+  def pop = {
+    index -= 1
+    buffer(index).asInstanceOf[IntMap[V]]
+  }
+
+  def push(x: IntMap[V]): Unit = {
+    buffer(index) = x.asInstanceOf[AnyRef]
+    index += 1
+  }
+  push(it)
+
+  /**
+    * What value do we assign to a tip?
+    */
+  def valueOf(tip: IntMap.Tip[V]): T
+
+  def hasNext = index != 0
+  final def next(): T =
+    pop match {
+      case IntMap.Bin(_,_, t@IntMap.Tip(_, _), right) => {
+        push(right)
+        valueOf(t)
+      }
+      case IntMap.Bin(_, _, left, right) => {
+        push(right)
+        push(left)
+        next()
+      }
+      case t@IntMap.Tip(_, _) => valueOf(t)
+      // This should never happen. We don't allow IntMap.Nil in subtrees of the IntMap
+      // and don't return an IntMapIterator for IntMap.Nil.
+      case IntMap.Nil => throw new IllegalStateException("Empty maps not allowed as subtrees")
+    }
+}
+
+private[immutable] class IntMapEntryIterator[V](it: IntMap[V]) extends IntMapIterator[V, (Int, V)](it) {
+  def valueOf(tip: IntMap.Tip[V]) = (tip.key, tip.value)
+}
+
+private[immutable] class IntMapValueIterator[V](it: IntMap[V]) extends IntMapIterator[V, V](it) {
+  def valueOf(tip: IntMap.Tip[V]) = tip.value
+}
+
+private[immutable] class IntMapKeyIterator[V](it: IntMap[V]) extends IntMapIterator[V, Int](it) {
+  def valueOf(tip: IntMap.Tip[V]) = tip.key
+}
+
+import IntMap._
+
+/** Specialised immutable map structure for integer keys, based on
+  *  [[http://ittc.ku.edu/~andygill/papers/IntMap98.pdf Fast Mergeable Integer Maps]]
+  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
+  *
+  *  '''Note:''' This class is as of 2.8 largely superseded by HashMap.
+  *
+  *  @tparam T    type of the values associated with integer keys.
+  *
+  *  @since 2.7
+  *  @define Coll `immutable.IntMap`
+  *  @define coll immutable integer map
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+sealed abstract class IntMap[+T] extends Map[Int, T]
+  with MapOps[Int, T, Map, IntMap[T]]
+  with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]] {
+
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Int, T)]): IntMap[T] =
+    intMapFromIterable[T](coll)
+  protected[this] def intMapFromIterable[V2](coll: strawman.collection.Iterable[(Int, V2)]): IntMap[V2] = {
+    val b = IntMap.newBuilder[V2]()
+    b.sizeHint(coll)
+    b.addAll(coll)
+    b.result()
+  }
+  def iterableFactory: IterableFactoryLike[Iterable] = Iterable
+  protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
+    new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
+      def add(elem: (Int, T)): this.type = { elems = elems + elem; this }
+    }
+  def mapFactory: MapFactory[Map] = Map
+  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
+
+  override def empty: IntMap[T] = IntMap.Nil
+
+  override def toList = {
+    val buffer = new strawman.collection.mutable.ListBuffer[(Int, T)]
+    foreach(buffer += _)
+    buffer.toList
+  }
+
+  /**
+    * Iterator over key, value pairs of the map in unsigned order of the keys.
+    *
+    * @return an iterator over pairs of integer keys and corresponding values.
+    */
+  def iterator(): Iterator[(Int, T)] = this match {
+    case IntMap.Nil => Iterator.empty
+    case _ => new IntMapEntryIterator(this)
+  }
+
+  /**
+    * Loops over the key, value pairs of the map in unsigned order of the keys.
+    */
+  override final def foreach[U](f: ((Int, T)) => U): Unit = this match {
+    case IntMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
+    case IntMap.Tip(key, value) => f((key, value))
+    case IntMap.Nil =>
+  }
+
+  override def keysIterator(): Iterator[Int] = this match {
+    case IntMap.Nil => Iterator.empty
+    case _ => new IntMapKeyIterator(this)
+  }
+
+  /**
+    * Loop over the keys of the map. The same as `keys.foreach(f)`, but may
+    * be more efficient.
+    *
+    * @param f The loop body
+    */
+  final def foreachKey(f: Int => Unit): Unit = this match {
+    case IntMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
+    case IntMap.Tip(key, _) => f(key)
+    case IntMap.Nil =>
+  }
+
+  override def valuesIterator(): Iterator[T] = this match {
+    case IntMap.Nil => Iterator.empty
+    case _ => new IntMapValueIterator(this)
+  }
+
+  /**
+    * Loop over the values of the map. The same as `values.foreach(f)`, but may
+    * be more efficient.
+    *
+    * @param f The loop body
+    */
+  final def foreachValue(f: T => Unit): Unit = this match {
+    case IntMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
+    case IntMap.Tip(_, value) => f(value)
+    case IntMap.Nil =>
+  }
+
+  override def className = "IntMap"
+
+  override def isEmpty = this == IntMap.Nil
+
+  override def filter(f: ((Int, T)) => Boolean): IntMap[T] = this match {
+    case IntMap.Bin(prefix, mask, left, right) => {
+      val (newleft, newright) = (left.filter(f), right.filter(f))
+      if ((left eq newleft) && (right eq newright)) this
+      else bin(prefix, mask, newleft, newright)
+    }
+    case IntMap.Tip(key, value) =>
+      if (f((key, value))) this
+      else IntMap.Nil
+    case IntMap.Nil => IntMap.Nil
+  }
+
+  def transform[S](f: (Int, T) => S): IntMap[S] = this match {
+    case b@IntMap.Bin(prefix, mask, left, right) => b.bin(left.transform(f), right.transform(f))
+    case t@IntMap.Tip(key, value) => t.withValue(f(key, value))
+    case IntMap.Nil => IntMap.Nil
+  }
+
+  final override def size: Int = this match {
+    case IntMap.Nil => 0
+    case IntMap.Tip(_, _) => 1
+    case IntMap.Bin(_, _, left, right) => left.size + right.size
+  }
+
+  final def get(key: Int): Option[T] = this match {
+    case IntMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left.get(key) else right.get(key)
+    case IntMap.Tip(key2, value) => if (key == key2) Some(value) else None
+    case IntMap.Nil => None
+  }
+
+  final override def getOrElse[S >: T](key: Int, default: => S): S = this match {
+    case IntMap.Nil => default
+    case IntMap.Tip(key2, value) => if (key == key2) value else default
+    case IntMap.Bin(prefix, mask, left, right) =>
+      if (zero(key, mask)) left.getOrElse(key, default) else right.getOrElse(key, default)
+  }
+
+  final override def apply(key: Int): T = this match {
+    case IntMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left(key) else right(key)
+    case IntMap.Tip(key2, value) => if (key == key2) value else throw new IllegalArgumentException("Key not found")
+    case IntMap.Nil => throw new IllegalArgumentException("key not found")
+  }
+
+  override def + [S >: T] (kv: (Int, S)): IntMap[S] = updated(kv._1, kv._2)
+
+  override def updated[S >: T](key: Int, value: S): IntMap[S] = this match {
+    case IntMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) join(key, IntMap.Tip(key, value), prefix, this)
+      else if (zero(key, mask)) IntMap.Bin(prefix, mask, left.updated(key, value), right)
+      else IntMap.Bin(prefix, mask, left, right.updated(key, value))
+    case IntMap.Tip(key2, value2) =>
+      if (key == key2) IntMap.Tip(key, value)
+      else join(key, IntMap.Tip(key, value), key2, this)
+    case IntMap.Nil => IntMap.Tip(key, value)
+  }
+
+  def map[V2](f: ((Int, T)) => (Int, V2)): IntMap[V2] = intMapFromIterable(View.Map(toIterable, f))
+
+  def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]): IntMap[V2] = intMapFromIterable(View.FlatMap(toIterable, f))
+
+  override def concat [V1 >: T](that: collection.Iterable[(Int, V1)]): IntMap[V1] =
+    super.concat(that).asInstanceOf[IntMap[V1]] // Already has corect type but not declared as such
+
+  /**
+    * Updates the map, using the provided function to resolve conflicts if the key is already present.
+    *
+    * Equivalent to:
+    * {{{
+    *   this.get(key) match {
+    *     case None => this.update(key, value)
+    *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
+    *   }
+    * }}}
+    *
+    * @tparam S     The supertype of values in this `LongMap`.
+    * @param key    The key to update
+    * @param value  The value to use if there is no conflict
+    * @param f      The function used to resolve conflicts.
+    * @return       The updated map.
+    */
+  def updateWith[S >: T](key: Int, value: S, f: (T, S) => S): IntMap[S] = this match {
+    case IntMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) join(key, IntMap.Tip(key, value), prefix, this)
+      else if (zero(key, mask)) IntMap.Bin(prefix, mask, left.updateWith(key, value, f), right)
+      else IntMap.Bin(prefix, mask, left, right.updateWith(key, value, f))
+    case IntMap.Tip(key2, value2) =>
+      if (key == key2) IntMap.Tip(key, f(value2, value))
+      else join(key, IntMap.Tip(key, value), key2, this)
+    case IntMap.Nil => IntMap.Tip(key, value)
+  }
+
+  def remove (key: Int): IntMap[T] = this match {
+    case IntMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) this
+      else if (zero(key, mask)) bin(prefix, mask, left - key, right)
+      else bin(prefix, mask, left, right - key)
+    case IntMap.Tip(key2, _) =>
+      if (key == key2) IntMap.Nil
+      else this
+    case IntMap.Nil => IntMap.Nil
+  }
+
+  /**
+    * A combined transform and filter function. Returns an `IntMap` such that
+    * for each `(key, value)` mapping in this map, if `f(key, value) == None`
+    * the map contains no mapping for key, and if `f(key, value)`.
+    *
+    * @tparam S  The type of the values in the resulting `LongMap`.
+    * @param f   The transforming function.
+    * @return    The modified map.
+    */
+  def modifyOrRemove[S](f: (Int, T) => Option[S]): IntMap[S] = this match {
+    case IntMap.Bin(prefix, mask, left, right) =>
+      val newleft = left.modifyOrRemove(f)
+      val newright = right.modifyOrRemove(f)
+      if ((left eq newleft) && (right eq newright)) this.asInstanceOf[IntMap[S]]
+      else bin(prefix, mask, newleft, newright)
+    case IntMap.Tip(key, value) => f(key, value) match {
+      case None =>
+        IntMap.Nil
+      case Some(value2) =>
+        //hack to preserve sharing
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this.asInstanceOf[IntMap[S]]
+        else IntMap.Tip(key, value2)
+    }
+    case IntMap.Nil =>
+      IntMap.Nil
+  }
+
+  /**
+    * Forms a union map with that map, using the combining function to resolve conflicts.
+    *
+    * @tparam S      The type of values in `that`, a supertype of values in `this`.
+    * @param that    The map to form a union with.
+    * @param f       The function used to resolve conflicts between two mappings.
+    * @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
+    */
+  def unionWith[S >: T](that: IntMap[S], f: (Int, S, S) => S): IntMap[S] = (this, that) match{
+    case (IntMap.Bin(p1, m1, l1, r1), that@(IntMap.Bin(p2, m2, l2, r2))) =>
+      if (shorter(m1, m2)) {
+        if (!hasMatch(p2, p1, m1)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else if (zero(p2, m1)) IntMap.Bin(p1, m1, l1.unionWith(that, f), r1)
+        else IntMap.Bin(p1, m1, l1, r1.unionWith(that, f))
+      } else if (shorter(m2, m1)){
+        if (!hasMatch(p1, p2, m2)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else if (zero(p1, m2)) IntMap.Bin(p2, m2, this.unionWith(l2, f), r2)
+        else IntMap.Bin(p2, m2, l2, this.unionWith(r2, f))
+      }
+      else {
+        if (p1 == p2) IntMap.Bin(p1, m1, l1.unionWith(l2,f), r1.unionWith(r2, f))
+        else join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+      }
+    case (IntMap.Tip(key, value), x) => x.updateWith[S](key, value, (x, y) => f(key, y, x))
+    case (x, IntMap.Tip(key, value)) => x.updateWith[S](key, value, (x, y) => f(key, x, y))
+    case (IntMap.Nil, x) => x
+    case (x, IntMap.Nil) => x
+  }
+
+  /**
+    * Forms the intersection of these two maps with a combining function. The
+    * resulting map is a map that has only keys present in both maps and has
+    * values produced from the original mappings by combining them with `f`.
+    *
+    * @tparam S      The type of values in `that`.
+    * @tparam R      The type of values in the resulting `LongMap`.
+    * @param that    The map to intersect with.
+    * @param f       The combining function.
+    * @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
+    */
+  def intersectionWith[S, R](that: IntMap[S], f: (Int, T, S) => R): IntMap[R] = (this, that) match {
+    case (IntMap.Bin(p1, m1, l1, r1), that@IntMap.Bin(p2, m2, l2, r2)) =>
+      if (shorter(m1, m2)) {
+        if (!hasMatch(p2, p1, m1)) IntMap.Nil
+        else if (zero(p2, m1)) l1.intersectionWith(that, f)
+        else r1.intersectionWith(that, f)
+      } else if (m1 == m2) bin(p1, m1, l1.intersectionWith(l2, f), r1.intersectionWith(r2, f))
+      else {
+        if (!hasMatch(p1, p2, m2)) IntMap.Nil
+        else if (zero(p1, m2)) this.intersectionWith(l2, f)
+        else this.intersectionWith(r2, f)
+      }
+    case (IntMap.Tip(key, value), that) => that.get(key) match {
+      case None => IntMap.Nil
+      case Some(value2) => IntMap.Tip(key, f(key, value, value2))
+    }
+    case (_, IntMap.Tip(key, value)) => this.get(key) match {
+      case None => IntMap.Nil
+      case Some(value2) => IntMap.Tip(key, f(key, value2, value))
+    }
+    case (_, _) => IntMap.Nil
+  }
+
+  /**
+    * Left biased intersection. Returns the map that has all the same mappings
+    * as this but only for keys which are present in the other map.
+    *
+    * @tparam R      The type of values in `that`.
+    * @param that    The map to intersect with.
+    * @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
+    */
+  def intersection[R](that: IntMap[R]): IntMap[T] =
+    this.intersectionWith(that, (key: Int, value: T, value2: R) => value)
+
+  def ++[S >: T](that: IntMap[S]) =
+    this.unionWith[S](that, (key, x, y) => y)
+
+  /**
+    * The entry with the lowest key value considered in unsigned order.
+    */
+  @tailrec
+  final def firstKey: Int = this match {
+    case Bin(_, _, l, r) => l.firstKey
+    case Tip(k, v) => k
+    case IntMap.Nil => throw new IllegalStateException("Empty set")
+  }
+
+  /**
+    * The entry with the highest key value considered in unsigned order.
+    */
+  @tailrec
+  final def lastKey: Int = this match {
+    case Bin(_, _, l, r) => r.lastKey
+    case Tip(k, v) => k
+    case IntMap.Nil => throw new IllegalStateException("Empty set")
+  }
+}

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -1,0 +1,442 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package immutable
+
+import scala.{Int, Long, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Some, IllegalArgumentException, `inline`}
+import java.lang.IllegalStateException
+import strawman.collection.generic.BitOperations
+import strawman.collection.mutable.{Builder, ImmutableBuilder, ListBuffer}
+import scala.annotation.tailrec
+import scala.annotation.tailrec
+
+/** Utility class for long maps.
+  *  @author David MacIver
+  */
+private[immutable] object LongMapUtils extends BitOperations.Long {
+  def branchMask(i: Long, j: Long) = highestOneBit(i ^ j)
+
+  def join[T](p1: Long, t1: LongMap[T], p2: Long, t2: LongMap[T]): LongMap[T] = {
+    val m = branchMask(p1, p2)
+    val p = mask(p1, m)
+    if (zero(p1, m)) LongMap.Bin(p, m, t1, t2)
+    else LongMap.Bin(p, m, t2, t1)
+  }
+
+  def bin[T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]): LongMap[T] = (left, right) match {
+    case (left, LongMap.Nil) => left
+    case (LongMap.Nil, right) => right
+    case (left, right) => LongMap.Bin(prefix, mask, left, right)
+  }
+}
+
+import LongMapUtils._
+
+/** A companion object for long maps.
+  *
+  *  @define Coll  `LongMap`
+  *  @since 2.7
+  */
+object LongMap {
+  def empty[T]: LongMap[T]  = LongMap.Nil
+  def singleton[T](key: Long, value: T): LongMap[T] = LongMap.Tip(key, value)
+  def apply[T](elems: (Long, T)*): LongMap[T] =
+    elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
+
+  private[immutable] case object Nil extends LongMap[Nothing] {
+    // Important, don't remove this! See IntMap for explanation.
+    override def equals(that : Any) = that match {
+      case (that: AnyRef) if (this eq that) => true
+      case (that: LongMap[_]) => false // The only empty LongMaps are eq Nil
+      case that => super.equals(that)
+    }
+  }
+
+  private[immutable] case class Tip[+T](key: Long, value: T) extends LongMap[T] {
+    def withValue[S](s: S) =
+      if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[LongMap.Tip[S]]
+      else LongMap.Tip(key, s)
+  }
+  private[immutable] case class Bin[+T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]) extends LongMap[T] {
+    def bin[S](left: LongMap[S], right: LongMap[S]): LongMap[S] = {
+      if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[LongMap.Bin[S]]
+      else LongMap.Bin[S](prefix, mask, left, right)
+    }
+  }
+}
+
+// Iterator over a non-empty LongMap.
+private[immutable] abstract class LongMapIterator[V, T](it: LongMap[V]) extends AbstractIterator[T] {
+
+  // Basically this uses a simple stack to emulate conversion over the tree. However
+  // because we know that Longs are only 64 bits we can have at most 64 LongMap.Bins and
+  // one LongMap.Tip sitting on the tree at any point. Therefore we know the maximum stack
+  // depth is 65
+  var index = 0
+  var buffer = new Array[AnyRef](65)
+
+  def pop() = {
+    index -= 1
+    buffer(index).asInstanceOf[LongMap[V]]
+  }
+
+  def push(x: LongMap[V]): Unit = {
+    buffer(index) = x.asInstanceOf[AnyRef]
+    index += 1
+  }
+  push(it)
+
+  /**
+    * What value do we assign to a tip?
+    */
+  def valueOf(tip: LongMap.Tip[V]): T
+
+  def hasNext = index != 0
+  final def next(): T =
+    pop() match {
+      case LongMap.Bin(_,_, t@LongMap.Tip(_, _), right) => {
+        push(right)
+        valueOf(t)
+      }
+      case LongMap.Bin(_, _, left, right) => {
+        push(right)
+        push(left)
+        next()
+      }
+      case t@LongMap.Tip(_, _) => valueOf(t)
+      // This should never happen. We don't allow LongMap.Nil in subtrees of the LongMap
+      // and don't return an LongMapIterator for LongMap.Nil.
+      case LongMap.Nil => throw new IllegalStateException("Empty maps not allowed as subtrees")
+    }
+}
+
+private[immutable] class LongMapEntryIterator[V](it: LongMap[V]) extends LongMapIterator[V, (Long, V)](it){
+  def valueOf(tip: LongMap.Tip[V]) = (tip.key, tip.value)
+}
+
+private[immutable] class LongMapValueIterator[V](it: LongMap[V]) extends LongMapIterator[V, V](it){
+  def valueOf(tip: LongMap.Tip[V]) = tip.value
+}
+
+private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIterator[V, Long](it){
+  def valueOf(tip: LongMap.Tip[V]) = tip.key
+}
+
+/**
+  *  Specialised immutable map structure for long keys, based on
+  *  <a href="http://citeseer.ist.psu.edu/okasaki98fast.html">Fast Mergeable Long Maps</a>
+  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
+  *
+  *  Note: This class is as of 2.8 largely superseded by HashMap.
+  *
+  *  @tparam T      type of the values associated with the long keys.
+  *
+  *  @since 2.7
+  *  @define Coll `immutable.LongMap`
+  *  @define coll immutable long integer map
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+sealed abstract class LongMap[+T] extends Map[Long, T]
+  with MapOps[Long, T, Map, LongMap[T]]
+  with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]] {
+
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, T)]): LongMap[T] = {
+    //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
+    val b = newSpecificBuilder()
+    b.sizeHint(coll)
+    b.addAll(coll)
+    b.result()
+  }
+  def iterableFactory: IterableFactory[Iterable] = Iterable
+  protected[this] def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] =
+    new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
+      def add(elem: (Long, T)): this.type = { elems = elems + elem; this }
+    }
+  def mapFactory: MapFactory[Map] = Map
+  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
+
+  override def empty: LongMap[T] = LongMap.Nil
+
+  override def toList = {
+    val buffer = new ListBuffer[(Long, T)]
+    foreach(buffer += _)
+    buffer.toList
+  }
+
+  /**
+    * Iterator over key, value pairs of the map in unsigned order of the keys.
+    *
+    * @return an iterator over pairs of long keys and corresponding values.
+    */
+  def iterator(): Iterator[(Long, T)] = this match {
+    case LongMap.Nil => Iterator.empty
+    case _ => new LongMapEntryIterator(this)
+  }
+
+  /**
+    * Loops over the key, value pairs of the map in unsigned order of the keys.
+    */
+  override final def foreach[U](f: ((Long, T)) => U): Unit = this match {
+    case LongMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
+    case LongMap.Tip(key, value) => f((key, value))
+    case LongMap.Nil =>
+  }
+
+  override def keysIterator(): Iterator[Long] = this match {
+    case LongMap.Nil => Iterator.empty
+    case _ => new LongMapKeyIterator(this)
+  }
+
+  /**
+    * Loop over the keys of the map. The same as keys.foreach(f), but may
+    * be more efficient.
+    *
+    * @param f The loop body
+    */
+  final def foreachKey(f: Long => Unit): Unit = this match {
+    case LongMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
+    case LongMap.Tip(key, _) => f(key)
+    case LongMap.Nil =>
+  }
+
+  override def valuesIterator(): Iterator[T] = this match {
+    case LongMap.Nil => Iterator.empty
+    case _ => new LongMapValueIterator(this)
+  }
+
+  /**
+    * Loop over the values of the map. The same as values.foreach(f), but may
+    * be more efficient.
+    *
+    * @param f The loop body
+    */
+  final def foreachValue(f: T => Unit): Unit = this match {
+    case LongMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
+    case LongMap.Tip(_, value) => f(value)
+    case LongMap.Nil =>
+  }
+
+  override def className = "LongMap"
+
+  override def isEmpty = this == LongMap.Nil
+
+  override def filter(f: ((Long, T)) => Boolean): LongMap[T] = this match {
+    case LongMap.Bin(prefix, mask, left, right) => {
+      val (newleft, newright) = (left.filter(f), right.filter(f))
+      if ((left eq newleft) && (right eq newright)) this
+      else bin(prefix, mask, newleft, newright)
+    }
+    case LongMap.Tip(key, value) =>
+      if (f((key, value))) this
+      else LongMap.Nil
+    case LongMap.Nil => LongMap.Nil
+  }
+
+  def transform[S](f: (Long, T) => S): LongMap[S] = this match {
+    case b@LongMap.Bin(prefix, mask, left, right) => b.bin(left.transform(f), right.transform(f))
+    case t@LongMap.Tip(key, value) => t.withValue(f(key, value))
+    case LongMap.Nil => LongMap.Nil
+  }
+
+  final override def size: Int = this match {
+    case LongMap.Nil => 0
+    case LongMap.Tip(_, _) => 1
+    case LongMap.Bin(_, _, left, right) => left.size + right.size
+  }
+
+  final def get(key: Long): Option[T] = this match {
+    case LongMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left.get(key) else right.get(key)
+    case LongMap.Tip(key2, value) => if (key == key2) Some(value) else None
+    case LongMap.Nil => None
+  }
+
+  final override def getOrElse[S >: T](key: Long, default: => S): S = this match {
+    case LongMap.Nil => default
+    case LongMap.Tip(key2, value) => if (key == key2) value else default
+    case LongMap.Bin(prefix, mask, left, right) =>
+      if (zero(key, mask)) left.getOrElse(key, default) else right.getOrElse(key, default)
+  }
+
+  final override def apply(key: Long): T = this match {
+    case LongMap.Bin(prefix, mask, left, right) => if (zero(key, mask)) left(key) else right(key)
+    case LongMap.Tip(key2, value) => if (key == key2) value else throw new IllegalArgumentException("Key not found")
+    case LongMap.Nil => throw new IllegalArgumentException("key not found")
+  }
+
+  override def + [S >: T] (kv: (Long, S)): LongMap[S] = updated(kv._1, kv._2)
+
+  override def updated[S >: T](key: Long, value: S): LongMap[S] = this match {
+    case LongMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) join(key, LongMap.Tip(key, value), prefix, this)
+      else if (zero(key, mask)) LongMap.Bin(prefix, mask, left.updated(key, value), right)
+      else LongMap.Bin(prefix, mask, left, right.updated(key, value))
+    case LongMap.Tip(key2, value2) =>
+      if (key == key2) LongMap.Tip(key, value)
+      else join(key, LongMap.Tip(key, value), key2, this)
+    case LongMap.Nil => LongMap.Tip(key, value)
+  }
+
+  /**
+    * Updates the map, using the provided function to resolve conflicts if the key is already present.
+    *
+    * Equivalent to
+    * {{{
+    *   this.get(key) match {
+    *     case None => this.update(key, value)
+    *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
+    *   }
+    * }}}
+    *
+    * @tparam S     The supertype of values in this `LongMap`.
+    * @param key    The key to update.
+    * @param value  The value to use if there is no conflict.
+    * @param f      The function used to resolve conflicts.
+    * @return       The updated map.
+    */
+  def updateWith[S >: T](key: Long, value: S, f: (T, S) => S): LongMap[S] = this match {
+    case LongMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) join(key, LongMap.Tip(key, value), prefix, this)
+      else if (zero(key, mask)) LongMap.Bin(prefix, mask, left.updateWith(key, value, f), right)
+      else LongMap.Bin(prefix, mask, left, right.updateWith(key, value, f))
+    case LongMap.Tip(key2, value2) =>
+      if (key == key2) LongMap.Tip(key, f(value2, value))
+      else join(key, LongMap.Tip(key, value), key2, this)
+    case LongMap.Nil => LongMap.Tip(key, value)
+  }
+
+  def remove(key: Long): LongMap[T] = this match {
+    case LongMap.Bin(prefix, mask, left, right) =>
+      if (!hasMatch(key, prefix, mask)) this
+      else if (zero(key, mask)) bin(prefix, mask, left - key, right)
+      else bin(prefix, mask, left, right - key)
+    case LongMap.Tip(key2, _) =>
+      if (key == key2) LongMap.Nil
+      else this
+    case LongMap.Nil => LongMap.Nil
+  }
+
+  /**
+    * A combined transform and filter function. Returns an `LongMap` such that
+    * for each `(key, value)` mapping in this map, if `f(key, value) == None`
+    * the map contains no mapping for key, and if `f(key, value)`.
+    *
+    * @tparam S    The type of the values in the resulting `LongMap`.
+    * @param f     The transforming function.
+    * @return      The modified map.
+    */
+  def modifyOrRemove[S](f: (Long, T) => Option[S]): LongMap[S] = this match {
+    case LongMap.Bin(prefix, mask, left, right) => {
+      val newleft = left.modifyOrRemove(f)
+      val newright = right.modifyOrRemove(f)
+      if ((left eq newleft) && (right eq newright)) this.asInstanceOf[LongMap[S]]
+      else bin(prefix, mask, newleft, newright)
+    }
+    case LongMap.Tip(key, value) => f(key, value) match {
+      case None => LongMap.Nil
+      case Some(value2) =>
+        //hack to preserve sharing
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this.asInstanceOf[LongMap[S]]
+        else LongMap.Tip(key, value2)
+    }
+    case LongMap.Nil => LongMap.Nil
+  }
+
+  /**
+    * Forms a union map with that map, using the combining function to resolve conflicts.
+    *
+    * @tparam S      The type of values in `that`, a supertype of values in `this`.
+    * @param that    The map to form a union with.
+    * @param f       The function used to resolve conflicts between two mappings.
+    * @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
+    */
+  def unionWith[S >: T](that: LongMap[S], f: (Long, S, S) => S): LongMap[S] = (this, that) match{
+    case (LongMap.Bin(p1, m1, l1, r1), that@(LongMap.Bin(p2, m2, l2, r2))) =>
+      if (shorter(m1, m2)) {
+        if (!hasMatch(p2, p1, m1)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else if (zero(p2, m1)) LongMap.Bin(p1, m1, l1.unionWith(that, f), r1)
+        else LongMap.Bin(p1, m1, l1, r1.unionWith(that, f))
+      } else if (shorter(m2, m1)){
+        if (!hasMatch(p1, p2, m2)) join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+        else if (zero(p1, m2)) LongMap.Bin(p2, m2, this.unionWith(l2, f), r2)
+        else LongMap.Bin(p2, m2, l2, this.unionWith(r2, f))
+      }
+      else {
+        if (p1 == p2) LongMap.Bin(p1, m1, l1.unionWith(l2,f), r1.unionWith(r2, f))
+        else join[S](p1, this, p2, that) // TODO: remove [S] when scala/bug#5548 is fixed
+      }
+    case (LongMap.Tip(key, value), x) => x.updateWith[S](key, value, (x, y) => f(key, y, x)) // TODO: remove [S] when scala/bug#5548 is fixed
+    case (x, LongMap.Tip(key, value)) => x.updateWith[S](key, value, (x, y) => f(key, x, y))
+    case (LongMap.Nil, x) => x
+    case (x, LongMap.Nil) => x
+  }
+
+  /**
+    * Forms the intersection of these two maps with a combining function. The
+    * resulting map is a map that has only keys present in both maps and has
+    * values produced from the original mappings by combining them with `f`.
+    *
+    * @tparam S      The type of values in `that`.
+    * @tparam R      The type of values in the resulting `LongMap`.
+    * @param that    The map to intersect with.
+    * @param f       The combining function.
+    * @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
+    */
+  def intersectionWith[S, R](that: LongMap[S], f: (Long, T, S) => R): LongMap[R] = (this, that) match {
+    case (LongMap.Bin(p1, m1, l1, r1), that@LongMap.Bin(p2, m2, l2, r2)) =>
+      if (shorter(m1, m2)) {
+        if (!hasMatch(p2, p1, m1)) LongMap.Nil
+        else if (zero(p2, m1)) l1.intersectionWith(that, f)
+        else r1.intersectionWith(that, f)
+      } else if (m1 == m2) bin(p1, m1, l1.intersectionWith(l2, f), r1.intersectionWith(r2, f))
+      else {
+        if (!hasMatch(p1, p2, m2)) LongMap.Nil
+        else if (zero(p1, m2)) this.intersectionWith(l2, f)
+        else this.intersectionWith(r2, f)
+      }
+    case (LongMap.Tip(key, value), that) => that.get(key) match {
+      case None => LongMap.Nil
+      case Some(value2) => LongMap.Tip(key, f(key, value, value2))
+    }
+    case (_, LongMap.Tip(key, value)) => this.get(key) match {
+      case None => LongMap.Nil
+      case Some(value2) => LongMap.Tip(key, f(key, value2, value))
+    }
+    case (_, _) => LongMap.Nil
+  }
+
+  /**
+    * Left biased intersection. Returns the map that has all the same mappings as this but only for keys
+    * which are present in the other map.
+    *
+    * @tparam R      The type of values in `that`.
+    * @param that    The map to intersect with.
+    * @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
+    */
+  def intersection[R](that: LongMap[R]): LongMap[T] =
+    this.intersectionWith(that, (key: Long, value: T, value2: R) => value)
+
+  def ++[S >: T](that: LongMap[S]) =
+    this.unionWith[S](that, (key, x, y) => y)
+
+  @tailrec
+  final def firstKey: Long = this match {
+    case LongMap.Bin(_, _, l, r) => l.firstKey
+    case LongMap.Tip(k, v) => k
+    case LongMap.Nil => throw new IllegalStateException("Empty set")
+  }
+
+  @tailrec
+  final def lastKey: Long = this match {
+    case LongMap.Bin(_, _, l, r) => r.lastKey
+    case LongMap.Tip(k , v) => k
+    case LongMap.Nil => throw new IllegalStateException("Empty set")
+  }
+
+}

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -1,0 +1,506 @@
+package strawman
+package collection
+package mutable
+
+import scala.{AnyRef, Any, Nothing, Array, Int, Boolean, Some, None, Option, SerialVersionUID, Serializable, NoSuchElementException, Unit, deprecated}
+import scala.math
+
+/** This class implements mutable maps with `AnyRef` keys based on a hash table with open addressing.
+ *
+ *  Basic map operations on single entries, including `contains` and `get`,
+ *  are typically significantly faster with `AnyRefMap` than [[HashMap]].
+ *  Note that numbers and characters are not handled specially in AnyRefMap;
+ *  only plain `equals` and `hashCode` are used in comparisons.
+ *
+ *  Methods that traverse or regenerate the map, including `foreach` and `map`,
+ *  are not in general faster than with `HashMap`.  The methods `foreachKey`,
+ *  `foreachValue`, `mapValuesNow`, and `transformValues` are, however, faster
+ *  than alternative ways to achieve the same functionality.
+ *
+ *  Maps with open addressing may become less efficient at lookup after
+ *  repeated addition/removal of elements.  Although `AnyRefMap` makes a
+ *  decent attempt to remain efficient regardless,  calling `repack`
+ *  on a map that will no longer have elements removed but will be
+ *  used heavily may save both time and storage space.
+ *
+ *  This map is not intended to contain more than 2^29^ entries (approximately
+ *  500 million).  The maximum capacity is 2^30^, but performance will degrade
+ *  rapidly as 2^30^ is approached.
+ *
+ */
+@SerialVersionUID(1L)
+class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initialBufferSize: Int, initBlank: Boolean)
+  extends Map[K, V]
+    with MapOps[K, V, Map, AnyRefMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable, AnyRefMap[K, V]]
+    with Serializable {
+
+  import AnyRefMap._
+  def this() = this(AnyRefMap.exceptionDefault, 16, true)
+
+  /** Creates a new `AnyRefMap` that returns default values according to a supplied key-value mapping. */
+  def this(defaultEntry: K => V) = this(defaultEntry, 16, true)
+
+  /** Creates a new `AnyRefMap` with an initial buffer of specified size.
+   *
+   *  An `AnyRefMap` can typically contain half as many elements as its buffer size
+   *  before it requires resizing.
+   */
+  def this(initialBufferSize: Int) = this(AnyRefMap.exceptionDefault, initialBufferSize, true)
+
+  /** Creates a new `AnyRefMap` with specified default values and initial buffer size. */
+  def this(defaultEntry: K => V, initialBufferSize: Int) = this(defaultEntry, initialBufferSize, true)
+
+  private[this] var mask = 0
+  private[this] var _size = 0
+  private[this] var _vacant = 0
+  private[this] var _hashes: Array[Int] = null
+  private[this] var _keys: Array[AnyRef] = null
+  private[this] var _values: Array[AnyRef] = null
+
+  if (initBlank) defaultInitialize(initialBufferSize)
+
+  private[this] def defaultInitialize(n: Int): Unit = {
+    mask =
+      if (n<0) 0x7
+      else (((1 << (32 - java.lang.Integer.numberOfLeadingZeros(n-1))) - 1) & 0x3FFFFFFF) | 0x7
+    _hashes = new Array[Int](mask+1)
+    _keys = new Array[AnyRef](mask+1)
+    _values = new Array[AnyRef](mask+1)
+  }
+
+  private[collection] def initializeTo(
+    m: Int, sz: Int, vc: Int, hz: Array[Int], kz: Array[AnyRef], vz: Array[AnyRef]
+  ): Unit = {
+    mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
+  }
+
+  def mapFactory: strawman.collection.MapFactory[Map] = Map
+  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
+    var sz = coll.knownSize
+    if(sz < 0) sz = 4
+    val arm = new AnyRefMap[K, V](sz * 2)
+    coll.foreach{ case (k,v) => arm(k) = v }
+    if (arm.size < (sz>>3)) arm.repack()
+    arm
+  }
+  protected[this] def newSpecificBuilder(): Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
+
+  override def size: Int = _size
+  override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)
+
+  private def imbalanced: Boolean =
+    (_size + _vacant) > 0.5*mask || _vacant > _size
+
+  private def hashOf(key: K): Int = {
+    if (key eq null) 0x41081989
+    else {
+      val h = key.hashCode
+      // Part of the MurmurHash3 32 bit finalizer
+      val i = (h ^ (h >>> 16)) * 0x85EBCA6B
+      val j = (i ^ (i >>> 13))
+      if (j==0) 0x41081989 else j & 0x7FFFFFFF
+    }
+  }
+
+  private def seekEntry(h: Int, k: AnyRef): Int = {
+    var e = h & mask
+    var x = 0
+    var g = 0
+    while ({ g = _hashes(e); g != 0}) {
+      if (g == h && { val q = _keys(e); (q eq k) || ((q ne null) && (q equals k)) }) return e
+      x += 1
+      e = (e + 2*(x+1)*x - 3) & mask
+    }
+    e | MissingBit
+  }
+
+  private def seekEntryOrOpen(h: Int, k: AnyRef): Int = {
+    var e = h & mask
+    var x = 0
+    var g = 0
+    var o = -1
+    while ({ g = _hashes(e); g != 0}) {
+      if (g == h && { val q = _keys(e); (q eq k) || ((q ne null) && (q equals k)) }) return e
+      else if (o == -1 && g+g == 0) o = e
+      x += 1
+      e = (e + 2*(x+1)*x - 3) & mask
+    }
+    if (o >= 0) o | MissVacant else e | MissingBit
+  }
+
+  override def contains(key: K): Boolean = seekEntry(hashOf(key), key) >= 0
+
+  override def get(key: K): Option[V] = {
+    val i = seekEntry(hashOf(key), key)
+    if (i < 0) None else Some(_values(i).asInstanceOf[V])
+  }
+
+  override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
+    val i = seekEntry(hashOf(key), key)
+    if (i < 0) default else _values(i).asInstanceOf[V]
+  }
+
+  override def getOrElseUpdate(key: K, defaultValue: => V): V = {
+    val h = hashOf(key)
+    var i = seekEntryOrOpen(h, key)
+    if (i < 0) {
+      // It is possible that the default value computation was side-effecting
+      // Our hash table may have resized or even contain what we want now
+      // (but if it does, we'll replace it)
+      val value = {
+        val oh = _hashes
+        val ans = defaultValue
+        if (oh ne _hashes) {
+          i = seekEntryOrOpen(h, key)
+          if (i >= 0) _size -= 1
+        }
+        ans
+      }
+      _size += 1
+      val j = i & IndexMask
+      _hashes(j) = h
+      _keys(j) = key.asInstanceOf[AnyRef]
+      _values(j) = value.asInstanceOf[AnyRef]
+      if ((i & VacantBit) != 0) _vacant -= 1
+      else if (imbalanced) repack()
+      value
+    }
+    else _values(i).asInstanceOf[V]
+  }
+
+  /** Retrieves the value associated with a key, or the default for that type if none exists
+   *  (null for AnyRef, 0 for floats and integers).
+   *
+   *  Note: this is the fastest way to retrieve a value that may or
+   *  may not exist, if the default null/zero is acceptable.  For key/value
+   *  pairs that do exist, `apply` (i.e. `map(key)`) is equally fast.
+   */
+  def getOrNull(key: K): V = {
+    val i = seekEntry(hashOf(key), key)
+    (if (i < 0) null else _values(i)).asInstanceOf[V]
+  }
+
+  /** Retrieves the value associated with a key.
+   *  If the key does not exist in the map, the `defaultEntry` for that key
+   *  will be returned instead; an exception will be thrown if no
+   *  `defaultEntry` was supplied.
+   */
+  override def apply(key: K): V = {
+    val i = seekEntry(hashOf(key), key)
+    if (i < 0) defaultEntry(key) else _values(i).asInstanceOf[V]
+  }
+
+  /** Defers to defaultEntry to find a default value for the key.  Throws an
+   *  exception if no other default behavior was specified.
+   */
+  override def default(key: K) = defaultEntry(key)
+
+  private def repack(newMask: Int): Unit = {
+    val oh = _hashes
+    val ok = _keys
+    val ov = _values
+    mask = newMask
+    _hashes = new Array[Int](mask+1)
+    _keys = new Array[AnyRef](mask+1)
+    _values = new Array[AnyRef](mask+1)
+    _vacant = 0
+    var i = 0
+    while (i < oh.length) {
+      val h = oh(i)
+      if (h+h != 0) {
+        var e = h & mask
+        var x = 0
+        while (_hashes(e) != 0) { x += 1; e = (e + 2*(x+1)*x - 3) & mask }
+        _hashes(e) = h
+        _keys(e) = ok(i)
+        _values(e) = ov(i)
+      }
+      i += 1
+    }
+  }
+
+  /** Repacks the contents of this `AnyRefMap` for maximum efficiency of lookup.
+   *
+   *  For maps that undergo a complex creation process with both addition and
+   *  removal of keys, and then are used heavily with no further removal of
+   *  elements, calling `repack` after the end of the creation can result in
+   *  improved performance.  Repacking takes time proportional to the number
+   *  of entries in the map.
+   */
+  def repack(): Unit = {
+    var m = mask
+    if (_size + _vacant >= 0.5*mask && !(_vacant > 0.2*mask)) m = ((m << 1) + 1) & IndexMask
+    while (m > 8 && 8*_size < m) m = m >>> 1
+    repack(m)
+  }
+
+  override def put(key: K, value: V): Option[V] = {
+    val h = hashOf(key)
+    val k = key
+    val i = seekEntryOrOpen(h, k)
+    if (i < 0) {
+      val j = i & IndexMask
+      _hashes(j) = h
+      _keys(j) = k
+      _values(j) = value.asInstanceOf[AnyRef]
+      _size += 1
+      if ((i & VacantBit) != 0) _vacant -= 1
+      else if (imbalanced) repack()
+      None
+    }
+    else {
+      val ans = Some(_values(i).asInstanceOf[V])
+      _hashes(i) = h
+      _keys(i) = k
+      _values(i) = value.asInstanceOf[AnyRef]
+      ans
+    }
+  }
+
+  /** Updates the map to include a new key-value pair.
+   *
+   *  This is the fastest way to add an entry to an `AnyRefMap`.
+   */
+  override def update(key: K, value: V): Unit = {
+    val h = hashOf(key)
+    val k = key
+    val i = seekEntryOrOpen(h, k)
+    if (i < 0) {
+      val j = i & IndexMask
+      _hashes(j) = h
+      _keys(j) = k
+      _values(j) = value.asInstanceOf[AnyRef]
+      _size += 1
+      if ((i & VacantBit) != 0) _vacant -= 1
+      else if (imbalanced) repack()
+    }
+    else {
+      _hashes(i) = h
+      _keys(i) = k
+      _values(i) = value.asInstanceOf[AnyRef]
+    }
+  }
+
+  /** Adds a new key/value pair to this map and returns the map. */
+  def add(key: K, value: V): this.type = { update(key, value); this }
+
+  def add(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
+
+  def subtract(key: K): this.type = {
+    val i = seekEntry(hashOf(key), key)
+    if (i >= 0) {
+      _size -= 1
+      _vacant += 1
+      _hashes(i) = Int.MinValue
+      _keys(i) = null
+      _values(i) = null
+    }
+    this
+  }
+
+  def iterator(): Iterator[(K, V)] = new Iterator[(K, V)] {
+    private[this] val hz = _hashes
+    private[this] val kz = _keys
+    private[this] val vz = _values
+
+    private[this] var index = 0
+
+    def hasNext: Boolean = index<hz.length && {
+      var h = hz(index)
+      while (h+h == 0) {
+        index += 1
+        if (index >= hz.length) return false
+        h = hz(index)
+      }
+      true
+    }
+
+    def next(): (K, V) = {
+      if (hasNext) {
+        val ans = (kz(index).asInstanceOf[K], vz(index).asInstanceOf[V])
+        index += 1
+        ans
+      }
+      else throw new NoSuchElementException("next")
+    }
+  }
+
+  override def foreach[U](f: ((K,V)) => U): Unit = {
+    var i = 0
+    var e = _size
+    while (e > 0) {
+      while(i < _hashes.length && { val h = _hashes(i); h+h == 0 && i < _hashes.length}) i += 1
+      if (i < _hashes.length) {
+        f((_keys(i).asInstanceOf[K], _values(i).asInstanceOf[V]))
+        i += 1
+        e -= 1
+      }
+      else return
+    }
+  }
+
+  override def clone(): AnyRefMap[K, V] = {
+    val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
+    val kz = java.util.Arrays.copyOf(_keys, _keys.length)
+    val vz = java.util.Arrays.copyOf(_values,  _values.length)
+    val arm = new AnyRefMap[K, V](defaultEntry, 1, false)
+    arm.initializeTo(mask, _size, _vacant, hz, kz,  vz)
+    arm
+  }
+
+  override def concat[V2 >: V](xs: strawman.collection.Iterable[(K, V2)]): AnyRefMap[K, V2] = {
+    val arm = clone().asInstanceOf[AnyRefMap[K, V2]]
+    xs.foreach(kv => arm += kv)
+    arm
+  }
+
+  @deprecated("Use AnyRefMap.from(m).add(k,v) instead of m.updated(k, v)", "2.13.0")
+  def updated[V1 >: V](key: K, value: V1): AnyRefMap[K, V1] = {
+    val arm = clone().asInstanceOf[AnyRefMap[K, V1]]
+    arm += ((key, value))
+    arm
+  }
+
+  private[this] def foreachElement[A,B](elems: Array[AnyRef], f: A => B): Unit = {
+    var i,j = 0
+    while (i < _hashes.length & j < _size) {
+      val h = _hashes(i)
+      if (h+h != 0) {
+        j += 1
+        f(elems(i).asInstanceOf[A])
+      }
+      i += 1
+    }
+  }
+
+  /** Applies a function to all keys of this map. */
+  def foreachKey[A](f: K => A): Unit = foreachElement[K,A](_keys, f)
+
+  /** Applies a function to all values of this map. */
+  def foreachValue[A](f: V => A): Unit = foreachElement[V,A](_values, f)
+
+  /** Creates a new `AnyRefMap` with different values.
+   *  Unlike `mapValues`, this method generates a new
+   *  collection immediately.
+   */
+  def mapValuesNow[V1](f: V => V1): AnyRefMap[K, V1] = {
+    val arm = new AnyRefMap[K,V1](AnyRefMap.exceptionDefault,  1,  false)
+    val hz = java.util.Arrays.copyOf(_hashes, _hashes.length)
+    val kz = java.util.Arrays.copyOf(_keys, _keys.length)
+    val vz = new Array[AnyRef](_values.length)
+    var i,j = 0
+    while (i < _hashes.length & j < _size) {
+      val h = _hashes(i)
+      if (h+h != 0) {
+        j += 1
+        vz(i) = f(_values(i).asInstanceOf[V]).asInstanceOf[AnyRef]
+      }
+      i += 1
+    }
+    arm.initializeTo(mask, _size, _vacant, hz, kz, vz)
+    arm
+  }
+
+  /** Applies a transformation function to all values stored in this map.
+   *  Note: the default, if any,  is not transformed.
+   */
+  def transformValues(f: V => V): this.type = {
+    var i,j = 0
+    while (i < _hashes.length & j < _size) {
+      val h = _hashes(i)
+      if (h+h != 0) {
+        j += 1
+        _values(i) = f(_values(i).asInstanceOf[V]).asInstanceOf[AnyRef]
+      }
+      i += 1
+    }
+    this
+  }
+
+  //TODO Replace this default implementation that used to be in MapLike
+  def clear(): Unit = keysIterator() foreach -=
+}
+
+object AnyRefMap {
+  private final val IndexMask  = 0x3FFFFFFF
+  private final val MissingBit = 0x80000000
+  private final val VacantBit  = 0x40000000
+  private final val MissVacant = 0xC0000000
+
+  @SerialVersionUID(1L)
+  private class ExceptionDefault extends (Any => Nothing) with Serializable {
+    def apply(k: Any): Nothing = throw new NoSuchElementException(if (k == null) "(null)" else k.toString)
+  }
+  private val exceptionDefault = new ExceptionDefault
+
+  /** A builder for instances of `AnyRefMap`.
+   *
+   *  This builder can be reused to create multiple instances.
+   */
+  final class AnyRefMapBuilder[K <: AnyRef, V] extends ReusableBuilder[(K, V), AnyRefMap[K, V]] {
+    private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
+    def add(entry: (K, V)): this.type = {
+      elems += entry
+      this
+    }
+    def clear(): Unit = elems = new AnyRefMap[K, V]
+    def result(): AnyRefMap[K, V] = elems
+  }
+
+  /** Creates a new `AnyRefMap` with zero or more key/value pairs. */
+  def apply[K <: AnyRef, V](elems: (K, V)*): AnyRefMap[K, V] = buildFromIterableOnce(elems.toStrawman)
+
+  private def buildFromIterableOnce[K <: AnyRef, V](elems: IterableOnce[(K, V)]): AnyRefMap[K, V] = {
+    var sz = elems.knownSize
+    if(sz < 0) sz = 4
+    val arm = new AnyRefMap[K, V](sz * 2)
+    elems.foreach{ case (k,v) => arm(k) = v }
+    if (arm.size < (sz>>3)) arm.repack()
+    arm
+  }
+
+  /** Creates a new empty `AnyRefMap`. */
+  def empty[K <: AnyRef, V]: AnyRefMap[K, V] = new AnyRefMap[K, V]
+
+  /** Creates a new empty `AnyRefMap` with the supplied default */
+  def withDefault[K <: AnyRef, V](default: K => V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
+
+  /** Creates a new `AnyRefMap` from an existing source collection. A source collection
+    * which is already an `AnyRefMap` gets cloned.
+    *
+    * @param source Source collection
+    * @tparam A the type of the collection’s elements
+    * @return a new `AnyRefMap` with the elements of `source`
+    */
+  def from[K <: AnyRef, V](source: IterableOnce[(K, V)]): AnyRefMap[K, V] = source match {
+    case source: AnyRefMap[_, _] => source.clone().asInstanceOf[AnyRefMap[K, V]]
+    case _ => buildFromIterableOnce(source)
+  }
+
+  /** Creates a new `AnyRefMap` from arrays of keys and values.
+   *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
+   */
+  def fromZip[K <: AnyRef, V](keys: Array[K], values: Array[V]): AnyRefMap[K, V] = {
+    val sz = math.min(keys.length, values.length)
+    val arm = new AnyRefMap[K, V](sz * 2)
+    var i = 0
+    while (i < sz) { arm(keys(i)) = values(i); i += 1 }
+    if (arm.size < (sz>>3)) arm.repack()
+    arm
+  }
+
+  /** Creates a new `AnyRefMap` from keys and values.
+   *  Equivalent to but more efficient than `AnyRefMap((keys zip values): _*)`.
+   */
+  def fromZip[K <: AnyRef, V](keys: Iterable[K], values: Iterable[V]): AnyRefMap[K, V] = {
+    val sz = math.min(keys.size, values.size)
+    val arm = new AnyRefMap[K, V](sz * 2)
+    val ki = keys.iterator()
+    val vi = values.iterator()
+    while (ki.hasNext && vi.hasNext) arm(ki.next()) = vi.next()
+    if (arm.size < (sz >> 3)) arm.repack()
+    arm
+  }
+}

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -1,0 +1,606 @@
+package strawman.collection
+package mutable
+
+import scala.{Long, AnyRef, Boolean, NoSuchElementException, Some, None, Option, Unit, Int, Array, Serializable, Nothing, math, deprecated}
+
+/** This class implements mutable maps with `Long` keys based on a hash table with open addressing.
+  *
+  *  Basic map operations on single entries, including `contains` and `get`,
+  *  are typically substantially faster with `LongMap` than [[HashMap]].  Methods
+  *  that act on the whole map,  including `foreach` and `map` are not in
+  *  general expected to be faster than with a generic map, save for those
+  *  that take particular advantage of the internal structure of the map:
+  *  `foreachKey`, `foreachValue`, `mapValuesNow`, and `transformValues`.
+  *
+  *  Maps with open addressing may become less efficient at lookup after
+  *  repeated addition/removal of elements.  Although `LongMap` makes a
+  *  decent attempt to remain efficient regardless,  calling `repack`
+  *  on a map that will no longer have elements removed but will be
+  *  used heavily may save both time and storage space.
+  *
+  *  This map is not intended to contain more than 2^29 entries (approximately
+  *  500 million).  The maximum capacity is 2^30, but performance will degrade
+  *  rapidly as 2^30 is approached.
+  *
+  */
+final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBufferSize: Int, initBlank: Boolean)
+  extends Map[Long, V]
+    with MapOps[Long, V, Map, LongMap[V]]
+    with StrictOptimizedIterableOps[(Long, V), Iterable, LongMap[V]]
+    with Serializable
+{
+  import LongMap._
+
+  def this() = this(LongMap.exceptionDefault, 16, true)
+
+  def clear(): Unit = { keysIterator() foreach -= } // TODO optimize
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, V)]): LongMap[V] = {
+    //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
+    val b = newSpecificBuilder()
+    b.sizeHint(coll)
+    b.addAll(coll)
+    b.result()
+  }
+  protected[this] def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
+  def mapFactory: strawman.collection.MapFactory[Map] = Map
+  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
+
+  /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
+  def this(defaultEntry: Long => V) = this(defaultEntry, 16, true)
+
+  /** Creates a new `LongMap` with an initial buffer of specified size.
+    *
+    *  A LongMap can typically contain half as many elements as its buffer size
+    *  before it requires resizing.
+    */
+  def this(initialBufferSize: Int) = this(LongMap.exceptionDefault, initialBufferSize, true)
+
+  /** Creates a new `LongMap` with specified default values and initial buffer size. */
+  def this(defaultEntry: Long => V,  initialBufferSize: Int) = this(defaultEntry,  initialBufferSize,  true)
+
+  private[this] var mask = 0
+  private[this] var extraKeys: Int = 0
+  private[this] var zeroValue: AnyRef = null
+  private[this] var minValue: AnyRef = null
+  private[this] var _size = 0
+  private[this] var _vacant = 0
+  private[this] var _keys: Array[Long] = null
+  private[this] var _values: Array[AnyRef] = null
+
+  if (initBlank) defaultInitialize(initialBufferSize)
+
+  private[this] def defaultInitialize(n: Int) = {
+    mask =
+      if (n<0) 0x7
+      else (((1 << (32 - java.lang.Integer.numberOfLeadingZeros(n-1))) - 1) & 0x3FFFFFFF) | 0x7
+    _keys = new Array[Long](mask+1)
+    _values = new Array[AnyRef](mask+1)
+  }
+
+  private[collection] def initializeTo(
+                                        m: Int, ek: Int, zv: AnyRef, mv: AnyRef, sz: Int, vc: Int, kz: Array[Long], vz: Array[AnyRef]
+                                      ): Unit = {
+    mask = m; extraKeys = ek; zeroValue = zv; minValue = mv; _size = sz; _vacant = vc; _keys = kz; _values = vz
+  }
+
+  override def size: Int = _size + (extraKeys+1)/2
+  override def empty: LongMap[V] = new LongMap()
+
+  private def imbalanced: Boolean =
+    (_size + _vacant) > 0.5*mask || _vacant > _size
+
+  private def toIndex(k: Long): Int = {
+    // Part of the MurmurHash3 32 bit finalizer
+    val h = ((k ^ (k >>> 32)) & 0xFFFFFFFFL).toInt
+    val x = (h ^ (h >>> 16)) * 0x85EBCA6B
+    (x ^ (x >>> 13)) & mask
+  }
+
+  private def seekEmpty(k: Long): Int = {
+    var e = toIndex(k)
+    var x = 0
+    while (_keys(e) != 0) { x += 1; e = (e + 2*(x+1)*x - 3) & mask }
+    e
+  }
+
+  private def seekEntry(k: Long): Int = {
+    var e = toIndex(k)
+    var x = 0
+    var q = 0L
+    while ({ q = _keys(e); if (q==k) return e; q != 0}) { x += 1; e = (e + 2*(x+1)*x - 3) & mask }
+    e | MissingBit
+  }
+
+  private def seekEntryOrOpen(k: Long): Int = {
+    var e = toIndex(k)
+    var x = 0
+    var q = 0L
+    while ({ q = _keys(e); if (q==k) return e; q+q != 0}) {
+      x += 1
+      e = (e + 2*(x+1)*x - 3) & mask
+    }
+    if (q == 0) return e | MissingBit
+    val o = e | MissVacant
+    while ({ q = _keys(e); if (q==k) return e; q != 0}) {
+      x += 1
+      e = (e + 2*(x+1)*x - 3) & mask
+    }
+    o
+  }
+
+  override def contains(key: Long): Boolean = {
+    if (key == -key) (((key>>>63).toInt+1) & extraKeys) != 0
+    else seekEntry(key) >= 0
+  }
+
+  override def get(key: Long): Option[V] = {
+    if (key == -key) {
+      if ((((key>>>63).toInt+1) & extraKeys) == 0) None
+      else if (key == 0) Some(zeroValue.asInstanceOf[V])
+      else Some(minValue.asInstanceOf[V])
+    }
+    else {
+      val i = seekEntry(key)
+      if (i < 0) None else Some(_values(i).asInstanceOf[V])
+    }
+  }
+
+  override def getOrElse[V1 >: V](key: Long, default: => V1): V1 = {
+    if (key == -key) {
+      if ((((key>>>63).toInt+1) & extraKeys) == 0) default
+      else if (key == 0) zeroValue.asInstanceOf[V1]
+      else minValue.asInstanceOf[V1]
+    }
+    else {
+      val i = seekEntry(key)
+      if (i < 0) default else _values(i).asInstanceOf[V1]
+    }
+  }
+
+  override def getOrElseUpdate(key: Long, defaultValue: => V): V = {
+    if (key == -key) {
+      val kbits = (key>>>63).toInt + 1
+      if ((kbits & extraKeys) == 0) {
+        val value = defaultValue
+        extraKeys |= kbits
+        if (key == 0) zeroValue = value.asInstanceOf[AnyRef]
+        else minValue = value.asInstanceOf[AnyRef]
+        value
+      }
+      else if (key == 0) zeroValue.asInstanceOf[V]
+      else minValue.asInstanceOf[V]
+    }
+    else {
+      var i = seekEntryOrOpen(key)
+      if (i < 0) {
+        // It is possible that the default value computation was side-effecting
+        // Our hash table may have resized or even contain what we want now
+        // (but if it does, we'll replace it)
+        val value = {
+          val ok = _keys
+          val ans = defaultValue
+          if (ok ne _keys) {
+            i = seekEntryOrOpen(key)
+            if (i >= 0) _size -= 1
+          }
+          ans
+        }
+        _size += 1
+        val j = i & IndexMask
+        _keys(j) = key
+        _values(j) = value.asInstanceOf[AnyRef]
+        if ((i & VacantBit) != 0) _vacant -= 1
+        else if (imbalanced) repack()
+        value
+      }
+      else _values(i).asInstanceOf[V]
+    }
+  }
+
+  /** Retrieves the value associated with a key, or the default for that type if none exists
+    *  (null for AnyRef, 0 for floats and integers).
+    *
+    *  Note: this is the fastest way to retrieve a value that may or
+    *  may not exist, if the default null/zero is acceptable.  For key/value
+    *  pairs that do exist,  `apply` (i.e. `map(key)`) is equally fast.
+    */
+  def getOrNull(key: Long): V = {
+    if (key == -key) {
+      if ((((key>>>63).toInt+1) & extraKeys) == 0) null.asInstanceOf[V]
+      else if (key == 0) zeroValue.asInstanceOf[V]
+      else minValue.asInstanceOf[V]
+    }
+    else {
+      val i = seekEntry(key)
+      if (i < 0) null.asInstanceOf[V] else _values(i).asInstanceOf[V]
+    }
+  }
+
+  /** Retrieves the value associated with a key.
+    *  If the key does not exist in the map, the `defaultEntry` for that key
+    *  will be returned instead.
+    */
+  override def apply(key: Long): V = {
+    if (key == -key) {
+      if ((((key>>>63).toInt+1) & extraKeys) == 0) defaultEntry(key)
+      else if (key == 0) zeroValue.asInstanceOf[V]
+      else minValue.asInstanceOf[V]
+    }
+    else {
+      val i = seekEntry(key)
+      if (i < 0) defaultEntry(key) else _values(i).asInstanceOf[V]
+    }
+  }
+
+  /** The user-supplied default value for the key.  Throws an exception
+    *  if no other default behavior was specified.
+    */
+  override def default(key: Long) = defaultEntry(key)
+
+  private def repack(newMask: Int): Unit = {
+    val ok = _keys
+    val ov = _values
+    mask = newMask
+    _keys = new Array[Long](mask+1)
+    _values = new Array[AnyRef](mask+1)
+    _vacant = 0
+    var i = 0
+    while (i < ok.length) {
+      val k = ok(i)
+      if (k != -k) {
+        val j = seekEmpty(k)
+        _keys(j) = k
+        _values(j) = ov(i)
+      }
+      i += 1
+    }
+  }
+
+  /** Repacks the contents of this `LongMap` for maximum efficiency of lookup.
+    *
+    *  For maps that undergo a complex creation process with both addition and
+    *  removal of keys, and then are used heavily with no further removal of
+    *  elements, calling `repack` after the end of the creation can result in
+    *  improved performance.  Repacking takes time proportional to the number
+    *  of entries in the map.
+    */
+  def repack(): Unit = {
+    var m = mask
+    if (_size + _vacant >= 0.5*mask && !(_vacant > 0.2*mask)) m = ((m << 1) + 1) & IndexMask
+    while (m > 8 && 8*_size < m) m = m >>> 1
+    repack(m)
+  }
+
+  override def put(key: Long, value: V): Option[V] = {
+    if (key == -key) {
+      if (key == 0) {
+        val ans = if ((extraKeys&1) == 1) Some(zeroValue.asInstanceOf[V]) else None
+        zeroValue = value.asInstanceOf[AnyRef]
+        extraKeys |= 1
+        ans
+      }
+      else {
+        val ans = if ((extraKeys&2) == 1) Some(minValue.asInstanceOf[V]) else None
+        minValue = value.asInstanceOf[AnyRef]
+        extraKeys |= 2
+        ans
+      }
+    }
+    else {
+      val i = seekEntryOrOpen(key)
+      if (i < 0) {
+        val j = i & IndexMask
+        _keys(j) = key
+        _values(j) = value.asInstanceOf[AnyRef]
+        _size += 1
+        if ((i & VacantBit) != 0) _vacant -= 1
+        else if (imbalanced) repack()
+        None
+      }
+      else {
+        val ans = Some(_values(i).asInstanceOf[V])
+        _keys(i) = key
+        _values(i) = value.asInstanceOf[AnyRef]
+        ans
+      }
+    }
+  }
+
+  /** Updates the map to include a new key-value pair.
+    *
+    *  This is the fastest way to add an entry to a `LongMap`.
+    */
+  override def update(key: Long, value: V): Unit = {
+    if (key == -key) {
+      if (key == 0) {
+        zeroValue = value.asInstanceOf[AnyRef]
+        extraKeys |= 1
+      }
+      else {
+        minValue = value.asInstanceOf[AnyRef]
+        extraKeys |= 2
+      }
+    }
+    else {
+      val i = seekEntryOrOpen(key)
+      if (i < 0) {
+        val j = i & IndexMask
+        _keys(j) = key
+        _values(j) = value.asInstanceOf[AnyRef]
+        _size += 1
+        if ((i & VacantBit) != 0) _vacant -= 1
+        else if (imbalanced) repack()
+      }
+      else {
+        _keys(i) = key
+        _values(i) = value.asInstanceOf[AnyRef]
+      }
+    }
+  }
+
+  /** Adds a new key/value pair to this map and returns the map. */
+  def +=(key: Long, value: V): this.type = { update(key, value); this }
+
+  override def add(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
+
+  def subtract(key: Long): this.type = {
+    if (key == -key) {
+      if (key == 0L) {
+        extraKeys &= 0x2
+        zeroValue = null
+      }
+      else {
+        extraKeys &= 0x1
+        minValue = null
+      }
+    }
+    else {
+      val i = seekEntry(key)
+      if (i >= 0) {
+        _size -= 1
+        _vacant += 1
+        _keys(i) = Long.MinValue
+        _values(i) = null
+      }
+    }
+    this
+  }
+
+  def iterator(): Iterator[(Long, V)] = new Iterator[(Long, V)] {
+    private[this] val kz = _keys
+    private[this] val vz = _values
+
+    private[this] var nextPair: (Long, V) =
+      if (extraKeys==0) null
+      else if ((extraKeys&1)==1) (0L, zeroValue.asInstanceOf[V])
+      else (Long.MinValue, minValue.asInstanceOf[V])
+
+    private[this] var anotherPair: (Long, V) =
+      if (extraKeys==3) (Long.MinValue, minValue.asInstanceOf[V])
+      else null
+
+    private[this] var index = 0
+
+    def hasNext: Boolean = nextPair != null || (index < kz.length && {
+      var q = kz(index)
+      while (q == -q) {
+        index += 1
+        if (index >= kz.length) return false
+        q = kz(index)
+      }
+      nextPair = (kz(index), vz(index).asInstanceOf[V])
+      index += 1
+      true
+    })
+    def next() = {
+      if (nextPair == null && !hasNext) throw new NoSuchElementException("next")
+      val ans = nextPair
+      if (anotherPair != null) {
+        nextPair = anotherPair
+        anotherPair = null
+      }
+      else nextPair = null
+      ans
+    }
+  }
+
+  override def foreach[U](f: ((Long,V)) => U): Unit = {
+    if ((extraKeys & 1) == 1) f((0L, zeroValue.asInstanceOf[V]))
+    if ((extraKeys & 2) == 2) f((Long.MinValue, minValue.asInstanceOf[V]))
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        f((k, _values(i).asInstanceOf[V]))
+      }
+      i += 1
+    }
+  }
+
+  override def clone(): LongMap[V] = {
+    val kz = java.util.Arrays.copyOf(_keys, _keys.length)
+    val vz = java.util.Arrays.copyOf(_values,  _values.length)
+    val lm = new LongMap[V](defaultEntry, 1, false)
+    lm.initializeTo(mask, extraKeys, zeroValue, minValue, _size, _vacant, kz,  vz)
+    lm
+  }
+
+  /*
+  override def +[V1 >: V](kv: (Long, V1)): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    lm += kv
+    lm
+  }
+  */
+
+  override def concat[V1 >: V](xs: strawman.collection.Iterable[(Long, V1)]): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    xs.foreach(kv => lm += kv)
+    lm
+  }
+
+  @deprecated("Use LongMap.from(m).add(k,v) instead of m.updated(k, v)", "2.13.0")
+  def updated[V1 >: V](key: Long, value: V1): LongMap[V1] = {
+    val lm = clone().asInstanceOf[LongMap[V1]]
+    lm += (key, value)
+    lm
+  }
+
+  /** Applies a function to all keys of this map. */
+  def foreachKey[A](f: Long => A): Unit = {
+    if ((extraKeys & 1) == 1) f(0L)
+    if ((extraKeys & 2) == 2) f(Long.MinValue)
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        f(k)
+      }
+      i += 1
+    }
+  }
+
+  /** Applies a function to all values of this map. */
+  def foreachValue[A](f: V => A): Unit = {
+    if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V])
+    if ((extraKeys & 2) == 2) f(minValue.asInstanceOf[V])
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        f(_values(i).asInstanceOf[V])
+      }
+      i += 1
+    }
+  }
+
+  /** Creates a new `LongMap` with different values.
+    *  Unlike `mapValues`, this method generates a new
+    *  collection immediately.
+    */
+  def mapValuesNow[V1](f: V => V1): LongMap[V1] = {
+    val zv = if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef] else null
+    val mv = if ((extraKeys & 2) == 2) f(minValue.asInstanceOf[V]).asInstanceOf[AnyRef] else null
+    val lm = new LongMap[V1](LongMap.exceptionDefault,  1,  false)
+    val kz = java.util.Arrays.copyOf(_keys, _keys.length)
+    val vz = new Array[AnyRef](_values.length)
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        vz(i) = f(_values(i).asInstanceOf[V]).asInstanceOf[AnyRef]
+      }
+      i += 1
+    }
+    lm.initializeTo(mask, extraKeys, zv, mv, _size, _vacant, kz, vz)
+    lm
+  }
+
+  /** Applies a transformation function to all values stored in this map.
+    *  Note: the default, if any,  is not transformed.
+    */
+  def transformValues(f: V => V): this.type = {
+    if ((extraKeys & 1) == 1) zeroValue = f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef]
+    if ((extraKeys & 2) == 2) minValue = f(minValue.asInstanceOf[V]).asInstanceOf[AnyRef]
+    var i,j = 0
+    while (i < _keys.length & j < _size) {
+      val k = _keys(i)
+      if (k != -k) {
+        j += 1
+        _values(i) = f(_values(i).asInstanceOf[V]).asInstanceOf[AnyRef]
+      }
+      i += 1
+    }
+    this
+  }
+}
+
+object LongMap {
+  private final val IndexMask  = 0x3FFFFFFF
+  private final val MissingBit = 0x80000000
+  private final val VacantBit  = 0x40000000
+  private final val MissVacant = 0xC0000000
+
+  private val exceptionDefault: Long => Nothing = (k: Long) => throw new NoSuchElementException(k.toString)
+
+  /*
+  implicit def canBuildFrom[V, U]: CanBuildFrom[LongMap[V], (Long, U), LongMap[U]] =
+    new CanBuildFrom[LongMap[V], (Long, U), LongMap[U]] {
+      def apply(from: LongMap[V]): LongMapBuilder[U] = apply()
+      def apply(): LongMapBuilder[U] = new LongMapBuilder[U]
+    }
+    */
+
+  /** A builder for instances of `LongMap`.
+    *
+    *  This builder can be reused to create multiple instances.
+    */
+  final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
+    private[collection] var elems: LongMap[V] = new LongMap[V]
+    override def add(entry: (Long, V)): this.type = {
+      elems += entry
+      this
+    }
+    def clear(): Unit = elems = new LongMap[V]
+    def result(): LongMap[V] = elems
+  }
+
+  /** Creates a new `LongMap` with zero or more key/value pairs. */
+  def apply[V](elems: (Long, V)*): LongMap[V] = buildFromIterableOnce(elems.toStrawman)
+
+  private def buildFromIterableOnce[V](elems: IterableOnce[(Long, V)]): LongMap[V] = {
+    var sz = elems.knownSize
+    if(sz < 0) sz = 4
+    val lm = new LongMap[V](sz * 2)
+    elems.foreach{ case (k,v) => lm(k) = v }
+    if (lm.size < (sz>>3)) lm.repack()
+    lm
+  }
+
+  /** Creates a new empty `LongMap`. */
+  def empty[V]: LongMap[V] = new LongMap[V]
+
+  /** Creates a new empty `LongMap` with the supplied default */
+  def withDefault[V](default: Long => V): LongMap[V] = new LongMap[V](default)
+
+  /** Creates a new `LongMap` from an existing source collection. A source collection
+    * which is already a `LongMap` gets cloned.
+    *
+    * @param source Source collection
+    * @tparam A the type of the collection’s elements
+    * @return a new `LongMap` with the elements of `source`
+    */
+  def from[V](source: IterableOnce[(Long, V)]): LongMap[V] = source match {
+    case source: LongMap[_] => source.clone().asInstanceOf[LongMap[V]]
+    case _ => buildFromIterableOnce(source)
+  }
+
+  /** Creates a new `LongMap` from arrays of keys and values.
+    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+    */
+  def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
+    val sz = math.min(keys.length, values.length)
+    val lm = new LongMap[V](sz * 2)
+    var i = 0
+    while (i < sz) { lm(keys(i)) = values(i); i += 1 }
+    if (lm.size < (sz>>3)) lm.repack()
+    lm
+  }
+
+  /** Creates a new `LongMap` from keys and values.
+    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+    */
+  def fromZip[V](keys: strawman.collection.Iterable[Long], values: strawman.collection.Iterable[V]): LongMap[V] = {
+    val sz = math.min(keys.size, values.size)
+    val lm = new LongMap[V](sz * 2)
+    val ki = keys.iterator()
+    val vi = values.iterator()
+    while (ki.hasNext && vi.hasNext) lm(ki.next()) = vi.next()
+    if (lm.size < (sz >> 3)) lm.repack()
+    lm
+  }
+}

--- a/collections/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Map.scala
@@ -53,6 +53,7 @@ trait Map[K, V]
 trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C]
+    with Growable[(K, V)]
     with Shrinkable[K] {
 
   def iterableFactory = Iterable
@@ -153,6 +154,14 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
       coll -= elem
     this
   }
+
+  /** Retains only those mappings for which the predicate
+    *  `p` returns `true`.
+    *
+    * @param p  The test predicate
+    */
+  @deprecated("Use .filterInPlace instead of .retain", "2.13.0")
+  @`inline` final def retain(p: (K, V) => Boolean): this.type = filterInPlace(p.tupled)
 }
 
 /**

--- a/collections/src/main/scala/strawman/collection/mutable/WeakHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WeakHashMap.scala
@@ -1,0 +1,55 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package mutable
+
+import generic._
+import convert.Wrappers._
+
+/** A hash map with references to entries which are weakly reachable. Entries are
+ *  removed from this map when the key is no longer (strongly) referenced. This class wraps
+ *  `java.util.WeakHashMap`.
+ *
+ *  @tparam A      type of keys contained in this map
+ *  @tparam B      type of values associated with the keys
+ *
+ *  @since 2.8
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak_hash_maps "Scala's Collection Library overview"]]
+ *  section on `Weak Hash Maps` for more information.
+ *
+ *  @define Coll `WeakHashMap`
+ *  @define coll weak hash map
+ *  @define thatinfo the class of the returned collection. In the standard library configuration,
+ *    `That` is always `WeakHashMap[A, B]` if the elements contained in the resulting collection are
+ *    pairs of type `(A, B)`. This is because an implicit of type `CanBuildFrom[WeakHashMap, (A, B), WeakHashMap[A, B]]`
+ *    is defined in object `WeakHashMap`. Otherwise, `That` resolves to the most specific type that doesn't have
+ *    to contain pairs of type `(A, B)`, which is `Iterable`.
+ *  @define bfinfo an implicit value of class `CanBuildFrom` which determines the
+ *    result class `That` from the current representation type `Repr`
+ *    and the new element type `B`. This is usually the `canBuildFrom` value
+ *    defined in object `WeakHashMap`.
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+class WeakHashMap[A, B] extends JMapWrapper[A, B](new java.util.WeakHashMap)
+			   with JMapWrapperLike[A, B, WeakHashMap[A, B]] {
+  override def empty = new WeakHashMap[A, B]
+}
+
+/** $factoryInfo
+ *  @define Coll `WeakHashMap`
+ *  @define coll weak hash map
+ */
+object WeakHashMap extends MapFactory[WeakHashMap] {
+  def empty[K, V]: WeakHashMap[K,V] = new WeakHashMap[K, V]
+  def from[K, V](it: collection.IterableOnce[(K, V)]): WeakHashMap[K,V] = Growable.from(empty[K, V], it)
+  def newBuilder[K, V](): Builder[(K, V), WeakHashMap[K,V]] = new GrowableBuilder(WeakHashMap.empty[K, V])
+}
+

--- a/test/junit/src/test/scala/strawman/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/AnyRefMapTest.scala
@@ -1,0 +1,16 @@
+package strawman.collection.mutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+
+@RunWith(classOf[JUnit4])
+class AnyRefMapTest {
+
+  @Test def testAnyRefMapCopy: Unit = {
+    val m1 = AnyRefMap("a" -> "b")
+    val m2: AnyRefMap[String, AnyRef] = AnyRefMap.from(m1)
+    assertEquals(m1, m2)
+  }
+}


### PR DESCRIPTION
This is another big chunk of my scala-integration branch that contains some of the more exotic `Map` types from Scala 2.12. They are all used in the compiler codebase.