### PR TITLE
A port of mutable.Queue from the old collections

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
@@ -1,0 +1,263 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package mutable
+
+import scala.{Int, Unit, Serializable, Option, NoSuchElementException, IndexOutOfBoundsException, Some, None, Boolean}
+import scala.Predef.require
+import scala.annotation.tailrec
+
+/** A linked list implementation which is used internally in MutableList and Queue.
+  */
+private[mutable] final class LinkedList[A]() extends AbstractSeq[A]
+  with LinearSeq[A]
+  with LinearSeqOps[A, LinkedList, LinkedList[A]]
+  with Growable[A]
+  with Shrinkable[A]
+  with Serializable { self =>
+
+  /** Creates a new list. If the parameter next is null, the result is an empty list. Otherwise, the result is
+    * a list with elem at the head, followed by the contents of next.
+    *
+    * Note that next is part of the new list, as opposed to the +: operator,
+    * which makes a new copy of the original list.
+    *
+    * @example
+    * {{{
+    *     scala> val m = LinkedList(1)
+    *     m: scala.collection.mutable.LinkedList[Int] = LinkedList(1)
+    *
+    *     scala> val n = new LinkedList[Int](2, m)
+    *     n: scala.collection.mutable.LinkedList[Int] = LinkedList(2, 1)
+    * }}}
+    */
+  def this(elem: A, next: LinkedList[A]) = {
+    this()
+    if (next != null) {
+      this.elem = elem
+      this.next = next
+    }
+  }
+
+  var elem: A = _
+  var next: LinkedList[A] = this
+
+  def iterableFactory: SeqFactory[LinkedList] = LinkedList
+  protected[this] def newSpecificBuilder(): Builder[A, LinkedList[A]] = LinkedList.newBuilder()
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): LinkedList[A] = LinkedList.from(coll)
+
+  def clear(): Unit = {
+    elem = null.asInstanceOf[A]
+    next = this
+  }
+
+  def add(elem: A): this.type = { append(LinkedList(elem)); this }
+
+  // Members declared in strawman.collection.mutable.IterableOps
+  def filterInPlace(p: A => Boolean): this.type = {
+    var these = this
+    while (these.nonEmpty) {
+      if(!p(these.elem)) {
+        these.elem = these.next.elem
+        these.next = these.next.next
+      } else these = these.next
+    }
+    this
+  }
+
+  def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
+    val l = flatMap(f)
+    this.elem = l.elem
+    this.next = l.next
+    this
+  }
+
+  def mapInPlace(f: A => A): this.type = {
+    var these = this
+    while (these.nonEmpty) {
+      these.elem = f(these.elem)
+      these = these.next
+    }
+    this
+  }
+
+  def insert(idx: Int,elem: A): Unit = atLocation(idx)(_.insert(LinkedList(elem)))
+
+  def insertAll(idx: Int, elems: IterableOnce[A]): Unit = atLocation(idx)(_.insert(LinkedList.from(elems)))
+
+  def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
+    remove(from, replaced)
+    insertAll(from, patch)
+    this
+  }
+
+  def remove(idx: Int, count: Int): Unit = {
+    var i = 0
+    while(i < count) {
+      remove(idx)
+      i += 1
+    }
+  }
+
+  def remove(idx: Int): A = atLocation(idx) { l =>
+    val e = l.elem
+    l.elem = l.next.elem
+    l.next = l.next.next
+    e
+  }
+
+  def subtract(elem: A): this.type = {
+    var these = this
+    while (these.nonEmpty) {
+      if(these.elem == elem) {
+        these.elem = these.next.elem
+        these.next = these.next.next
+        return this
+      }
+      these = these.next
+    }
+    this
+  }
+
+  override def isEmpty = next eq this
+
+  /** Determines the length of this $coll by traversing and counting every
+    * node.
+    */
+  override def length: Int = size0(this, 0)
+
+  @tailrec private def size0(elem: LinkedList[A], acc: Int): Int =
+    if (elem.isEmpty) acc else size0(elem.next, acc + 1)
+
+  override def head: A =
+    if (isEmpty) throw new NoSuchElementException
+    else elem
+
+  override def tail: LinkedList[A] = {
+    require(nonEmpty, "tail of empty list")
+    next
+  }
+
+  /** If `this` is empty then it does nothing and returns `that`. Otherwise, appends `that` to `this`. The append
+    * requires a full traversal of `this`.
+    *
+    * Examples:
+    *
+    * {{{
+    *      scala> val a = LinkedList(1, 2)
+    *      a: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2)
+    *
+    *      scala> val b = LinkedList(1, 2)
+    *      b: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2)
+    *
+    *      scala> a.append(b)
+    *      res0: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2, 1, 2)
+    *
+    *      scala> println(a)
+    *      LinkedList(1, 2, 1, 2)
+    * }}}
+    *
+    * {{{
+    *    scala> val a = new LinkedList[Int]()
+    *    a: scala.collection.mutable.LinkedList[Int] = LinkedList()
+    *
+    *    scala> val b = LinkedList(1, 2)
+    *    b: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2)
+    *
+    *    scala> val c = a.append(b)
+    *    c: scala.collection.mutable.LinkedList[Int] = LinkedList(1, 2)
+    *
+    *    scala> println(a)
+    *    LinkedList()
+    * }}}
+    *
+    *  @return the list after append (this is the list itself if nonempty,
+    *  or list `that` if list this is empty. )
+    */
+  def append(that: LinkedList[A]): LinkedList[A] = {
+    @tailrec
+    def loop(x: LinkedList[A]): Unit = {
+      if (x.next.isEmpty) x.next = that
+      else loop(x.next)
+    }
+    if (isEmpty) that
+    else { loop(this); this }
+  }
+
+  /** Insert linked list `that` at current position of this linked list
+    *  @note this linked list must not be empty
+    */
+  def insert(that: LinkedList[A]): Unit = {
+    require(nonEmpty, "insert into empty list")
+    if (that.nonEmpty) {
+      that append next
+      next = that
+    }
+  }
+
+  override def drop(n: Int): LinkedList[A] = {
+    var i = 0
+    var these: LinkedList[A] = this
+    while (i < n && !these.isEmpty) {
+      these = these.next
+      i += 1
+    }
+    these
+  }
+
+  private def atLocation[T](n: Int)(f: LinkedList[A] => T): T = {
+    val loc = drop(n)
+    if (loc.nonEmpty) f(loc)
+    else throw new IndexOutOfBoundsException(n.toString)
+  }
+
+  override def apply(n: Int): A   = atLocation(n)(_.elem)
+  def update(n: Int, x: A): Unit  = atLocation(n)(_.elem = x)
+
+  def get(n: Int): Option[A] = {
+    val loc = drop(n)
+    if (loc.nonEmpty) Some(loc.elem)
+    else None
+  }
+
+  override def iterator(): Iterator[A] = new AbstractIterator[A] {
+    var elems = self
+    def hasNext = elems.nonEmpty
+    def next() = {
+      val res = elems.elem
+      elems = elems.next
+      res
+    }
+  }
+
+  override def foreach[U](f: A => U): Unit = {
+    var these = this
+    while (these.nonEmpty) {
+      f(these.elem)
+      these = these.next
+    }
+  }
+
+  /** Return a clone of this list.
+    *
+    *  @return a `LinkedList` with the same elements.
+    */
+  override def clone(): LinkedList[A] = {
+    val bf = newSpecificBuilder()
+    bf ++= this
+    bf.result()
+  }
+}
+
+private[mutable] object LinkedList extends StrictOptimizedSeqFactory[LinkedList] {
+  def from[A](coll: IterableOnce[A]): LinkedList[A] = new LinkedList[A] ++= coll
+  def newBuilder[A](): Builder[A, LinkedList[A]] =
+    (new MutableList) mapResult ((l: MutableList[A]) => l.toLinkedList)
+  def empty[A]: LinkedList[A] = new LinkedList[A]
+}

--- a/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
@@ -1,0 +1,257 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package mutable
+
+import scala.{Unit, Int, Serializable, Option, NoSuchElementException, Boolean, IndexOutOfBoundsException}
+import scala.Predef.require
+import immutable.List
+
+/**
+  *  This class is used internally to represent mutable lists. It is the
+  *  basis for the implementation of the class `Queue`.
+  *
+  *  @author  Matthias Zenger
+  *  @author  Martin Odersky
+  *  @version 2.8
+  *  @since   1
+  *  @define Coll `mutable.MutableList`
+  *  @define coll mutable list
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
+  *  section on `Mutable Lists` for more information.
+  */
+private[mutable] class MutableList[A]
+  extends AbstractSeq[A]
+    with LinearSeq[A]
+    with StrictOptimizedSeqOps[A, MutableList, MutableList[A]]
+    with LinearSeqOps[A, MutableList, MutableList[A]]
+    with Builder[A, MutableList[A]]
+    with Serializable
+{
+  protected var first0: LinkedList[A] = new LinkedList[A]
+  protected var last0: LinkedList[A] = first0
+  protected var len: Int = 0
+
+  def iterableFactory: SeqFactory[MutableList] = MutableList
+  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): MutableList[A] = iterableFactory.from(coll)
+  protected[this] def newSpecificBuilder(): Builder[A, MutableList[A]] = iterableFactory.newBuilder()
+
+  def filterInPlace(p: A => Boolean): this.type = {
+    var these = first0
+    while (these.nonEmpty) {
+      if(!p(these.elem)) {
+        these.elem = these.next.elem
+        if(these.next eq last0) last0 = these
+        these.next = these.next.next
+        len -= 1
+      } else these = these.next
+    }
+    this
+  }
+
+  def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
+    val l = flatMap(f)
+    this.first0 = l.first0
+    this.last0 = l.last0
+    this.len = l.len
+    this
+  }
+
+  def mapInPlace(f: A => A): this.type = { first0.mapInPlace(f); this }
+
+  def insert(idx: Int, elem: A): Unit = insertAll(idx, LinkedList(elem))
+
+  def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
+    val loc = first0.drop(idx)
+    if(loc.isEmpty) throw new IndexOutOfBoundsException(idx.toString)
+    val it = elems.iterator()
+    while(it.hasNext) {
+      val elem = it.next()
+      val l = LinkedList(elem)
+      if(last0 eq loc.next) last0 = l
+      loc.next = l
+      len += 1
+    }
+  }
+
+  def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
+    remove(from, replaced)
+    insertAll(from, patch)
+    this
+  }
+
+  def remove(idx: Int, count: Int): Unit = {
+    var loc = first0.drop(idx)
+    var i = 0
+    while(i < count) {
+      if(loc.isEmpty) throw new IndexOutOfBoundsException(idx.toString)
+      loc.elem = loc.next.elem
+      if(last0 == loc.next) last0 = loc.next.next
+      loc.next = loc.next.next
+      len -= 1
+      loc = loc.next
+    }
+  }
+
+  def remove(idx: Int): A = {
+    val loc = first0.drop(idx)
+    if(loc.isEmpty) throw new IndexOutOfBoundsException(idx.toString)
+    val e = loc.elem
+    loc.elem = loc.next.elem
+    if(last0 eq loc.next) last0 = loc.next.next
+    loc.next = loc.next.next
+    len -= 1
+    e
+  }
+
+  def subtract(elem: A): this.type = {
+    var these = first0
+    while (these.nonEmpty) {
+      if(these.elem == elem) {
+        these.elem = these.next.elem
+        if(last0 eq these.next) last0 = these.next.next
+        these.next = these.next.next
+        len -= 1
+        return this
+      }
+      these = these.next
+    }
+    this
+  }
+
+  def toQueue = new Queue(first0, last0, len)
+
+  /** Is the list empty?
+    */
+  override def isEmpty = len == 0
+
+  /** Returns the first element in this list
+    */
+  override def head: A = if (nonEmpty) first0.head else throw new NoSuchElementException
+
+  /** Returns the rest of this list
+    */
+  override def tail: MutableList[A] = {
+    val tl = new MutableList[A]
+    tailImpl(tl)
+    tl
+  }
+
+  protected final def tailImpl(tl: MutableList[A]): Unit = {
+    require(nonEmpty, "tail of empty list")
+    tl.first0 = first0.tail
+    tl.len = len - 1
+    tl.last0 = if (tl.len == 0) tl.first0 else last0
+  }
+
+  /** Prepends a single element to this list. This operation takes constant
+    *  time.
+    *  @param elem  the element to prepend.
+    *  @return   this $coll.
+    */
+  def +=: (elem: A): this.type = { prependElem(elem); this }
+
+  /** Returns the length of this list.
+    */
+  override def length: Int = len
+
+  /** Returns the `n`-th element of this list.
+    *  @throws IndexOutOfBoundsException if index does not exist.
+    */
+  override def apply(n: Int): A = first0.apply(n)
+
+  /** Updates the `n`-th element of this list to a new value.
+    *  @throws IndexOutOfBoundsException if index does not exist.
+    */
+  def update(n: Int, x: A): Unit = first0.update(n, x)
+
+  /** Returns the `n`-th element of this list or `None`
+    *  if index does not exist.
+    */
+  def get(n: Int): Option[A] = first0.get(n)
+
+  protected def prependElem(elem: A): Unit = {
+    first0 = new LinkedList[A](elem, first0)
+    if (len == 0) last0 = first0
+    len = len + 1
+  }
+
+  protected def appendElem(elem: A): Unit = {
+    if (len == 0) {
+      prependElem(elem)
+    } else {
+      last0.next = new LinkedList[A]
+      last0 = last0.next
+      last0.elem = elem
+      last0.next = new LinkedList[A] // for performance, use sentinel `object` instead?
+      len = len + 1
+    }
+  }
+
+  /** Returns an iterator over up to `length` elements of this list.
+    */
+  override def iterator(): Iterator[A] = if (isEmpty) Iterator.empty else
+    new AbstractIterator[A] {
+      var elems   = first0
+      var count   = len
+      def hasNext = count > 0 && elems.nonEmpty
+      def next()  = {
+        if (!hasNext) throw new NoSuchElementException
+        count = count - 1
+        val e = elems.elem
+        elems = if (count == 0) null else elems.next
+        e
+      }
+    }
+
+  override def last = {
+    if (isEmpty) throw new NoSuchElementException("MutableList.empty.last")
+    last0.elem
+  }
+
+  /** Returns an instance of [[scala.List]] containing the same
+    *  sequence of elements.
+    */
+  override def toList: List[A] = first0.toList
+
+  /** Returns the current list of elements as a linked List
+    *  sequence of elements.
+    */
+  private[mutable] def toLinkedList: LinkedList[A] = first0
+
+  /** Appends a single element to this buffer. This takes constant time.
+    *
+    *  @param elem  the element to append.
+    */
+  def add(elem: A): this.type = { appendElem(elem); this }
+
+  def clear(): Unit = {
+    first0 = new LinkedList[A]
+    last0 = first0
+    len = 0
+  }
+
+  def result(): MutableList[A] = this
+
+  override def clone(): MutableList[A]  = {
+    val bf = newSpecificBuilder()
+    bf ++= this
+    bf.result()
+  }
+}
+
+private[mutable] object MutableList extends StrictOptimizedSeqFactory[MutableList] {
+  def newBuilder[A](): Builder[A, MutableList[A]] = new MutableList[A]
+  def empty[A]: MutableList[A] = new MutableList[A]
+  def from[A](source: IterableOnce[A]): MutableList[A] = {
+    val l = new MutableList[A]
+    l ++= source
+    l
+  }
+}

--- a/collections/src/main/scala/strawman/collection/mutable/Queue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Queue.scala
@@ -1,0 +1,208 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+package mutable
+
+import scala.{Int, Boolean, Unit, Option, Some, None, NoSuchElementException, Cloneable, Serializable, deprecated}
+
+/** `Queue` objects implement data structures that allow to
+  *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+  *
+  *  @author  Matthias Zenger
+  *  @author  Martin Odersky
+  *  @version 2.8
+  *  @since   1
+  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#queues "Scala's Collection Library overview"]]
+  *  section on `Queues` for more information.
+  *
+  *  @define Coll `mutable.Queue`
+  *  @define coll mutable queue
+  *  @define orderDependent
+  *  @define orderDependentFold
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+  /*
+extends Buffer[A]
+with SeqOps[A, ListBuffer, ListBuffer[A]]
+with StrictOptimizedSeqOps[A, ListBuffer, ListBuffer[A]]
+with ReusableBuilder[A, immutable.List[A]]
+with Serializable {*/
+
+class Queue[A]
+  extends MutableList[A]
+    with LinearSeqOps[A, Queue, Queue[A]]
+    with StrictOptimizedSeqOps[A, Queue, Queue[A]]
+    with Builder[A, Queue[A]]
+    with Cloneable
+    with Serializable
+{
+  private[mutable] def this(fst: LinkedList[A], lst: LinkedList[A], lng: Int) = {
+    this()
+    first0 = fst
+    last0 = lst
+    len = lng
+  }
+
+  override def iterableFactory: SeqFactory[Queue] = Queue
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): Queue[A] = iterableFactory.from(coll)
+  override protected[this] def newSpecificBuilder(): Builder[A, Queue[A]] = iterableFactory.newBuilder()
+
+  /** Adds all elements to the queue.
+    *
+    *  @param  elems       the elements to add.
+    */
+  def enqueue(elems: A*): Unit = this ++= elems.toStrawman
+
+  /** Returns the first element in the queue, and removes this element
+    *  from the queue.
+    *
+    *  @throws java.util.NoSuchElementException
+    *  @return the first element of the queue.
+    */
+  def dequeue(): A =
+    if (isEmpty)
+      throw new NoSuchElementException("queue empty")
+    else {
+      val res = first0.elem
+      first0 = first0.next
+      decrementLength()
+      res
+    }
+
+  /** Returns the first element in the queue which satisfies the
+    *  given predicate, and removes this element from the queue.
+    *
+    *  @param p   the predicate used for choosing the first element
+    *  @return the first element of the queue for which p yields true
+    */
+  def dequeueFirst(p: A => Boolean): Option[A] =
+    if (isEmpty)
+      None
+    else if (p(first0.elem)) {
+      val res: Option[A] = Some(first0.elem)
+      first0 = first0.next
+      decrementLength()
+      res
+    } else {
+      val optElem = removeFromList(p)
+      if (optElem != None) decrementLength()
+      optElem
+    }
+
+  private def removeFromList(p: A => Boolean): Option[A] = {
+    var leftlst = first0
+    var res: Option[A] = None
+    while (leftlst.next.nonEmpty && !p(leftlst.next.elem)) {
+      leftlst = leftlst.next
+    }
+    if (leftlst.next.nonEmpty) {
+      res = Some(leftlst.next.elem)
+      if (leftlst.next eq last0) last0 = leftlst
+      leftlst.next = leftlst.next.next
+    }
+    res
+  }
+
+  /** Returns all elements in the queue which satisfy the
+    *  given predicate, and removes those elements from the queue.
+    *
+    *  @param p   the predicate used for choosing elements
+    *  @return    a sequence of all elements in the queue for which
+    *             p yields true.
+    */
+  def dequeueAll(p: A => Boolean): Seq[A] = {
+    if (first0.isEmpty)
+      Seq.empty
+    else {
+      val res = new ArrayBuffer[A]
+      while ((first0.nonEmpty) && p(first0.elem)) {
+        res += first0.elem
+        first0 = first0.next
+        decrementLength()
+      }
+      if (first0.isEmpty) res
+      else removeAllFromList(p, res)
+    }
+  }
+
+  private def removeAllFromList(p: A => Boolean, res: ArrayBuffer[A]): ArrayBuffer[A] = {
+    var leftlst = first0
+    while (leftlst.next.nonEmpty) {
+      if (p(leftlst.next.elem)) {
+        res += leftlst.next.elem
+        if (leftlst.next eq last0) last0 = leftlst
+        leftlst.next = leftlst.next.next
+        decrementLength()
+      } else leftlst = leftlst.next
+    }
+    res
+  }
+
+  /** Return the proper suffix of this list which starts with the first element that satisfies `p`.
+    *  That element is unlinked from the list. If no element satisfies `p`, return None.
+    */
+  @deprecated("extractFirst inappropriately exposes implementation details. Use dequeue or dequeueAll.", "2.11.0")
+  def extractFirst(start: LinkedList[A], p: A => Boolean): Option[LinkedList[A]] = {
+    if (isEmpty) None
+    else {
+      var cell = start
+      while ((cell.next.nonEmpty) && !p(cell.next.elem)) {
+        cell = cell.next
+      }
+      if (cell.next.isEmpty)
+        None
+      else {
+        val res: Option[LinkedList[A]] = Some(cell.next)
+        cell.next = cell.next.next
+        decrementLength()
+        res
+      }
+    }
+  }
+
+  /** Returns the first element in the queue, or throws an error if there
+    *  is no element contained in the queue.
+    *
+    *  @return the first element.
+    */
+  def front: A = head
+
+
+  // TODO - Don't override this just for new to create appropriate type....
+  override def tail: Queue[A] = {
+    val tl = new Queue[A]
+    tailImpl(tl)
+    tl
+  }
+
+  override def clone(): Queue[A] = {
+    val bf = newSpecificBuilder()
+    bf ++= this
+    bf.result()
+  }
+
+  override def result(): Queue[A] = this
+
+  private[this] def decrementLength(): Unit = {
+    len -= 1
+    if (len == 0) last0 = first0
+  }
+}
+
+
+object Queue extends StrictOptimizedSeqFactory[Queue] {
+  def newBuilder[A](): Builder[A, Queue[A]] = new Queue[A]
+  def empty[A]: Queue[A] = new Queue[A]
+  def from[A](source: IterableOnce[A]): Queue[A] = {
+    val l = new Queue[A]
+    l ++= source
+    l
+  }
+}


### PR DESCRIPTION
This includes mutable.LinkedList and mutable.MutableList. They were
already deprecated in 2.12 and are now package-private. We should
consider simplifying the implementation of Queue so that they can be
removed entirely in the future.