### PR TITLE
Rename Growable.add to addOne

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ArrayBufferBenchmark.scala
@@ -68,7 +68,7 @@ class ArrayBufferBenchmark {
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys.add(i)
+      ys.addOne(i)
       i += 1
     }
     bh.consume(ys)
@@ -80,7 +80,7 @@ class ArrayBufferBenchmark {
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys.add(i)
+      ys.addOne(i)
       i += 1
       ys = ys.init
     }
@@ -93,7 +93,7 @@ class ArrayBufferBenchmark {
     val ys = xs
     var i = 0L
     while (i < 1000) {
-      if ((i & 1) == 1) ys.add(i)
+      if ((i & 1) == 1) ys.addOne(i)
       else ys.insert(0, i)
       i += 1
     }

--- a/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/mutable/ListBufferBenchmark.scala
@@ -68,7 +68,7 @@ class ListBufferBenchmark {
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys.add(i)
+      ys.addOne(i)
       i += 1
     }
     bh.consume(ys)
@@ -80,7 +80,7 @@ class ListBufferBenchmark {
     var ys = xs
     var i = 0L
     while (i < 1000) {
-      ys.add(i)
+      ys.addOne(i)
       i += 1
       ys = ys.init
     }
@@ -93,7 +93,7 @@ class ListBufferBenchmark {
     val ys = xs
     var i = 0L
     while (i < 1000) {
-      if ((i & 1) == 1) ys.add(i)
+      if ((i & 1) == 1) ys.addOne(i)
       else ys.insert(0, i)
       i += 1
     }

--- a/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
+++ b/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
@@ -866,7 +866,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     inserthc(k, hc, v)
   }
 
-  def add(kv: (K, V)) = {
+  def addOne(kv: (K, V)) = {
     update(kv._1, kv._2)
     this
   }
@@ -876,7 +876,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     removehc(k, null.asInstanceOf[V], hc)
   }
 
-  def subtract(k: K) = {
+  def subtractOne(k: K) = {
     remove(k)
     this
   }

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -94,7 +94,7 @@ private[collection] trait Wrappers {
     def apply(i: Int) = underlying.get(i)
     def update(i: Int, elem: A) = underlying.set(i, elem)
     def prepend(elem: A) = { underlying.subList(0, 0) add elem; this }
-    def add(elem: A): this.type = { underlying add elem; this }
+    def addOne(elem: A): this.type = { underlying add elem; this }
     def insert(idx: Int,elem: A): Unit = underlying.subList(0, idx).add(elem)
     def insertAll(i: Int, elems: IterableOnce[A]) = {
       val ins = underlying.subList(0, i)
@@ -135,7 +135,7 @@ private[collection] trait Wrappers {
     protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
     def iterableFactory = mutable.ArrayBuffer
     protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
-    def subtract(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
+    def subtractOne(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
   }
 
   @SerialVersionUID(1L)
@@ -187,8 +187,8 @@ private[collection] trait Wrappers {
 
     def contains(elem: A): Boolean = underlying.contains(elem)
 
-    def add(elem: A): this.type = { underlying add elem; this }
-    def subtract(elem: A): this.type = { underlying remove elem; this }
+    def addOne(elem: A): this.type = { underlying add elem; this }
+    def subtractOne(elem: A): this.type = { underlying remove elem; this }
 
     //TODO Should Set.remove return the canonical element? There is no efficient way to support this for wrapped Java Sets
     override def remove(elem: A): Option[A] = if(underlying remove elem) Some(elem) else None
@@ -306,8 +306,8 @@ private[collection] trait Wrappers {
         None
     }
 
-    def add(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtract(key: K): this.type = { underlying remove key; this }
+    def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtractOne(key: K): this.type = { underlying remove key; this }
 
     override def put(k: K, v: V): Option[V] = Option(underlying.put(k, v))
 
@@ -415,8 +415,8 @@ private[collection] trait Wrappers {
 
     def get(k: A) = Option(underlying get k)
 
-    def add(kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtract(key: A): this.type = { underlying remove key; this }
+    def addOne(kv: (A, B)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtractOne(key: A): this.type = { underlying remove key; this }
 
     override def put(k: A, v: B): Option[B] = Option(underlying.put(k, v))
 
@@ -445,8 +445,8 @@ private[collection] trait Wrappers {
       if (v != null) Some(v.asInstanceOf[String]) else None
     }
 
-    def add(kv: (String, String)): this.type = { underlying.put(kv._1, kv._2); this }
-    def subtract(key: String): this.type = { underlying remove key; this }
+    def addOne(kv: (String, String)): this.type = { underlying.put(kv._1, kv._2); this }
+    def subtractOne(key: String): this.type = { underlying remove key; this }
 
     override def put(k: String, v: String): Option[String] = {
       val r = underlying.put(k, v)

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -122,7 +122,7 @@ object HashMap extends MapFactory[HashMap] {
 
   def newBuilder[K, V](): Builder[(K, V), HashMap[K, V]] =
     new ImmutableBuilder[(K, V), HashMap[K, V]](empty) {
-      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
   private[collection] abstract class Merger[A, B] {

--- a/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -74,7 +74,7 @@ object HashSet extends IterableFactory[HashSet] {
 
   def newBuilder[A](): Builder[A, HashSet[A]] =
     new ImmutableBuilder[A, HashSet[A]](empty) {
-      def add(elem: A): this.type = { elems = elems + elem; this }
+      def addOne(elem: A): this.type = { elems = elems + elem; this }
     }
 
   private object EmptyHashSet extends HashSet[Any] {

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -77,7 +77,7 @@ object IntMap {
 
   def newBuilder[V](): Builder[(Int, V), IntMap[V]] =
     new ImmutableBuilder[(Int, V), IntMap[V]](empty) {
-      def add(elem: (Int, V)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (Int, V)): this.type = { elems = elems + elem; this }
     }
 }
 
@@ -171,7 +171,7 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
   def iterableFactory: IterableFactoryLike[Iterable] = Iterable
   protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
-      def add(elem: (Int, T)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
     }
   def mapFactory: MapFactory[Map] = Map
   protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)

--- a/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -170,7 +170,7 @@ object ListMap extends MapFactory[ListMap] {
 
   def newBuilder[K, V](): Builder[(K, V), ListMap[K, V]] =
     new ImmutableBuilder[(K, V), ListMap[K, V]](empty) {
-      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -127,7 +127,7 @@ object ListSet extends IterableFactory[ListSet] {
 
   def newBuilder[A](): Builder[A, ListSet[A]] =
     new ImmutableBuilder[A, ListSet[A]](empty) {
-      def add(elem: A): this.type = { elems = elems + elem; this }
+      def addOne(elem: A): this.type = { elems = elems + elem; this }
     }
 }
 

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -157,7 +157,7 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
   def iterableFactory: IterableFactory[Iterable] = Iterable
   protected[this] def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] =
     new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
-      def add(elem: (Long, T)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
     }
   def mapFactory: MapFactory[Map] = Map
   protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)

--- a/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -156,7 +156,7 @@ object TreeMap extends SortedMapFactory[TreeMap] {
 
   def newBuilder[K : Ordering, V](): Builder[(K, V), TreeMap[K, V]] =
     new ImmutableBuilder[(K, V), TreeMap[K, V]](empty) {
-      def add(elem: (K, V)): this.type = { elems = elems + elem; this }
+      def addOne(elem: (K, V)): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -160,7 +160,7 @@ object TreeSet extends SortedIterableFactory[TreeSet] {
 
   def newBuilder[A : Ordering](): Builder[A, TreeSet[A]] =
     new ImmutableBuilder[A, TreeSet[A]](empty) {
-      def add(elem: A): this.type = { elems = elems + elem; this }
+      def addOne(elem: A): this.type = { elems = elems + elem; this }
     }
 
 }

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -635,7 +635,7 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
   private var blockIndex = 0
   private var lo = 0
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     if (lo >= display0.length) {
       val newBlockIndex = blockIndex + 32
       gotoNextBlockStartWritable(newBlockIndex, blockIndex ^ newBlockIndex)

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -284,11 +284,11 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   /** Adds a new key/value pair to this map and returns the map. */
-  def add(key: K, value: V): this.type = { update(key, value); this }
+  def addOne(key: K, value: V): this.type = { update(key, value); this }
 
-  def add(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
+  def addOne(kv: (K, V)): this.type = { update(kv._1, kv._2); this }
 
-  def subtract(key: K): this.type = {
+  def subtractOne(key: K): this.type = {
     val i = seekEntry(hashOf(key), key)
     if (i >= 0) {
       _size -= 1
@@ -441,7 +441,7 @@ object AnyRefMap {
    */
   final class AnyRefMapBuilder[K <: AnyRef, V] extends ReusableBuilder[(K, V), AnyRefMap[K, V]] {
     private[collection] var elems: AnyRefMap[K, V] = new AnyRefMap[K, V]
-    def add(entry: (K, V)): this.type = {
+    def addOne(entry: (K, V)): this.type = {
       elems += entry
       this
     }

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -78,14 +78,14 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   def clear(): Unit =
     end = 0
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     ensureSize(end + 1)
     this(end) = elem
     end += 1
     this
   }
 
-  def subtract(elem: A): this.type = {
+  def subtractOne(elem: A): this.type = {
     val i = indexOf(elem)
     if (i != -1) remove(i)
     this

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
@@ -80,7 +80,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: T): this.type = {
+    def addOne(elem: T): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -129,7 +129,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Byte): this.type = {
+    def addOne(elem: Byte): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -178,7 +178,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Short): this.type = {
+    def addOne(elem: Short): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -227,7 +227,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Char): this.type = {
+    def addOne(elem: Char): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -276,7 +276,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Int): this.type = {
+    def addOne(elem: Int): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -325,7 +325,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Long): this.type = {
+    def addOne(elem: Long): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -374,7 +374,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Float): this.type = {
+    def addOne(elem: Float): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -423,7 +423,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Double): this.type = {
+    def addOne(elem: Double): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -472,7 +472,7 @@ object ArrayBuilder {
       capacity = size
     }
 
-    def add(elem: Boolean): this.type = {
+    def addOne(elem: Boolean): this.type = {
       ensureSize(size + 1)
       elems(size) = elem
       size += 1
@@ -508,7 +508,7 @@ object ArrayBuilder {
   /** A class for array builders for arrays of `Unit` type. It can be reused. */
   final class ofUnit extends ArrayBuilder[Unit] {
 
-    def add(elem: Unit): this.type = {
+    def addOne(elem: Unit): this.type = {
       size += 1
       this
     }

--- a/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -55,7 +55,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = new BitSet(elems)
 
-  def add(elem: Int): this.type = {
+  def addOne(elem: Int): this.type = {
     require(elem >= 0)
     if (!contains(elem)) {
       val idx = elem >> LogWL
@@ -64,7 +64,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
 
-  def subtract(elem: Int): this.type = {
+  def subtractOne(elem: Int): this.type = {
     require(elem >= 0)
     if (contains(elem)) {
       val idx = elem >> LogWL

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -65,7 +65,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
 
   /** A builder resulting from this builder my mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo) = new Builder[A, NewTo] {
-    def add(x: A): this.type = { self += x; this }
+    def addOne(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()
     override def addAll(xs: IterableOnce[A]): this.type = { self ++= xs; this }
     def result(): NewTo = f(self.result())
@@ -79,15 +79,15 @@ class StringBuilder extends Builder[Char, String] {
   //TODO In the old collections, StringBuilder extends Seq -- should it do the same here to get this method?
   def length: Int = sb.length()
 
-  def add(x: Char) = { sb.append(x); this }
+  def addOne(x: Char) = { sb.append(x); this }
 
   def clear() = sb.setLength(0)
 
-  /** Overloaded version of `addAllInPlace` that takes a string */
-  def addAllInPlace(s: String): this.type = { sb.append(s); this }
+  /** Overloaded version of `addAll` that takes a string */
+  def addAll(s: String): this.type = { sb.append(s); this }
 
-  /** Alias for `addAllInPlace` */
-  def ++= (s: String): this.type = addAllInPlace(s)
+  /** Alias for `addAll` */
+  def ++= (s: String): this.type = addAll(s)
 
   def result() = sb.toString
 

--- a/collections/src/main/scala/strawman/collection/mutable/Growable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Growable.scala
@@ -22,14 +22,14 @@ trait Growable[-A] extends Clearable {
    *  @param elem  the element to $add.
    *  @return the $coll itself
    */
-  def add(elem: A): this.type
+  def addOne(elem: A): this.type
 
-  /** Alias for `add` */
-  @`inline` final def += (elem: A): this.type = add(elem)
+  /** Alias for `addOne` */
+  @`inline` final def += (elem: A): this.type = addOne(elem)
 
   //TODO This causes a conflict in StringBuilder; looks like a compiler bug
-  //@deprecated("Use add or += instead of append", "2.13.0")
-  //@`inline` final def append(elem: A): Unit = add(elem)
+  //@deprecated("Use addOne or += instead of append", "2.13.0")
+  //@`inline` final def append(elem: A): Unit = addOne(elem)
 
   /** ${Add}s two or more elements to this $coll.
    *
@@ -48,12 +48,12 @@ trait Growable[-A] extends Clearable {
   def addAll(xs: IterableOnce[A]): this.type = {
     val it = xs.iterator()
     while (it.hasNext) {
-      add(it.next())
+      addOne(it.next())
     }
     this
   }
 
-  /** Alias for `addAllInPlace` */
+  /** Alias for `addAll` */
   @`inline` final def ++= (xs: IterableOnce[A]): this.type = addAll(xs)
 }
 

--- a/collections/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/GrowableBuilder.scala
@@ -22,6 +22,6 @@ class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
 
   def result(): To = elems
 
-  def add(elem: Elem): this.type = { elems += elem; this }
+  def addOne(elem: Elem): this.type = { elems += elem; this }
 
 }

--- a/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -54,7 +54,7 @@ class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, Default
     if (e eq null) None else Some(e.value)
   }
 
-  def add(kv: (K, V)): this.type = {
+  def addOne(kv: (K, V)): this.type = {
     val e = table.findOrAddEntry(kv._1, kv._2)
     if (e ne null) e.value = kv._2
     this
@@ -62,7 +62,7 @@ class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, Default
 
   def clear(): Unit = table.clearTable()
 
-  def subtract(key: K): this.type = { table.removeEntry(key); this }
+  def subtractOne(key: K): this.type = { table.removeEntry(key); this }
 
   override def size: Int = table.size
 

--- a/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -37,11 +37,11 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder()
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     table.addElem(elem)
     this
   }
-  def subtract(elem: A): this.type = {
+  def subtractOne(elem: A): this.type = {
     table.removeElem(elem)
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -113,9 +113,9 @@ class LinkedHashMap[K, V]
     }
   }
 
-  def add(kv: (K, V)): this.type = { put(kv._1, kv._2); this }
+  def addOne(kv: (K, V)): this.type = { put(kv._1, kv._2); this }
 
-  def subtract(key: K): this.type = { remove(key); this }
+  def subtractOne(key: K): this.type = { remove(key); this }
 
   def iterator(): Iterator[(K, V)] = new Iterator[(K, V)] {
     private var cur = firstEntry

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
@@ -67,12 +67,12 @@ class LinkedHashSet[A]
 
   def contains(elem: A): Boolean = table.findEntry(elem) ne null
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     table.findOrAddEntry(elem, null)
     this
   }
 
-  def subtract(elem: A): this.type = {
+  def subtractOne(elem: A): this.type = {
     remove(elem)
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -96,7 +96,7 @@ class ListBuffer[A]
     first = Nil
   }
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     ensureUnaliased()
     val last1 = (elem :: Nil).asInstanceOf[::[A]]
     if (len == 0) first = last1 else last0.next = last1
@@ -105,7 +105,7 @@ class ListBuffer[A]
     this
   }
 
-  def subtract(elem: A): this.type = {
+  def subtractOne(elem: A): this.type = {
     ensureUnaliased()
     if (isEmpty) {}
     else if (first.head == elem) {

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -341,9 +341,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   /** Adds a new key/value pair to this map and returns the map. */
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
-  override def add(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
+  override def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
 
-  def subtract(key: Long): this.type = {
+  def subtractOne(key: Long): this.type = {
     if (key == -key) {
       if (key == 0L) {
         extraKeys &= 0x2
@@ -541,7 +541,7 @@ object LongMap {
     */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
-    override def add(entry: (Long, V)): this.type = {
+    override def addOne(entry: (Long, V)): this.type = {
       elems += entry
       this
     }

--- a/collections/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Map.scala
@@ -189,8 +189,8 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
     override def empty = new WithDefault(underlying.empty, d)
 
     def clear(): Unit = underlying.clear()
-    def add(elem: (K, V)): this.type = { underlying.add(elem); this }
-    def subtract(elem: K): this.type = { underlying.subtract(elem); this }
+    def addOne(elem: (K, V)): this.type = { underlying.addOne(elem); this }
+    def subtractOne(elem: K): this.type = { underlying.subtractOne(elem); this }
     override def put(key: K, value: V): Option[V] = underlying.put(key, value)
     override def update(key: K, value: V): Unit = underlying.update(key, value)
     override def remove(key: K): Option[V] = underlying.remove(key)

--- a/collections/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Set.scala
@@ -42,7 +42,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     */
   def get(elem: A): Option[A]
 
-  def insert(elem: A): Boolean =
+  def add(elem: A): Boolean =
     !contains(elem) && {
       coll += elem; true
     }
@@ -61,7 +61,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     *  @param included a flag indicating whether element should be included or excluded.
     */
   def update(elem: A, included: Boolean): Unit = {
-    if (included) insert(elem)
+    if (included) add(elem)
     else remove(elem)
   }
 

--- a/collections/src/main/scala/strawman/collection/mutable/Shrinkable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Shrinkable.scala
@@ -22,10 +22,10 @@ trait Shrinkable[-A] {
     *  @param elem  the element to remove.
     *  @return the $coll itself
     */
-  def subtract(elem: A): this.type
+  def subtractOne(elem: A): this.type
 
-  /** Alias for `subtract` */
-  @`inline` final def -= (elem: A): this.type = subtract(elem)
+  /** Alias for `subtractOne` */
+  @`inline` final def -= (elem: A): this.type = subtractOne(elem)
 
   /** Removes two or more elements from this $coll.
     *
@@ -34,14 +34,11 @@ trait Shrinkable[-A] {
     *  @param elems the remaining elements to remove.
     *  @return the $coll itself
     */
-  def subtract(elem1: A, elem2: A, elems: A*): this.type = {
+  def -= (elem1: A, elem2: A, elems: A*): this.type = {
     this -= elem1
     this -= elem2
     this --= elems.toStrawman
   }
-
-  /** Alias for `subtract` */
-  @`inline` final def -= (elem1: A, elem2: A, elems: A*): this.type = subtract(elem1, elem2, elems: _*)
 
   /** Removes all elements produced by an iterator from this $coll.
     *
@@ -51,13 +48,13 @@ trait Shrinkable[-A] {
   def subtractAll(xs: collection.IterableOnce[A]): this.type = {
     @tailrec def loop(xs: collection.LinearSeq[A]): Unit = {
       if (xs.nonEmpty) {
-        subtract(xs.head)
+        subtractOne(xs.head)
         loop(xs.tail)
       }
     }
     xs match {
       case xs: collection.LinearSeq[A] => loop(xs)
-      case xs => xs.iterator().foreach(subtract)
+      case xs => xs.iterator().foreach(subtractOne)
     }
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -54,9 +54,9 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def empty: TreeMap[K, V] = TreeMap.empty
 
-  def add(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
+  def addOne(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
 
-  def subtract(elem: K): this.type = { RB.delete(tree, elem); this }
+  def subtractOne(elem: K): this.type = { RB.delete(tree, elem); this }
 
   def clear(): Unit = RB.clear(tree)
 

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -55,12 +55,12 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def empty: TreeSet[A] = TreeSet.empty
 
-  def add(elem: A): this.type = {
+  def addOne(elem: A): this.type = {
     RB.insert(tree, elem, null)
     this
   }
 
-  def subtract(elem: A): this.type = {
+  def subtractOne(elem: A): this.type = {
     RB.delete(tree, elem)
     this
   }

--- a/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
@@ -112,7 +112,7 @@ class BuildFromTest {
     val left = bfLeft.newBuilder(coll)
     val right = bfRight.newBuilder(coll)
     for (a <- coll)
-      f(a).fold(left.add, right.add)
+      f(a).fold(left.addOne, right.addOne)
     (left.result(), right.result())
   }
 

--- a/test/junit/src/test/scala/strawman/collection/mutable/SetTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/SetTest.scala
@@ -14,8 +14,8 @@ class SetTest {
     protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[String]): MySet = new MySet(fromIterable(coll))
     protected[this] def newSpecificBuilder(): Builder[String, MySet] = iterableFactory.newBuilder[String]().mapResult(new MySet(_))
 
-    def subtract(elem: String) = { self -= elem; this }
-    def add(elem: String) = { self += elem; this }
+    def subtractOne(elem: String) = { self -= elem; this }
+    def addOne(elem: String) = { self += elem; this }
 
     def empty = new MySet(self.empty)
     def iterator() = self.iterator()


### PR DESCRIPTION
- Align Shrinkable with Growable: subtract becomes subtractOne,
  the multi-element overload of subtract is removed in favor of -=

- Rename Set.insert to Set.add

This avoids incompatibilities with the old collections library where
Set.add returns whether the element was added. The Java collections
do the same.