### PR TITLE
New immutable hash set and map

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ChampHashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ChampHashSetBenchmark.scala
@@ -5,25 +5,22 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import scala.{Any, AnyRef, Int, Long, Tuple2, Unit, math}
-import scala.Predef.{intWrapper, $conforms, tuple2ToZippedOps}
-
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
 @Warmup(iterations = 8)
 @Measurement(iterations = 8)
 @State(Scope.Benchmark)
-class ScalaHashSetBenchmark {
+class ChampHashSetBenchmark {
   @Param(scala.Array("0", "1", "2", "3", "4", "7", "8", "15", "16", "17", "39", "282", "4096", "131070", "7312102"))
   var size: Int = _
 
-  var xs: scala.collection.immutable.HashSet[Long] = _
-  var ys: scala.collection.immutable.HashSet[Long] = _
-  var zs: scala.collection.immutable.HashSet[Long] = _
-  var zipped: scala.collection.immutable.HashSet[(Long, Long)] = _
+  var xs: ChampHashSet[Long] = _
+  var ys: ChampHashSet[Long] = _
+  var zs: ChampHashSet[Long] = _
+  var zipped: ChampHashSet[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
-  def fresh(n: Int) = scala.collection.immutable.HashSet((1 to n).map(_.toLong): _*)
+  def fresh(n: Int) = ChampHashSet((1 to n).map(_.toLong): _*)
 
   @Setup(Level.Trial)
   def initTrial(): Unit = {
@@ -66,19 +63,18 @@ class ScalaHashSetBenchmark {
     }
   }
 
-//  // TODO: currently disabled, since it does not finish
-//  @Benchmark
-//  def traverse_initLast(bh: Blackhole): Unit = {
-//    var ys = xs
-//    while (ys.nonEmpty) {
-//      bh.consume(ys.last)
-//      ys = ys.init
-//    }
-//  }
+  @Benchmark
+  def traverse_initLast(bh: Blackhole): Unit = {
+    var ys = xs
+    while (ys.nonEmpty) {
+      bh.consume(ys.last)
+      ys = ys.init
+    }
+  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
-    val it = xs.iterator
+    val it = xs.iterator()
     while (it.hasNext) {
       bh.consume(it.next())
     }
@@ -151,10 +147,10 @@ class ScalaHashSetBenchmark {
   def transform_zipWithIndex(bh: Blackhole): Unit = bh.consume(xs.zipWithIndex)
 
   @Benchmark
-  def transform_lazyZip(bh: Blackhole): Unit = bh.consume((xs, xs).zipped.map((_, _)))
+  def transform_lazyZip(bh: Blackhole): Unit = bh.consume(xs.lazyZip(xs).map((_, _)))
 
   @Benchmark
-  def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip(t => (t._1, t._2)))
+  def transform_unzip(bh: Blackhole): Unit = bh.consume(zipped.unzip)
 
   @Benchmark
   def transform_groupBy(bh: Blackhole): Unit = {

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/HashSetBenchmark.scala
@@ -19,6 +19,7 @@ class HashSetBenchmark {
   var size: Int = _
 
   var xs: HashSet[Long] = _
+  var ys: HashSet[Long] = _
   var zs: HashSet[Long] = _
   var zipped: HashSet[(Long, Long)] = _
   var randomIndices: scala.Array[Int] = _
@@ -27,6 +28,7 @@ class HashSetBenchmark {
   @Setup(Level.Trial)
   def initTrial(): Unit = {
     xs = fresh(size)
+    ys = fresh(size)
     zs = fresh((size / 1000) max 2).map(-_)
     zipped = xs.map(x => (x, x))
     if (size > 0) {
@@ -64,14 +66,15 @@ class HashSetBenchmark {
     }
   }
 
-  @Benchmark
-  def traverse_initLast(bh: Blackhole): Unit = {
-    var ys = xs
-    while (ys.nonEmpty) {
-      bh.consume(ys.last)
-      ys = ys.init
-    }
-  }
+//  // TODO: currently disabled, since it does not finish
+//  @Benchmark
+//  def traverse_initLast(bh: Blackhole): Unit = {
+//    var ys = xs
+//    while (ys.nonEmpty) {
+//      bh.consume(ys.last)
+//      ys = ys.init
+//    }
+//  }
 
   @Benchmark
   def traverse_iterator(bh: Blackhole): Unit = {
@@ -158,4 +161,11 @@ class HashSetBenchmark {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
   }
+
+  @Benchmark
+  def traverse_subsetOf(bh: Blackhole): Unit = bh.consume(ys.subsetOf(xs))
+
+  @Benchmark
+  def traverse_equals(bh: Blackhole): Unit = bh.consume(xs == ys)
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ val commonSettings = Seq(
       <developer><id>odersky</id><name>Martin Odersky</name></developer>
       <developer><id>julienrf</id><name>Julien Richard-Foy</name></developer>
       <developer><id>szeiger</id><name>Stefan Zeiger</name></developer>
+      <developer><id>msteindorfer</id><name>Michael J. Steindorfer</name></developer>
     </developers>,
   // For publishing snapshots
   credentials ++= (

--- a/collections/src/main/scala/strawman/collection/immutable/ChampCommon.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampCommon.scala
@@ -1,0 +1,196 @@
+package strawman.collection.immutable
+
+import scala.{Any, Array, Boolean, Double, Int, Unit}
+
+import java.lang.Integer.bitCount
+import java.lang.Math.ceil
+
+private[immutable] final object Node {
+
+  final val HashCodeLength = 32
+
+  final val BitPartitionSize = 5
+
+  final val BitPartitionMask = (1 << BitPartitionSize) - 1
+
+  final val MaxDepth = ceil(HashCodeLength.toDouble / BitPartitionSize).toInt
+
+  final val SizeEmpty = 0
+
+  final val SizeOne = 1
+
+  final val SizeMoreThanOne = 2
+
+  final def maskFrom(hash: Int, shift: Int): Int = (hash >>> shift) & BitPartitionMask
+
+  final def bitposFrom(mask: Int): Int = 1 << mask
+
+  final def indexFrom(bitmap: Int, bitpos: Int): Int = bitCount(bitmap & (bitpos - 1))
+
+  final def indexFrom(bitmap: Int, mask: Int, bitpos: Int): Int = if (bitmap == -1) mask else indexFrom(bitmap, bitpos)
+
+}
+
+private[immutable] trait Node[T <: Node[T]] {
+
+  def hasNodes: Boolean
+
+  def nodeArity: Int
+
+  def getNode(index: Int): T
+
+  def hasPayload: Boolean
+
+  def payloadArity: Int
+
+  def getPayload(index: Int): Any
+
+  def sizePredicate: Int
+
+}
+
+/**
+  * Base class for fixed-stack iterators that traverse a hash-trie. The iterator performs a
+  * depth-first pre-order traversal, which yields first all payload elements of the current
+  * node before traversing sub-nodes (left to right).
+  *
+  * @tparam T the trie node type we are iterating over
+  *
+  * @author   Michael J. Steindorfer
+  */
+private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
+
+  import Node.MaxDepth
+
+  protected var currentValueCursor: Int = 0
+  protected var currentValueLength: Int = 0
+  protected var currentValueNode: T = _
+
+  private var currentStackLevel: Int = -1
+  private val nodeCursorsAndLengths: Array[Int] = Array.ofDim[Int](MaxDepth * 2)
+  private val nodes: Array[T] = Array.ofDim[Node[T]](MaxDepth).asInstanceOf[Array[T]]
+
+  def this(rootNode: T) = {
+    this()
+    if (rootNode.hasNodes) pushNode(rootNode)
+    if (rootNode.hasPayload) setupPayloadNode(rootNode)
+  }
+
+  private final def setupPayloadNode(node: T): Unit = {
+    currentValueNode = node
+    currentValueCursor = 0
+    currentValueLength = node.payloadArity
+  }
+
+  private final def pushNode(node: T): Unit = {
+    currentStackLevel = currentStackLevel + 1
+
+    val cursorIndex = currentStackLevel * 2
+    val lengthIndex = currentStackLevel * 2 + 1
+
+    nodes(currentStackLevel) = node
+    nodeCursorsAndLengths(cursorIndex) = 0
+    nodeCursorsAndLengths(lengthIndex) = node.nodeArity
+  }
+
+  private final def popNode(): Unit = {
+    currentStackLevel = currentStackLevel - 1
+  }
+
+  /**
+    * Searches for next node that contains payload values,
+    * and pushes encountered sub-nodes on a stack for depth-first traversal.
+    */
+  private final def searchNextValueNode(): Boolean = {
+    while (currentStackLevel >= 0) {
+      val cursorIndex = currentStackLevel * 2
+      val lengthIndex = currentStackLevel * 2 + 1
+
+      val nodeCursor = nodeCursorsAndLengths(cursorIndex)
+      val nodeLength = nodeCursorsAndLengths(lengthIndex)
+
+      if (nodeCursor < nodeLength) {
+        nodeCursorsAndLengths(cursorIndex) += 1
+
+        val nextNode = nodes(currentStackLevel).getNode(nodeCursor)
+
+        if (nextNode.hasNodes)   { pushNode(nextNode) }
+        if (nextNode.hasPayload) { setupPayloadNode(nextNode) ; return true }
+      } else {
+        popNode()
+      }
+    }
+
+    return false
+  }
+
+  final def hasNext = (currentValueCursor < currentValueLength) || searchNextValueNode()
+
+}
+
+/**
+  * Base class for fixed-stack iterators that traverse a hash-trie in reverse order. The base
+  * iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
+  *
+  * @tparam T the trie node type we are iterating over
+  *
+  * @author   Michael J. Steindorfer
+  */
+private[immutable] abstract class ChampBaseReverseIterator[T <: Node[T]] {
+
+  import Node.MaxDepth
+
+  protected var currentValueCursor: Int = -1
+  protected var currentValueNode: T = _
+
+  private var currentStackLevel: Int = -1
+  private val nodeIndex: Array[Int] = Array.ofDim[Int](MaxDepth + 1)
+  private val nodeStack: Array[T] = Array.ofDim[Node[T]](MaxDepth + 1).asInstanceOf[Array[T]]
+
+  def this(rootNode: T) = {
+    this()
+    pushNode(rootNode)
+    searchNextValueNode()
+  }
+
+  private final def setupPayloadNode(node: T): Unit = {
+    currentValueNode = node
+    currentValueCursor = node.payloadArity - 1
+  }
+
+  private final def pushNode(node: T): Unit = {
+    currentStackLevel = currentStackLevel + 1
+
+    nodeStack(currentStackLevel) = node
+    nodeIndex(currentStackLevel) = node.nodeArity - 1
+  }
+
+  private final def popNode(): Unit = {
+    currentStackLevel = currentStackLevel - 1
+  }
+
+  /**
+    * Searches for rightmost node that contains payload values,
+    * and pushes encountered sub-nodes on a stack for depth-first traversal.
+    */
+  private final def searchNextValueNode(): Boolean = {
+    while (currentStackLevel >= 0) {
+      val nodeCursor = nodeIndex(currentStackLevel) ; nodeIndex(currentStackLevel) = nodeCursor - 1
+
+      if (nodeCursor >= 0) {
+        val nextNode = nodeStack(currentStackLevel).getNode(nodeCursor)
+        pushNode(nextNode)
+      } else {
+        val currNode = nodeStack(currentStackLevel)
+        popNode()
+
+        if (currNode.hasPayload) { setupPayloadNode(currNode) ; return true }
+      }
+    }
+
+    return false
+  }
+
+  final def hasNext = (currentValueCursor >= 0) || searchNextValueNode()
+
+}

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
@@ -1,0 +1,655 @@
+package strawman
+package collection.immutable
+
+import collection.{IterableFactory, Iterator, MapFactory, StrictOptimizedIterableOps}
+import collection.Hashing.{computeHash, keepBits}
+
+import scala.annotation.unchecked.{uncheckedVariance => uV}
+import scala.{Any, AnyRef, Array, Boolean, Double, IndexOutOfBoundsException, Int, NoSuchElementException, None, Nothing, Option, SerialVersionUID, Serializable, Some, Tuple2, Unit, `inline`, math, sys, UnsupportedOperationException}
+import scala.Predef.{assert, require, ???}
+
+import java.lang.Integer.bitCount
+import java.lang.System.arraycopy
+
+import strawman.collection.mutable.{Builder, ImmutableBuilder}
+
+/** This class implements immutable maps using a Compressed Hash-Array Mapped Prefix-tree.
+  * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
+  *
+  *  @tparam K      the type of the keys contained in this hash set.
+  *  @tparam V      the type of the values associated with the keys in this hash map.
+  *
+  *  @author  Michael J. Steindorfer
+  *  @version 2.13
+  *  @since   2.13
+  *  @define Coll `immutable.ChampHashMap`
+  *  @define coll immutable champ hash map
+  */
+
+@SerialVersionUID(2L)
+final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V], val cachedJavaKeySetHashCode: Int, val cachedSize: Int)
+  extends Map[K, V]
+    with MapOps[K, V, ChampHashMap, ChampHashMap[K, V]]
+    with StrictOptimizedIterableOps[(K, V), Iterable /* ChampHashMap */, ChampHashMap[K, V]]
+    with Serializable {
+
+  def iterableFactory: IterableFactory[Iterable] = Iterable
+
+  def mapFactory: MapFactory[ChampHashMap] = ChampHashMap
+
+  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ChampHashMap[K2, V2] = ChampHashMap.from(it)
+
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ChampHashMap[K, V] = ChampHashMap.from(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[(K, V), ChampHashMap[K, V]] = ChampHashMap.newBuilder()
+
+  override def knownSize: Int = cachedSize
+
+  override def size: Int = cachedSize
+
+  override def isEmpty: Boolean = cachedSize == 0
+
+  def iterator(): Iterator[(K, V)] = new MapKeyValueTupleIterator[K, V](rootNode)
+
+  protected[immutable] def reverseIterator(): Iterator[(K, V)] = new MapKeyValueTupleReverseIterator[K, V](rootNode)
+
+  override final def contains(key: K): Boolean = rootNode.containsKey(key, computeHash(key), 0)
+
+  def get(key: K): Option[V] = rootNode.get(key, computeHash(key), 0)
+
+  def updated[V1 >: V](key: K, value: V1): ChampHashMap[K, V1] = {
+    val effect = MapEffect[K, V1]()
+    val keyHash = computeHash(key)
+    val newRootNode = rootNode.updated(key, value, keyHash, 0, effect)
+
+    if (effect.isModified) {
+      if (effect.hasReplacedValue) {
+        ChampHashMap(newRootNode, cachedJavaKeySetHashCode, cachedSize)
+      } else {
+        ChampHashMap(newRootNode, cachedJavaKeySetHashCode + keyHash, cachedSize + 1)
+      }
+    }
+    else this
+  }
+
+  def remove(key: K): ChampHashMap[K, V] = {
+    val effect = MapEffect[K, V]()
+    val keyHash = computeHash(key)
+    val newRootNode = rootNode.removed(key, keyHash, 0, effect)
+
+    if (effect.isModified)
+      ChampHashMap(newRootNode, cachedJavaKeySetHashCode - keyHash, cachedSize - 1)
+    else this
+  }
+
+  def empty: ChampHashMap[K, V] = ChampHashMap.empty
+
+  override def tail: ChampHashMap[K, V] = this - head._1
+
+  override def init: ChampHashMap[K, V] = this - last._1
+
+  override def head: (K, V) = iterator().next()
+
+  override def last: (K, V) = reverseIterator().next()
+
+  override def foreach[U](f: ((K, V)) => U): Unit = rootNode.foreach(f)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case map: ChampHashMap[K, V] =>
+        (this eq map) ||
+          (this.cachedSize == map.cachedSize) &&
+            (this.cachedJavaKeySetHashCode == map.cachedJavaKeySetHashCode) &&
+            (this.rootNode == map.rootNode)
+      case _ => super.equals(that)
+    }
+
+}
+
+private[immutable] object MapNode {
+
+  private final val EmptyMapNode = new BitmapIndexedMapNode(0, 0, Array.empty)
+
+  def empty[K, V]: MapNode[K, V] =
+    EmptyMapNode.asInstanceOf[MapNode[K, V]]
+
+  final val TupleLength = 2
+
+}
+
+@SerialVersionUID(2L)
+private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, V @uV]] with Serializable {
+
+  def get(key: K, hash: Int, shift: Int): Option[V]
+
+  def containsKey(key: K, hash: Int, shift: Int): Boolean =
+    this.get(key, hash, shift).isDefined
+
+  def contains[V1 >: V](key: K, value: V1, hash: Int, shift: Int): Boolean =
+    this.get(key, hash, shift).contains(value)
+
+  def updated[V1 >: V](key: K, value: V1, hash: Int, shift: Int, effect: MapEffect[K, V1]): MapNode[K, V1]
+
+  def removed[V1 >: V](key: K, hash: Int, shift: Int, effect: MapEffect[K, Any]): MapNode[K, V1]
+
+  def hasNodes: Boolean
+
+  def nodeArity: Int
+
+  def getNode(index: Int): MapNode[K, V]
+
+  def hasPayload: Boolean
+
+  def payloadArity: Int
+
+  def getPayload(index: Int): (K, V)
+
+  def sizePredicate: Int
+
+  def foreach[U](f: ((K, V)) => U): Unit
+
+}
+
+@SerialVersionUID(2L)
+private final class BitmapIndexedMapNode[K, +V](val dataMap: Int, val nodeMap: Int, val content: Array[Any]) extends MapNode[K, V] {
+
+  import Node._
+  import MapNode._
+
+  // assert(checkInvariantContentIsWellTyped())
+  // assert(checkInvariantSubNodesAreCompacted())
+
+  private final def checkInvariantSubNodesAreCompacted(): Boolean =
+    new MapKeyValueTupleIterator[K, V](this).size - payloadArity >= 2 * nodeArity
+
+  private final def checkInvariantContentIsWellTyped(): Boolean = {
+    val predicate1 = TupleLength * payloadArity + nodeArity == content.length
+
+    val predicate2 = Range(0, TupleLength * payloadArity)
+      .forall(i => content(i).isInstanceOf[MapNode[_, _]] == false)
+
+    val predicate3 = Range(TupleLength * payloadArity, content.length)
+      .forall(i => content(i).isInstanceOf[MapNode[_, _]] == true)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  def getPayload(index: Int) = Tuple2(
+    content(TupleLength * index).asInstanceOf[K],
+    content(TupleLength * index + 1).asInstanceOf[V])
+
+  def getNode(index: Int) =
+    content(content.length - 1 - index).asInstanceOf[MapNode[K, V]]
+
+  def get(key: K, keyHash: Int, shift: Int): Option[V] = {
+    val mask = maskFrom(keyHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val payload = this.getPayload(index)
+      return if (key == payload._1) Option(payload._2) else Option.empty
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      return this.getNode(index).get(key, keyHash, shift + BitPartitionSize)
+    }
+
+    Option.empty
+  }
+
+  override def containsKey(key: K, keyHash: Int, shift: Int): Boolean = {
+    val mask = maskFrom(keyHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      return key == this.getPayload(index)._1
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      return this.getNode(index).containsKey(key, keyHash, shift + BitPartitionSize)
+    }
+
+    false
+  }
+
+  override def contains[V1 >: V](key: K, value: V1, keyHash: Int, shift: Int): Boolean = {
+    val mask = maskFrom(keyHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      return (key, value) == this.getPayload(index)
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      return this.getNode(index).contains(key, value, keyHash, shift + BitPartitionSize)
+    }
+
+    false
+  }
+
+  def updated[V1 >: V](key: K, value: V1, keyHash: Int, shift: Int, effect: MapEffect[K, V1]): MapNode[K, V1] = {
+    val mask = maskFrom(keyHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val (key0, value0) = this.getPayload(index)
+
+      if (key0 == key) {
+        effect.setReplacedValue
+        return copyAndSetValue(bitpos, value)
+      } else {
+        val subNodeNew = mergeTwoKeyValPairs(key0, value0, computeHash(key0), key, value, keyHash, shift + BitPartitionSize)
+        effect.setModified
+        return copyAndMigrateFromInlineToNode(bitpos, subNodeNew)
+      }
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+
+      val subNodeNew = subNode.updated(key, value, keyHash, shift + BitPartitionSize, effect)
+      if (!effect.isModified) {
+        return this
+      } else {
+        return copyAndSetNode(bitpos, subNodeNew)
+      }
+    }
+
+    effect.setModified
+    copyAndInsertValue(bitpos, key, value)
+  }
+
+  def removed[V1 >: V](key: K, keyHash: Int, shift: Int, effect: MapEffect[K, Any]): MapNode[K, V1] = {
+    val mask = maskFrom(keyHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val (key0, _) = this.getPayload(index)
+
+      if (key0 == key) {
+        effect.setModified
+        if (this.payloadArity == 2 && this.nodeArity == 0) {
+          /*
+           * Create new node with remaining pair. The new node will a) either become the new root
+           * returned, or b) unwrapped and inlined during returning.
+           */
+          val newDataMap = if (shift == 0) (dataMap ^ bitpos) else bitposFrom(maskFrom(keyHash, 0))
+          if (index == 0)
+            return new BitmapIndexedMapNode[K, V1](newDataMap, 0, { val (k, v) = getPayload(1) ; Array(k, v) })
+          else
+            return new BitmapIndexedMapNode[K, V1](newDataMap, 0, { val (k, v) = getPayload(0) ; Array(k, v) })
+        }
+        else return copyAndRemoveValue(bitpos)
+      } else return this
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+
+      val subNodeNew = subNode.removed(key, keyHash, shift + BitPartitionSize, effect)
+      // assert(subNodeNew.sizePredicate != SizeEmpty, "Sub-node must have at least one element.")
+
+      if (!effect.isModified) return this
+      subNodeNew.sizePredicate match {
+        case SizeOne =>
+          if (this.payloadArity == 0 && this.nodeArity == 1) { // escalate (singleton or empty) result
+            return subNodeNew
+          }
+          else { // inline value (move to front)
+            return copyAndMigrateFromNodeToInline(bitpos, subNodeNew)
+          }
+
+        case SizeMoreThanOne =>
+          // modify current node (set replacement node)
+          return copyAndSetNode(bitpos, subNodeNew)
+      }
+    }
+
+    this
+  }
+
+  def mergeTwoKeyValPairs[V1 >: V](key0: K, value0: V1, keyHash0: Int, key1: K, value1: V1, keyHash1: Int, shift: Int): MapNode[K, V1] = {
+    // assert(key0 != key1)
+
+    if (shift >= HashCodeLength) {
+      new HashCollisionMapNode[K, V1](keyHash0, Vector((key0, value0), (key1, value1)))
+    } else {
+      val mask0 = maskFrom(keyHash0, shift)
+      val mask1 = maskFrom(keyHash1, shift)
+
+      if (mask0 != mask1) {
+        // unique prefixes, payload fits on same level
+        val dataMap = bitposFrom(mask0) | bitposFrom(mask1)
+
+        if (mask0 < mask1) {
+          new BitmapIndexedMapNode[K, V1](dataMap, 0, Array(key0, value0, key1, value1))
+        } else {
+          new BitmapIndexedMapNode[K, V1](dataMap, 0, Array(key1, value1, key0, value0))
+        }
+      } else {
+        // identical prefixes, payload must be disambiguated deeper in the trie
+        val nodeMap = bitposFrom(mask0)
+        val node = mergeTwoKeyValPairs(key0, value0, keyHash0, key1, value1, keyHash1, shift + BitPartitionSize)
+
+        new BitmapIndexedMapNode[K, V1](0, nodeMap, Array(node))
+      }
+    }
+  }
+  
+  def sizePredicate: Int =
+    if (nodeArity == 0) payloadArity match {
+      case 0 => SizeEmpty
+      case 1 => SizeOne
+      case _ => SizeMoreThanOne
+    } else SizeMoreThanOne
+
+  def hasNodes: Boolean = nodeMap != 0
+
+  def nodeArity: Int = bitCount(nodeMap)
+
+  def hasPayload: Boolean = dataMap != 0
+
+  def payloadArity: Int = bitCount(dataMap)
+
+  def dataIndex(bitpos: Int) = bitCount(dataMap & (bitpos - 1))
+
+  def nodeIndex(bitpos: Int) = bitCount(nodeMap & (bitpos - 1))
+
+  def copyAndSetValue[V1 >: V](bitpos: Int, newValue: V1) = {
+    val idx = TupleLength * dataIndex(bitpos) + 1
+
+    val src = this.content
+    val dst = new Array[Any](src.length)
+
+    // copy 'src' and set 1 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, src.length)
+    dst(idx) = newValue
+    new BitmapIndexedMapNode[K, V1](dataMap, nodeMap, dst)
+  }
+
+  def copyAndSetNode[V1 >: V](bitpos: Int, newNode: MapNode[K, V1]) = {
+    val idx = this.content.length - 1 - this.nodeIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length)
+
+    // copy 'src' and set 1 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, src.length)
+    dst(idx) = newNode
+    new BitmapIndexedMapNode[K, V1](dataMap, nodeMap, dst)
+  }
+
+  def copyAndInsertValue[V1 >: V](bitpos: Int, key: K, value: V1) = {
+    val idx = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length + TupleLength)
+
+    // copy 'src' and insert 2 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, idx)
+    dst(idx) = key
+    dst(idx + 1) = value
+    arraycopy(src, idx, dst, idx + TupleLength, src.length - idx)
+
+    new BitmapIndexedMapNode[K, V1](dataMap | bitpos, nodeMap, dst)
+  }
+
+  def copyAndRemoveValue(bitpos: Int) = {
+    val idx = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - TupleLength)
+
+    // copy 'src' and remove 2 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, idx)
+    arraycopy(src, idx + TupleLength, dst, idx, src.length - idx - TupleLength)
+
+    new BitmapIndexedMapNode[K, V](dataMap ^ bitpos, nodeMap, dst)
+  }
+
+  def copyAndMigrateFromInlineToNode[V1 >: V](bitpos: Int, node: MapNode[K, V1]) = {
+    val idxOld = TupleLength * dataIndex(bitpos)
+    val idxNew = this.content.length - TupleLength - nodeIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - TupleLength + 1)
+
+    // copy 'src' and remove 2 element(s) at position 'idxOld' and
+    // insert 1 element(s) at position 'idxNew'
+    // assert(idxOld <= idxNew)
+    arraycopy(src, 0, dst, 0, idxOld)
+    arraycopy(src, idxOld + TupleLength, dst, idxOld, idxNew - idxOld)
+    dst(idxNew) = node
+    arraycopy(src, idxNew + TupleLength, dst, idxNew + 1, src.length - idxNew - TupleLength)
+
+    new BitmapIndexedMapNode[K, V1](dataMap ^ bitpos, nodeMap | bitpos, dst)
+  }
+
+  def copyAndMigrateFromNodeToInline[V1 >: V](bitpos: Int, node: MapNode[K, V1]) = {
+    val idxOld = this.content.length - 1 - nodeIndex(bitpos)
+    val idxNew = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - 1 + TupleLength)
+
+    val (key, value) = node.getPayload(0)
+
+    // copy 'src' and remove 1 element(s) at position 'idxOld' and
+    // insert 2 element(s) at position 'idxNew'
+    // assert(idxOld >= idxNew)
+    arraycopy(src, 0, dst, 0, idxNew)
+    dst(idxNew) = key
+    dst(idxNew + 1) = value
+    arraycopy(src, idxNew, dst, idxNew + TupleLength, idxOld - idxNew)
+    arraycopy(src, idxOld + 1, dst, idxOld + TupleLength, src.length - idxOld - 1)
+
+    new BitmapIndexedMapNode[K, V1](dataMap | bitpos, nodeMap ^ bitpos, dst)
+  }
+
+  override def foreach[U](f: ((K, V)) => U): Unit = {
+    var i = 0
+    while (i < payloadArity) {
+      f(getPayload(i))
+      i += 1
+    }
+
+    var j = 0
+    while (j < nodeArity) {
+      getNode(j).foreach(f)
+      j += 1
+    }
+  }
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case node: BitmapIndexedMapNode[K, V] =>
+        (this eq node) ||
+          (this.nodeMap == node.nodeMap) &&
+            (this.dataMap == node.dataMap) &&
+            deepContentEquality(this.content, node.content, content.length)
+      case _ => false
+    }
+
+  @`inline` private def deepContentEquality(a1: Array[Any], a2: Array[Any], length: Int): Boolean = {
+    if (a1 eq a2)
+      true
+    else {
+      var isEqual = true
+      var i = 0
+
+      while (isEqual && i < length) {
+        isEqual = a1(i) == a2(i)
+        i += 1
+      }
+
+      isEqual
+    }
+  }
+
+  override def hashCode(): Int =
+    throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+}
+
+@SerialVersionUID(2L)
+private final class HashCollisionMapNode[K, +V](val hash: Int, val content: Vector[(K, V)]) extends MapNode[K, V] {
+
+  import Node._
+  import MapNode._
+
+  require(content.size >= 2)
+
+  def get(key: K, hash: Int, shift: Int): Option[V] =
+    if (this.hash == hash) content.find(key == _._1).map(_._2) else Option.empty
+
+  override def containsKey(key: K, hash: Int, shift: Int): Boolean =
+    this.hash == hash && content.exists(key == _._1)
+
+  override def contains[V1 >: V](key: K, value: V1, hash: Int, shift: Int): Boolean =
+    this.hash == hash && content.find(payload => key == payload._1 && value == payload._2).isDefined
+
+  def updated[V1 >: V](key: K, value: V1, hash: Int, shift: Int, effect: MapEffect[K, V1]): MapNode[K, V1] =
+    if (this.contains(key, value, hash, shift)) {
+      this
+    } else if (this.containsKey(key, hash, shift)) {
+      val index = content.indexWhere(key == _._1)
+      val (beforeTuple, fromTuple) = content.splitAt(index)
+      val updatedContent = beforeTuple.appended(Tuple2(key, value)).appendedAll(fromTuple.drop(1))
+
+      effect.setReplacedValue
+      new HashCollisionMapNode[K, V1](hash, updatedContent)
+    } else {
+      effect.setModified
+      new HashCollisionMapNode[K, V1](hash, content.appended(Tuple2(key, value)))
+    }
+
+  def removed[V1 >: V](key: K, hash: Int, shift: Int, effect: MapEffect[K, Any]): MapNode[K, V1] =
+    if (!this.containsKey(key, hash, shift)) {
+      this
+    } else {
+      effect.setModified
+      val updatedContent = content.filterNot(keyValuePair => keyValuePair._1 == key)
+      // assert(updatedContent.size == content.size - 1)
+
+      updatedContent.size match {
+        case 1 => new BitmapIndexedMapNode[K, V1](bitposFrom(maskFrom(hash, 0)), 0, { val (k, v) = updatedContent(0) ; Array(k, v) })
+        case _ => new HashCollisionMapNode[K, V1](hash, updatedContent)
+      }
+    }
+
+  def hasNodes: Boolean = false
+
+  def nodeArity: Int = 0
+
+  def getNode(index: Int): MapNode[K, V] =
+    throw new IndexOutOfBoundsException("No sub-nodes present in hash-collision leaf node.")
+
+  def hasPayload: Boolean = true
+
+  def payloadArity: Int = content.size
+
+  def getPayload(index: Int): (K, V) = content(index)
+
+  def sizePredicate: Int = SizeMoreThanOne
+
+  def foreach[U](f: ((K, V)) => U): Unit = content.foreach(f)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case node: HashCollisionMapNode[K, V] =>
+        (this eq node) ||
+          (this.hash == node.hash) &&
+            (this.content.size == node.content.size) &&
+            (this.content.forall(node.content.contains))
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+}
+
+private final case class MapEffect[K, +V]() {
+
+  private var modified: Boolean = false
+  private var replacedValue: Boolean = false
+
+  def isModified =  { modified }
+  def setModified = { modified = true }
+
+  def hasReplacedValue = { replacedValue }
+  def setReplacedValue = { replacedValue = true ; modified = true }
+
+}
+
+private final class MapKeyValueTupleIterator[K, V](rootNode: MapNode[K, V])
+  extends ChampBaseIterator[MapNode[K, V]](rootNode) with Iterator[(K, V)] {
+
+  def next() = {
+    if (!hasNext)
+      throw new NoSuchElementException
+
+    val payload = currentValueNode.getPayload(currentValueCursor)
+    currentValueCursor += 1
+
+    payload
+  }
+
+}
+
+private final class MapKeyValueTupleReverseIterator[K, V](rootNode: MapNode[K, V])
+  extends ChampBaseReverseIterator[MapNode[K, V]](rootNode) with Iterator[(K, V)] {
+
+  def next() = {
+    if (!hasNext)
+      throw new NoSuchElementException
+
+    val payload = currentValueNode.getPayload(currentValueCursor)
+    currentValueCursor -= 1
+
+    payload
+  }
+
+}
+
+/**
+  * $factoryInfo
+  *
+  * @define Coll `immutable.ChampHashMap`
+  * @define coll immutable champ hash map
+  */
+object ChampHashMap extends MapFactory[ChampHashMap] {
+
+  private[ChampHashMap] def apply[K, V](rootNode: MapNode[K, V], cachedJavaHashCode: Int, cachedSize: Int) =
+    new ChampHashMap[K, V](rootNode, cachedJavaHashCode, cachedSize)
+
+  private final val EmptyMap = new ChampHashMap(MapNode.empty, 0, 0)
+
+  def empty[K, V]: ChampHashMap[K, V] =
+    EmptyMap.asInstanceOf[ChampHashMap[K, V]]
+
+  def from[K, V](source: collection.IterableOnce[(K, V)]): ChampHashMap[K, V] =
+    source match {
+      case hs: ChampHashMap[K, V] => hs
+      case _ => (newBuilder[K, V]() ++= source).result()
+    }
+
+  def newBuilder[K, V](): Builder[(K, V), ChampHashMap[K, V]] =
+    new ImmutableBuilder[(K, V), ChampHashMap[K, V]](empty) {
+      def addOne(element: (K, V)): this.type = {
+        elems = elems + element
+        this
+      }
+    }
+
+}

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
@@ -1,0 +1,629 @@
+package strawman
+package collection
+package immutable
+
+import mutable.{Builder, ImmutableBuilder}
+import Hashing.computeHash
+
+import scala.{Any, AnyRef, Array, Boolean, Double, IndexOutOfBoundsException, Int, NoSuchElementException, None, SerialVersionUID, Serializable, Some, Unit, UnsupportedOperationException, `inline`, sys}
+import scala.Predef.{???, assert, require}
+
+import java.lang.Integer.{bitCount, numberOfTrailingZeros}
+import java.lang.System.arraycopy
+
+/** This class implements immutable sets using a Compressed Hash-Array Mapped Prefix-tree.
+  * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
+  *
+  *  @tparam A      the type of the elements contained in this hash set.
+  *
+  *  @author  Michael J. Steindorfer
+  *  @version 2.13
+  *  @since   2.13
+  *  @define Coll `immutable.ChampHashSet`
+  *  @define coll immutable champ hash set
+  */
+@SerialVersionUID(2L)
+final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val cachedJavaHashCode: Int, val cachedSize: Int)
+  extends Set[A]
+    with SetOps[A, ChampHashSet, ChampHashSet[A]]
+    with StrictOptimizedIterableOps[A, ChampHashSet, ChampHashSet[A]]
+    with Serializable {
+
+  def iterableFactory: IterableFactory[ChampHashSet] = ChampHashSet
+
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ChampHashSet[A] = fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, ChampHashSet[A]] = ChampHashSet.newBuilder()
+
+  override def knownSize: Int = cachedSize
+
+  override def size: Int = cachedSize
+
+  override def isEmpty: Boolean = cachedSize == 0
+
+  def iterator(): Iterator[A] = new SetIterator[A](rootNode)
+
+  protected[immutable] def reverseIterator(): Iterator[A] = new SetReverseIterator[A](rootNode)
+
+  def contains(element: A): Boolean = rootNode.contains(element, computeHash(element), 0)
+
+  def incl(element: A): ChampHashSet[A] = {
+    val effect = SetEffect[A]()
+    val elementHash = computeHash(element)
+    val newRootNode = rootNode.updated(element, elementHash, 0, effect)
+
+    if (effect.isModified)
+      ChampHashSet(newRootNode, cachedJavaHashCode + elementHash, cachedSize + 1)
+    else this
+  }
+
+  def excl(element: A): ChampHashSet[A] = {
+    val effect = SetEffect[A]()
+    val elementHash = computeHash(element)
+    val newRootNode = rootNode.removed(element, elementHash, 0, effect)
+
+    if (effect.isModified)
+      ChampHashSet(newRootNode, cachedJavaHashCode - elementHash, cachedSize - 1)
+    else this
+  }
+
+  def empty: ChampHashSet[A] = ChampHashSet.empty
+
+  override def tail: ChampHashSet[A] = this - head
+
+  override def init: ChampHashSet[A] = this - last
+
+  override def head: A = iterator().next()
+
+  override def last: A = reverseIterator().next()
+
+  override def foreach[U](f: A => U): Unit = rootNode.foreach(f)
+
+  def subsetOf(that: Set[A]): Boolean = if (that.isEmpty) true else that match {
+    case set: ChampHashSet[A] => rootNode.subsetOf(set.rootNode, 0)
+    case _ => super.subsetOf(that)
+  }
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case set: ChampHashSet[A] =>
+        (this eq set) ||
+          (this.cachedSize == set.cachedSize) &&
+            (this.cachedJavaHashCode == set.cachedJavaHashCode) &&
+            (this.rootNode == set.rootNode)
+      case _ => super.equals(that)
+    }
+
+}
+
+private[immutable] final object SetNode {
+
+  private final val EmptySetNode = new BitmapIndexedSetNode(0, 0, Array.empty)
+
+  def empty[A]: SetNode[A] =
+    EmptySetNode.asInstanceOf[SetNode[A]]
+
+  final val TupleLength = 1
+
+}
+
+@SerialVersionUID(2L)
+private[immutable] sealed abstract class SetNode[A] extends Node[SetNode[A]] with Serializable {
+
+  def contains(element: A, hash: Int, shift: Int): Boolean
+
+  def updated(element: A, hash: Int, shift: Int, effect: SetEffect[A]): SetNode[A]
+
+  def removed(element: A, hash: Int, shift: Int, effect: SetEffect[A]): SetNode[A]
+
+  def hasNodes: Boolean
+
+  def nodeArity: Int
+
+  def getNode(index: Int): SetNode[A]
+
+  def hasPayload: Boolean
+
+  def payloadArity: Int
+
+  def getPayload(index: Int): A
+
+  def sizePredicate: Int
+
+  def foreach[U](f: A => U): Unit
+
+  def subsetOf(that: SetNode[A], shift: Int): Boolean
+
+}
+
+@SerialVersionUID(2L)
+private final class BitmapIndexedSetNode[A](val dataMap: Int, val nodeMap: Int, val content: Array[Any]) extends SetNode[A] {
+
+  import Node._
+  import SetNode._
+
+  // assert(checkInvariantContentIsWellTyped())
+  // assert(checkInvariantSubNodesAreCompacted())
+
+  private final def checkInvariantSubNodesAreCompacted(): Boolean =
+    new SetIterator[A](this).size - payloadArity >= 2 * nodeArity
+
+  private final def checkInvariantContentIsWellTyped(): Boolean = {
+    val predicate1 = TupleLength * payloadArity + nodeArity == content.length
+
+    val predicate2 = Range(0, TupleLength * payloadArity)
+      .forall(i => content(i).isInstanceOf[SetNode[_]] == false)
+
+    val predicate3 = Range(TupleLength * payloadArity, content.length)
+      .forall(i => content(i).isInstanceOf[SetNode[_]] == true)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  def getPayload(index: Int) =
+    content(TupleLength * index).asInstanceOf[A]
+
+  def getNode(index: Int) =
+    content(content.length - 1 - index).asInstanceOf[SetNode[A]]
+
+  def contains(element: A, elementHash: Int, shift: Int): Boolean = {
+    val mask = maskFrom(elementHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      return element == this.getPayload(index)
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      return this.getNode(index).contains(element, elementHash, shift + BitPartitionSize)
+    }
+
+    false
+  }
+
+  def updated(element: A, elementHash: Int, shift: Int, effect: SetEffect[A]): SetNode[A] = {
+    val mask = maskFrom(elementHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val element0 = this.getPayload(index)
+
+      if (element0 == element) {
+        return this
+      } else {
+        val subNodeNew = mergeTwoKeyValPairs(element0, computeHash(element0), element, elementHash, shift + BitPartitionSize)
+        effect.setModified
+        return copyAndMigrateFromInlineToNode(bitpos, subNodeNew)
+      }
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+
+      val subNodeNew = subNode.updated(element, elementHash, shift + BitPartitionSize, effect)
+      if (!effect.isModified) {
+        return this
+      } else {
+        return copyAndSetNode(bitpos, subNodeNew)
+      }
+    }
+
+    effect.setModified
+    copyAndInsertValue(bitpos, element)
+  }
+
+  def removed(element: A, elementHash: Int, shift: Int, effect: SetEffect[A]): SetNode[A] = {
+    val mask = maskFrom(elementHash, shift)
+    val bitpos = bitposFrom(mask)
+
+    if ((dataMap & bitpos) != 0) {
+      val index = indexFrom(dataMap, mask, bitpos)
+      val element0 = this.getPayload(index)
+
+      if (element0 == element) {
+        effect.setModified
+        if (this.payloadArity == 2 && this.nodeArity == 0) {
+          /*
+           * Create new node with remaining pair. The new node will a) either become the new root
+           * returned, or b) unwrapped and inlined during returning.
+           */
+          val newDataMap = if (shift == 0) (dataMap ^ bitpos) else bitposFrom(maskFrom(elementHash, 0))
+          if (index == 0)
+            return new BitmapIndexedSetNode[A](newDataMap, 0, Array(getPayload(1)))
+          else
+            return new BitmapIndexedSetNode[A](newDataMap, 0, Array(getPayload(0)))
+        }
+        else return copyAndRemoveValue(bitpos)
+      } else return this
+    }
+
+    if ((nodeMap & bitpos) != 0) {
+      val index = indexFrom(nodeMap, mask, bitpos)
+      val subNode = this.getNode(index)
+
+      val subNodeNew = subNode.removed(element, elementHash, shift + BitPartitionSize, effect)
+      // assert(subNodeNew.sizePredicate != SizeEmpty, "Sub-node must have at least one element.")
+
+      if (!effect.isModified) return this
+      subNodeNew.sizePredicate match {
+        case SizeOne =>
+          if (this.payloadArity == 0 && this.nodeArity == 1) { // escalate (singleton or empty) result
+            return subNodeNew
+          }
+          else { // inline value (move to front)
+            return copyAndMigrateFromNodeToInline(bitpos, subNodeNew)
+          }
+
+        case SizeMoreThanOne =>
+          // modify current node (set replacement node)
+          return copyAndSetNode(bitpos, subNodeNew)
+      }
+    }
+
+    this
+  }
+
+  def mergeTwoKeyValPairs[A](key0: A, keyHash0: Int, key1: A, keyHash1: Int, shift: Int): SetNode[A] = {
+    // assert(key0 != key1)
+
+    if (shift >= HashCodeLength) {
+      new HashCollisionSetNode[A](keyHash0, Vector(key0, key1))
+    } else {
+      val mask0 = maskFrom(keyHash0, shift)
+      val mask1 = maskFrom(keyHash1, shift)
+
+      if (mask0 != mask1) {
+        // unique prefixes, payload fits on same level
+        val dataMap = bitposFrom(mask0) | bitposFrom(mask1)
+
+        if (mask0 < mask1) {
+          new BitmapIndexedSetNode[A](dataMap, 0, Array(key0, key1))
+        } else {
+          new BitmapIndexedSetNode[A](dataMap, 0, Array(key1, key0))
+        }
+      } else {
+        // identical prefixes, payload must be disambiguated deeper in the trie
+        val nodeMap = bitposFrom(mask0)
+        val node = mergeTwoKeyValPairs(key0, keyHash0, key1, keyHash1, shift + BitPartitionSize)
+
+        new BitmapIndexedSetNode[A](0, nodeMap, Array(node))
+      }
+    }
+  }
+
+  def sizePredicate: Int =
+    if (nodeArity == 0) payloadArity match {
+      case 0 => SizeEmpty
+      case 1 => SizeOne
+      case _ => SizeMoreThanOne
+    } else SizeMoreThanOne
+
+  def hasPayload: Boolean = dataMap != 0
+
+  def payloadArity: Int = bitCount(dataMap)
+
+  def hasNodes: Boolean = nodeMap != 0
+
+  def nodeArity: Int = bitCount(nodeMap)
+
+  def dataIndex(bitpos: Int) = bitCount(dataMap & (bitpos - 1))
+
+  def nodeIndex(bitpos: Int) = bitCount(nodeMap & (bitpos - 1))
+
+  def copyAndSetNode(bitpos: Int, newNode: SetNode[A]) = {
+    val idx = this.content.length - 1 - this.nodeIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length)
+
+    // copy 'src' and set 1 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, src.length)
+    dst(idx) = newNode
+    new BitmapIndexedSetNode[A](dataMap, nodeMap, dst)
+  }
+
+  def copyAndInsertValue(bitpos: Int, key: A) = {
+    val idx = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length + 1)
+
+    // copy 'src' and insert 1 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, idx)
+    dst(idx) = key
+    arraycopy(src, idx, dst, idx + 1, src.length - idx)
+
+    new BitmapIndexedSetNode[A](dataMap | bitpos, nodeMap, dst)
+  }
+
+  def copyAndRemoveValue(bitpos: Int) = {
+    val idx = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - 1)
+
+    // copy 'src' and remove 1 element(s) at position 'idx'
+    arraycopy(src, 0, dst, 0, idx)
+    arraycopy(src, idx + 1, dst, idx, src.length - idx - 1)
+
+    new BitmapIndexedSetNode[A](dataMap ^ bitpos, nodeMap, dst)
+  }
+
+  def copyAndMigrateFromInlineToNode(bitpos: Int, node: SetNode[A]) = {
+    val idxOld = TupleLength * dataIndex(bitpos)
+    val idxNew = this.content.length - TupleLength - nodeIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - 1 + 1)
+
+    // copy 'src' and remove 1 element(s) at position 'idxOld' and
+    // insert 1 element(s) at position 'idxNew'
+    // assert(idxOld <= idxNew)
+    arraycopy(src, 0, dst, 0, idxOld)
+    arraycopy(src, idxOld + 1, dst, idxOld, idxNew - idxOld)
+    dst(idxNew) = node
+    arraycopy(src, idxNew + 1, dst, idxNew + 1, src.length - idxNew - 1)
+
+    new BitmapIndexedSetNode[A](dataMap ^ bitpos, nodeMap | bitpos, dst)
+  }
+
+  def copyAndMigrateFromNodeToInline(bitpos: Int, node: SetNode[A]) = {
+    val idxOld = this.content.length - 1 - nodeIndex(bitpos)
+    val idxNew = TupleLength * dataIndex(bitpos)
+
+    val src = this.content
+    val dst = new Array[Any](src.length - 1 + 1)
+
+    // copy 'src' and remove 1 element(s) at position 'idxOld' and
+    // insert 1 element(s) at position 'idxNew'
+    // assert(idxOld >= idxNew)
+    arraycopy(src, 0, dst, 0, idxNew)
+    dst(idxNew) = node.getPayload(0)
+    arraycopy(src, idxNew, dst, idxNew + 1, idxOld - idxNew)
+    arraycopy(src, idxOld + 1, dst, idxOld + 1, src.length - idxOld - 1)
+
+    new BitmapIndexedSetNode[A](dataMap | bitpos, nodeMap ^ bitpos, dst)
+  }
+
+  def foreach[U](f: A => U): Unit = {
+    var i = 0
+    while (i < payloadArity) {
+      f(getPayload(i))
+      i += 1
+    }
+
+    var j = 0
+    while (j < nodeArity) {
+      getNode(j).foreach(f)
+      j += 1
+    }
+  }
+
+  def subsetOf(that: SetNode[A], shift: Int): Boolean = if (this eq that) true else that match {
+    case node: HashCollisionSetNode[A] => false
+    case node: BitmapIndexedSetNode[A] => {
+      val thisBitmap = this.dataMap | this.nodeMap
+      val nodeBitmap = node.dataMap | node.nodeMap
+
+      if ((thisBitmap | nodeBitmap) != nodeBitmap)
+        return false
+
+      var bitmap = thisBitmap & nodeBitmap
+      var bitsToSkip = numberOfTrailingZeros(bitmap)
+
+      var isValidSubset = true
+      while (isValidSubset && bitsToSkip < HashCodeLength) {
+        val bitpos = bitposFrom(bitsToSkip)
+
+        isValidSubset =
+          if ((this.dataMap & bitpos) != 0) {
+            if ((node.dataMap & bitpos) != 0) {
+              // Data x Data
+              val payload0 = this.getPayload(indexFrom(this.dataMap, bitpos))
+              val payload1 = node.getPayload(indexFrom(node.dataMap, bitpos))
+              payload0 == payload1
+            } else {
+              // Data x Node
+              val payload = this.getPayload(indexFrom(this.dataMap, bitpos))
+              val subNode = that.getNode(indexFrom(node.nodeMap, bitpos))
+              subNode.contains(payload, computeHash(payload), shift + BitPartitionSize);
+            }
+          } else {
+            // Node x Node
+            val subNode0 = this.getNode(indexFrom(this.nodeMap, bitpos))
+            val subNode1 = node.getNode(indexFrom(node.nodeMap, bitpos))
+            subNode0.subsetOf(subNode1, shift + BitPartitionSize)
+          }
+
+        val newBitmap = bitmap ^ bitpos
+        bitmap = newBitmap
+        bitsToSkip = numberOfTrailingZeros(newBitmap)
+      }
+      isValidSubset
+    }
+  }
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case node: BitmapIndexedSetNode[A] =>
+        (this eq node) ||
+          (this.nodeMap == node.nodeMap) &&
+            (this.dataMap == node.dataMap) &&
+            deepContentEquality(this.content, node.content, content.length)
+      case _ => false
+    }
+
+  @`inline` private def deepContentEquality(a1: Array[Any], a2: Array[Any], length: Int): Boolean = {
+    if (a1 eq a2)
+      true
+    else {
+      var isEqual = true
+      var i = 0
+
+      while (isEqual && i < length) {
+        isEqual = a1(i) == a2(i)
+        i += 1
+      }
+
+      isEqual
+    }
+  }
+
+  override def hashCode(): Int =
+    throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+}
+
+@SerialVersionUID(2L)
+private final class HashCollisionSetNode[A](val hash: Int, val content: Vector[A]) extends SetNode[A] {
+
+  import Node._
+  import SetNode._
+
+  require(content.size >= 2)
+
+  def contains(element: A, hash: Int, shift: Int): Boolean =
+    this.hash == hash && content.contains(element)
+
+  def updated(element: A, hash: Int, shift: Int, effect: SetEffect[A]): SetNode[A] =
+    if (this.contains(element, hash, shift)) {
+      this
+    } else {
+      effect.setModified
+      new HashCollisionSetNode[A](hash, content.appended(element))
+    }
+
+  /**
+    * Remove an element from the hash collision node.
+    *
+    * When after deletion only one element remains, we return a bit-mapped indexed node with a
+    * singleton element and a hash-prefix for trie level 0. This node will be then a) either become
+    * the new root, or b) unwrapped and inlined deeper in the trie.
+    */
+  def removed(element: A, hash: Int, shift: Int, effect: SetEffect[A]): SetNode[A] =
+    if (!this.contains(element, hash, shift)) {
+      this
+    } else {
+      effect.setModified
+      val updatedContent = content.filterNot(element0 => element0 == element)
+      // assert(updatedContent.size == content.size - 1)
+
+      updatedContent.size match {
+        case 1 => new BitmapIndexedSetNode[A](bitposFrom(maskFrom(hash, 0)), 0, updatedContent.toArray)
+        case _ => new HashCollisionSetNode[A](hash, updatedContent)
+      }
+    }
+
+  def hasNodes: Boolean = false
+
+  def nodeArity: Int = 0
+
+  def getNode(index: Int): SetNode[A] =
+    throw new IndexOutOfBoundsException("No sub-nodes present in hash-collision leaf node.")
+
+  def hasPayload: Boolean = true
+
+  def payloadArity: Int = content.size
+
+  def getPayload(index: Int): A = content(index)
+
+  def sizePredicate: Int = SizeMoreThanOne
+
+  def foreach[U](f: A => U): Unit = content.foreach(f)
+
+  def subsetOf(that: SetNode[A], shift: Int): Boolean = if (this eq that) true else that match {
+    case node: BitmapIndexedSetNode[A] => false
+    case node: HashCollisionSetNode[A] => {
+      this.payloadArity <= node.payloadArity && this.content.forall(node.content.contains)
+    }
+  }
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case node: HashCollisionSetNode[A] =>
+        (this eq node) ||
+          (this.hash == node.hash) &&
+            (this.content.size == node.content.size) &&
+            (this.content.forall(node.content.contains))
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+}
+
+private final case class SetEffect[A]() {
+
+  private var modified: Boolean = false
+
+  def isModified =  { modified }
+  def setModified = { modified = true }
+
+}
+
+private final class SetIterator[A](rootNode: SetNode[A])
+  extends ChampBaseIterator[SetNode[A]](rootNode) with Iterator[A] {
+
+  def next() = {
+    if (!hasNext)
+      throw new NoSuchElementException
+
+    val payload = currentValueNode.getPayload(currentValueCursor)
+    currentValueCursor += 1
+
+    payload
+  }
+
+}
+
+private final class SetReverseIterator[A](rootNode: SetNode[A])
+  extends ChampBaseReverseIterator[SetNode[A]](rootNode) with Iterator[A] {
+
+  def next() = {
+    if (!hasNext)
+      throw new NoSuchElementException
+
+    val payload = currentValueNode.getPayload(currentValueCursor)
+    currentValueCursor -= 1
+
+    payload
+  }
+
+}
+
+/**
+  * $factoryInfo
+  *
+  * @define Coll `immutable.ChampHashSet`
+  * @define coll immutable champ hash set
+  */
+object ChampHashSet extends IterableFactory[ChampHashSet] {
+
+  private[ChampHashSet] def apply[A](rootNode: SetNode[A], cachedJavaHashCode: Int, cachedSize: Int) =
+    new ChampHashSet[A](rootNode, cachedJavaHashCode, cachedSize)
+
+  private final val EmptySet = new ChampHashSet(SetNode.empty, 0, 0)
+
+  def empty[A]: ChampHashSet[A] =
+    EmptySet.asInstanceOf[ChampHashSet[A]]
+
+  def from[A](source: collection.IterableOnce[A]): ChampHashSet[A] =
+    source match {
+      case hs: ChampHashSet[A] => hs
+      case _ => (newBuilder[A]() ++= source).result()
+    }
+
+  def newBuilder[A](): Builder[A, ChampHashSet[A]] =
+    new ImmutableBuilder[A, ChampHashSet[A]](empty) {
+      def addOne(element: A): this.type = {
+        elems = elems + element
+        this
+      }
+    }
+
+}

--- a/test/junit/src/test/scala/strawman/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ChampMapSmokeTest.scala
@@ -1,0 +1,172 @@
+package strawman.collection.immutable
+
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Test
+
+object ChampMapSmokeTest {
+
+  private def emptyMap[K, V]: ChampHashMap[K, V] =
+    ChampHashMap.empty[K, V]
+
+  private def mapOf[K, V](keyValuePairs: (K, V)*): ChampHashMap[K, V] = {
+    val builder = ChampHashMap.newBuilder[K, V]()
+    keyValuePairs.foreach(builder.addOne)
+    builder.result
+  }
+
+  def mkTuple[KV](keyValue: KV): (KV, KV) = keyValue -> keyValue
+
+  def mkTuple[K, V](key: K, value: V): (K, V) = key -> value
+
+  def mkValue(value: Int) = new CustomHashInt(value, value)
+
+  def mkValue(value: Int, hash: Int) = new CustomHashInt(value, hash)
+
+}
+
+class ChampMapSmokeTest {
+
+  import ChampMapSmokeTest._
+
+  val v11h1 = mkValue(11, 1)
+  val v12h1 = mkValue(12, 1)
+
+  val v1h1 = mkValue(1, 1)
+  val v5h5 = mkValue(5, 5)
+
+  val v32769 = mkValue(32769, 32769)
+  val v32769a = mkValue(32769*10+1, 32769)
+  val v32769b = mkValue(32769*10+2, 32769)
+
+  @Test def testCheckPrefixConstruction(): Unit = {
+    val map: ChampHashMap[Int, Int] = emptyMap
+
+    val res1 = map + mkTuple(63) + mkTuple(64) + mkTuple(32768) + mkTuple(2147483647) + mkTuple(65536)
+    assert(res1.contains(63))
+    assert(res1.contains(64))
+    assert(res1.contains(32768))
+    assert(res1.contains(65536))
+    assert(res1.contains(2147483647))
+
+    val res2 = map + mkTuple(2147483647) + mkTuple(32768) + mkTuple(63) + mkTuple(64) + mkTuple(65536)
+    assert(res2.contains(63))
+    assert(res2.contains(64))
+    assert(res2.contains(32768))
+    assert(res2.contains(65536))
+    assert(res2.contains(2147483647))
+
+    assert(res1 == res2)
+  }
+
+  @Test def testCheckCompactionFromBeginUponDelete(): Unit = {
+    val map: ChampHashMap[Int, Int] = emptyMap
+    val res1 = map + mkTuple(1) + mkTuple(2)
+    val res2 = res1 + mkTuple(32769) - 2
+    /* should trigger assertion in data structure if not compacting */
+  }
+
+  @Test def testCheckCompactionFromMiddleUponDelete(): Unit = {
+    val map: ChampHashMap[Int, Int] = emptyMap
+    val res1 = map + mkTuple(1) + mkTuple(2) + mkTuple(65) + mkTuple(66)
+    val res2 = res1 + mkTuple(32769) - 66
+    assert(!(res1 == res2))
+  }
+
+  @Test def testCheckCompactionFromBeginUponDelete_HashCollisionNode1(): Unit = {
+    val map: ChampHashMap[CustomHashInt, CustomHashInt] = emptyMap
+
+    val res1 = map + mkTuple(v11h1) + mkTuple(v12h1)
+    assertTrue(res1.contains(v11h1))
+    assertTrue(res1.contains(v12h1))
+
+    val res2 = res1 - v12h1
+    assertTrue(res2.contains(v11h1))
+    assertEquals(mapOf() + mkTuple(v11h1), res2)
+
+    val res3 = res1 - v11h1
+    assertTrue(res3.contains(v12h1))
+    assertEquals(mapOf() + mkTuple(v12h1, v12h1), res3)
+
+    val resX = res1 + mkTuple(v32769) - v12h1
+    assertTrue(resX.contains(v11h1))
+    assertTrue(resX.contains(v32769))
+    assert(!(res1 == resX))
+  }
+
+  @Test def testCheckCompactionFromBeginUponDelete_HashCollisionNode2(): Unit = {
+    val map: ChampHashMap[CustomHashInt, CustomHashInt] = emptyMap
+
+    val res1 = map + mkTuple(v32769a) + mkTuple(v32769b)
+    assertEquals(2, res1.size)
+    assertTrue(res1.contains(v32769a))
+    assertTrue(res1.contains(v32769b))
+
+    val res2 = res1 + mkTuple(v1h1)
+    assertEquals(3, res2.size)
+    assertTrue(res2.contains(v1h1))
+    assertTrue(res2.contains(v32769a))
+    assertTrue(res2.contains(v32769b))
+
+    val res3 = res2 - v32769b
+    assertEquals(2, res3.size)
+    assertTrue(res3.contains(v1h1))
+    assertTrue(res3.contains(v32769a))
+    val expected = mapOf(mkTuple(v1h1), mkTuple(v32769a))
+    assertEquals(expected, res3)
+  }
+
+  @Test def testCheckCompactionFromBeginUponDelete_HashCollisionNode3(): Unit = {
+    val map: ChampHashMap[CustomHashInt, CustomHashInt] = emptyMap
+    val res1 = map + mkTuple(v32769a) + mkTuple(v32769b)
+    assertEquals(2, res1.size)
+    assertTrue(res1.contains(v32769a))
+    assertTrue(res1.contains(v32769b))
+
+    val res2 = res1 + mkTuple(v1h1)
+    assertEquals(3, res2.size)
+    assertTrue(res2.contains(v1h1))
+    assertTrue(res2.contains(v32769a))
+    assertTrue(res2.contains(v32769b))
+
+    val res3 = res2 - v1h1
+    assertEquals(2, res3.size)
+    assertTrue(res3.contains(v32769a))
+    assertTrue(res3.contains(v32769b))
+    assertEquals(res1, res3)
+  }
+
+  @Test def testCheckCompactionFromBeginUponDelete_HashCollisionNode4(): Unit = {
+    val map: ChampHashMap[CustomHashInt, CustomHashInt] = emptyMap
+    val res1 = map + mkTuple(v32769a) + mkTuple(v32769b)
+    assertEquals(2, res1.size)
+    assertTrue(res1.contains(v32769a))
+    assertTrue(res1.contains(v32769b))
+
+    val res2 = res1 + mkTuple(v5h5)
+    assertEquals(3, res2.size)
+    assertTrue(res2.contains(v5h5))
+    assertTrue(res2.contains(v32769a))
+    assertTrue(res2.contains(v32769b))
+
+    val res3 = res2 - v5h5
+    assertEquals(2, res3.size)
+    assertTrue(res3.contains(v32769a))
+    assertTrue(res3.contains(v32769b))
+    assertEquals(res1, res3)
+  }
+
+  @Test def testCreateSingletonWithFactoryMethod(): Unit = {
+    val map: ChampHashMap[Int, Int] = emptyMap + mkTuple(63, 65)
+    assertTrue(map.contains(63))
+    assertEquals(65, map.get(63).get)
+  }
+
+  @Test def testRemoveFromSingleton(): Unit = {
+    val map: ChampHashMap[Int, Int] = emptyMap + mkTuple(63, 65)
+    val res = map - 63
+    assertTrue(res.isEmpty)
+    assertFalse(res.contains(63))
+    assertEquals(emptyMap, res)
+  }
+
+}

--- a/test/junit/src/test/scala/strawman/collection/immutable/ChampSetSmokeTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/ChampSetSmokeTest.scala
@@ -1,0 +1,224 @@
+package strawman.collection.immutable
+
+import java.{util => ju}
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+import strawman.collection.convert.{DecorateAsJava, DecorateAsScala}
+
+object ChampSetSmokeTest {
+
+  private def emptySet: Set[CustomHashInt] =
+    Set.empty[CustomHashInt]
+
+  private def setOf(item: CustomHashInt): Set[CustomHashInt] =
+    emptySet + item
+
+  private def setOf(item0: CustomHashInt, item1: CustomHashInt): Set[CustomHashInt] =
+    emptySet + item0 + item1
+
+  private def setOf(item0: CustomHashInt, item1: CustomHashInt, item2: CustomHashInt): Set[CustomHashInt] =
+    emptySet + item0 + item1 + item2
+
+  def mkValue(value: Int) = new CustomHashInt(value, value)
+
+  def mkValue(value: Int, hash: Int) = new CustomHashInt(value, hash)
+
+}
+
+class ChampSetSmokeTest extends DecorateAsJava with DecorateAsScala {
+
+  import ChampSetSmokeTest._
+
+  @Test def testNodeValNode(): Unit = {
+    val input = new ju.LinkedHashMap[Integer, Integer]
+    input.put(1, 1)
+    input.put(2, 33)
+    input.put(3, 3)
+    input.put(4, 4)
+    input.put(5, 4)
+    input.put(6, 6)
+    input.put(7, 7)
+    input.put(8, 7)
+
+    var set: Set[CustomHashInt] = emptySet
+    input.forEach((key, value) => set = set + mkValue(key, value))
+    input.forEach((key, value) => assertTrue(set.contains(mkValue(key, value))))
+  }
+
+  @Test def testValNodeVal(): Unit = {
+    val input = new ju.LinkedHashMap[Integer, Integer]
+    input.put(1, 1)
+    input.put(2, 2)
+    input.put(3, 2)
+    input.put(4, 4)
+    input.put(5, 5)
+    input.put(6, 5)
+    input.put(7, 7)
+
+    var set: Set[CustomHashInt] = emptySet
+    input.forEach((key, value) => set = set + mkValue(key, value))
+    input.forEach((key, value) => assertTrue(set.contains(mkValue(key, value))))
+  }
+
+  @Test def testIteration(): Unit = {
+    val input = new ju.LinkedHashMap[Integer, Integer]
+    input.put(1, 1)
+    input.put(2, 2)
+    input.put(3, 2)
+    input.put(4, 4)
+    input.put(5, 5)
+    input.put(6, 5)
+    input.put(7, 7)
+
+    var set: Set[CustomHashInt] = emptySet
+    input.forEach((key, value) => set = set + mkValue(key, value))
+
+    set.foreach(item => input.remove(item.value))
+    assertTrue(input.isEmpty)
+  }
+
+  @Test def IterateWithLastBitsDifferent(): Unit = {
+    val hash_n2147483648_obj1 = mkValue(1, -2147483648)
+    val hash_p1073741824_obj2 = mkValue(2, 1073741824)
+
+    val todo: ju.Set[CustomHashInt] = new ju.HashSet[CustomHashInt]
+    todo.add(hash_n2147483648_obj1)
+    todo.add(hash_p1073741824_obj2)
+
+    val xs: Set[CustomHashInt] = setOf(hash_n2147483648_obj1, hash_p1073741824_obj2)
+    xs.forall(todo.remove)
+
+    assertEquals(ju.Collections.EMPTY_SET, todo)
+  }
+
+  @Test def TwoCollisionsEquals(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj2, hash98304_obj1)
+    assertEquals(xs, ys)
+  }
+
+  @Test def ThreeCollisionsEquals(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash98304_obj3 = mkValue(3, 98304)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2, hash98304_obj3)
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj3, hash98304_obj2, hash98304_obj1)
+    assertEquals(xs, ys)
+  }
+
+  @Test def RemovalFromCollisonNodeEqualsSingelton(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1)
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2) - hash98304_obj2
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionIterate(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+
+    val todo: ju.Set[CustomHashInt] = new ju.HashSet[CustomHashInt]
+    todo.add(hash98304_obj1)
+    todo.add(hash98304_obj2)
+
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    xs.forall(todo.remove)
+
+    assertEquals(ju.Collections.EMPTY_SET, todo)
+  }
+
+  @Test def CollisionWithMergeInlineAbove1(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2, hash268435456_obj3) - hash268435456_obj3
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineAbove1_2(): Unit = {
+    val hash8_obj1 = mkValue(1, 8)
+    val hash8_obj2 = mkValue(2, 8)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash8_obj1, hash8_obj2, hash268435456_obj3) - hash268435456_obj3
+    val ys: Set[CustomHashInt] = setOf(hash8_obj1, hash8_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineAbove2(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash268435456_obj3, hash98304_obj2) - hash268435456_obj3
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineAbove2_2(): Unit = {
+    val hash8_obj1 = mkValue(1, 8)
+    val hash8_obj2 = mkValue(2, 8)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash8_obj1, hash268435456_obj3, hash8_obj2) - hash268435456_obj3
+    val ys: Set[CustomHashInt] = setOf(hash8_obj1, hash8_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineAbove1RemoveOneCollisonNode(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2, hash268435456_obj3) - hash98304_obj2
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash268435456_obj3)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineAbove2RemoveOneCollisonNode(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash268435456_obj3 = mkValue(3, 268435456)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash268435456_obj3, hash98304_obj2) - hash98304_obj2
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash268435456_obj3)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineBelow1(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash8_obj3 = mkValue(3, 8)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2, hash8_obj3) - hash8_obj3
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineBelow2(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash8_obj3 = mkValue(3, 8)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash8_obj3, hash98304_obj2) - hash8_obj3
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineBelowRemoveOneCollisonNode1(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash8_obj3 = mkValue(3, 8)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash98304_obj2, hash8_obj3) - hash98304_obj2
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash8_obj3)
+    assertEquals(xs, ys)
+  }
+
+  @Test def CollisionWithMergeInlineBelowRemoveOneCollisonNode2(): Unit = {
+    val hash98304_obj1 = mkValue(1, 98304)
+    val hash98304_obj2 = mkValue(2, 98304)
+    val hash8_obj3 = mkValue(3, 8)
+    val xs: Set[CustomHashInt] = setOf(hash98304_obj1, hash8_obj3, hash98304_obj2) - hash98304_obj2
+    val ys: Set[CustomHashInt] = setOf(hash98304_obj1, hash8_obj3)
+    assertEquals(xs, ys)
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/immutable/CustomHashInt.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/CustomHashInt.scala
@@ -1,0 +1,28 @@
+package strawman.collection.immutable
+
+/**
+  * This class allows to create custom integer values that have a
+  * hash code that differs from the value itself.
+  *
+  * The main use-case for this class is to simulate hash-collisions
+  * when testing collection data structures.
+  */
+class CustomHashInt(val value: Int, val hash: Int) {
+
+  override def hashCode: Int = hash
+
+  override def equals(other: Any): Boolean = other match {
+    case that: CustomHashInt =>
+      (this eq that) || hash == that.hash && value == that.value
+    case _ => false
+  }
+
+  override def toString: String = s"$value, [hash = $hash]"
+
+}
+
+object CustomHashInt {
+
+  def apply(value: Int, hash: Int) = new CustomHashInt(value, hash)
+
+}

--- a/test/scalacheck/src/test/scala/strawman/collection/Generators.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/Generators.scala
@@ -27,5 +27,16 @@ object Generators {
     } yield mutable.TreeSet(elements: _*)
   implicit def arbTreeSet[A : Arbitrary : Ordering]: Arbitrary[mutable.TreeSet[A]] = Arbitrary(genTreeSet)
 
+  implicit def arbitraryImmutableHashSet[A](implicit arbitraryOldMutableSet: Arbitrary[scala.collection.mutable.Set[A]]): Arbitrary[immutable.HashSet[A]] =
+    Arbitrary(arbitraryOldMutableSet.arbitrary.map(m => immutable.HashSet.from(m.toSeq.toStrawman)))
+
+  implicit def arbitraryImmutableChampHashSet[A](implicit arbitraryOldMutableSet: Arbitrary[scala.collection.mutable.Set[A]]): Arbitrary[immutable.ChampHashSet[A]] =
+    Arbitrary(arbitraryOldMutableSet.arbitrary.map(m => immutable.ChampHashSet.from(m.toSeq.toStrawman)))
+
+  implicit def arbitraryImmutableHashMap[K, V](implicit arbitraryOldMutableSet: Arbitrary[scala.collection.mutable.Map[K, V]]): Arbitrary[immutable.HashMap[K, V]] =
+    Arbitrary(arbitraryOldMutableSet.arbitrary.map(m => immutable.HashMap.from(m.toSeq.toStrawman)))
+
+  implicit def arbitraryImmutableChampHashMap[K, V](implicit arbitraryOldMutableSet: Arbitrary[scala.collection.mutable.Map[K, V]]): Arbitrary[immutable.ChampHashMap[K, V]] =
+    Arbitrary(arbitraryOldMutableSet.arbitrary.map(m => immutable.ChampHashMap.from(m.toSeq.toStrawman)))
 
 }

--- a/test/scalacheck/src/test/scala/strawman/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -1,0 +1,64 @@
+package strawman.collection.immutable
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.scalacheck._
+
+import strawman.collection.Generators._
+
+object ImmutableChampHashMapProperties extends Properties("immutable.ChampHashMap") {
+
+  type K = String
+  type V = String
+  type T = (K, V)
+
+  //  override def overrideParameters(p: org.scalacheck.Test.Parameters) =
+  //    p.withMinSuccessfulTests(1000)
+
+  property("convertToScalaMapAndCheckSize") = forAll { (input: ChampHashMap[K, V]) =>
+    convertToScalaMapAndCheckSize(input)
+  }
+
+  private def convertToScalaMapAndCheckSize(input: ChampHashMap[K, V]) =
+    HashMap.from(input).size == input.size
+
+  property("convertToScalaMapAndCheckHashCode") = forAll { (input: ChampHashMap[K, V]) =>
+    convertToScalaMapAndCheckHashCode(input)
+  }
+
+  private def convertToScalaMapAndCheckHashCode(input: ChampHashMap[K, V]) =
+    HashMap.from(input).hashCode == input.hashCode
+
+  property("convertToScalaMapAndCheckEquality") = forAll { (input: ChampHashMap[K, V]) =>
+    input == HashMap.from(input) && HashMap.from(input) == input
+  }
+
+  property("input.equals(duplicate)") = forAll { (inputMap: ChampHashMap[K, V]) =>
+    val builder = ChampHashMap.newBuilder[K, V]()
+    inputMap.foreach(builder.addOne)
+
+    val duplicateMap = builder.result
+    inputMap == duplicateMap
+  }
+
+  property("checkSizeAfterInsertAll") = forAll { (inputValues: HashMap[K, V]) =>
+    val testMap = ChampHashMap.empty[K, V] ++ inputValues
+    inputValues.size == testMap.size
+  }
+
+  property("containsAfterInsert") = forAll { (inputValues: HashMap[K, V]) =>
+    val testMap = ChampHashMap.empty[K, V] ++ inputValues
+    inputValues.forall { case (key, value) => testMap.get(key).contains(value) }
+  }
+
+  property("iterator() equals reverseIterator().reverse()") = forAll { (input: ChampHashMap[K, V]) =>
+    val xs: List[(K, V)] = input.iterator()
+      .foldLeft(List.empty[(K, V)])((list: List[(K, V)], item: (K, V)) => list prepended item)
+
+    val ys: List[(K, V)] = input.reverseIterator()
+      .foldLeft(List.empty[(K, V)])((list: List[(K, V)], item: (K, V)) => list appended item)
+
+    xs == ys
+  }
+
+}

--- a/test/scalacheck/src/test/scala/strawman/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/src/test/scala/strawman/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -1,0 +1,235 @@
+package strawman.collection.immutable
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.scalacheck._
+
+import strawman.collection.Generators._
+
+object ImmutableChampHashSetProperties extends Properties("immutable.ChampHashSet") {
+
+  type K = String
+
+//  override def overrideParameters(p: org.scalacheck.Test.Parameters) =
+//    p.withMinSuccessfulTests(1000)
+
+  private def doSubtract(one: ChampHashSet[K], two: ChampHashSet[K]) = {
+    one.foldLeft(ChampHashSet.empty[K])((result, elem) => if (two contains elem) result else result + elem)
+  }
+
+  private def doIntersect(one: ChampHashSet[K], two: ChampHashSet[K]) = {
+    one.foldLeft(ChampHashSet.empty[K])((result, elem) => if (two contains elem) result + elem else result)
+  }
+
+  property("convertToScalaSetAndCheckSize") = forAll { (input: ChampHashSet[K]) =>
+    convertToScalaSetAndCheckSize(input)
+  }
+
+  private def convertToScalaSetAndCheckSize(input: ChampHashSet[K]) =
+    HashSet.from(input).size == input.size
+
+  property("convertToScalaSetAndCheckHashCode") = forAll { (input: ChampHashSet[K]) =>
+    convertToScalaSetAndCheckHashCode(input)
+  }
+
+  private def convertToScalaSetAndCheckHashCode(input: ChampHashSet[K]) =
+    HashSet.from(input).hashCode == input.hashCode
+
+  property("convertToScalaSetAndCheckEquality") = forAll { (input: ChampHashSet[K]) =>
+    input == HashSet.from(input) && HashSet.from(input) == input
+  }
+
+  property("input.equals(duplicate)") = forAll { (inputSet: ChampHashSet[K]) =>
+    val builder = ChampHashSet.newBuilder[K]()
+    inputSet.foreach(builder.addOne)
+
+    val duplicateSet = builder.result
+    inputSet == duplicateSet
+  }
+
+  property("checkSizeAfterInsertAll") = forAll { (inputValues: HashSet[K]) =>
+    val testSet = ChampHashSet.empty[K] ++ inputValues
+    inputValues.size == testSet.size
+  }
+
+  property("containsAfterInsert") = forAll { (inputValues: HashSet[K]) =>
+    var testSet = ChampHashSet.empty[K] ++ inputValues
+    inputValues.forall(testSet.contains)
+  }
+
+  property("notContainedAfterInsertRemove") = forAll { (input: ChampHashSet[K], item: K) =>
+    (input + item - item).contains(item) == false
+  }
+
+  property("intersectIdentityReference") = forAll { (inputShared: ChampHashSet[K]) =>
+    inputShared == inputShared.intersect(inputShared)
+  }
+
+  property("intersectIdentityStructural") = forAll { (inputShared: ChampHashSet[K]) =>
+    val builder = ChampHashSet.newBuilder[K]()
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result
+    inputShared == inputShared.intersect(duplicateSet)
+  }
+
+  property("intersect") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithoutShared = doSubtract(doSubtract(inputOne, inputShared), inputTwo)
+    val twoWithoutShared = doSubtract(doSubtract(inputTwo, inputShared), inputOne)
+
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val intersectedWithShared = oneWithShared.intersect(twoWithShared)
+
+    val predicate1 = inputShared.forall(intersectedWithShared.contains)
+    val predicate2 = !intersectedWithShared.exists(oneWithoutShared.contains)
+    val predicate3 = !intersectedWithShared.exists(twoWithoutShared.contains)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  property("intersectMaintainsSizeAndHashCode") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val intersectedWithShared = oneWithShared.intersect(twoWithShared)
+
+    convertToScalaSetAndCheckSize(intersectedWithShared) && convertToScalaSetAndCheckHashCode(intersectedWithShared)
+  }
+
+  property("intersectEqualToDefaultImplementation") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+
+    val intersectNative = oneWithShared.intersect(twoWithShared)
+    val intersectDefault = doIntersect(oneWithShared, twoWithShared)
+
+    intersectDefault == intersectNative
+  }
+
+  property("intersectIdentityMostlyReference") = forAll { (input: ChampHashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input == input.intersect(inputCopy) && inputCopy.intersect(input) == input
+  }
+
+  property("unionIdentityReference") = forAll { (inputShared: ChampHashSet[K]) =>
+    inputShared == inputShared.union(inputShared)
+  }
+
+  property("unionIdentityMostlyReference") = forAll { (input: ChampHashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input == input.union(inputCopy) && inputCopy.union(input) == input
+  }
+
+  property("unionIdentityStructural") = forAll { (inputShared: ChampHashSet[K]) =>
+    val builder = ChampHashSet.newBuilder[K]()
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result
+    inputShared == inputShared.union(duplicateSet)
+  }
+
+  property("union") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K]) =>
+    val unioned = inputOne.intersect(inputTwo)
+
+    unioned.forall(inputOne.contains) && unioned.forall(inputTwo.contains)
+  }
+
+  property("unionMaintainsSizeAndHashCode") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K]) =>
+    val unioned = inputOne.union(inputTwo)
+
+    convertToScalaSetAndCheckSize(unioned) && convertToScalaSetAndCheckHashCode(unioned)
+  }
+
+  property("unionEqualToDefaultImplementation") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K]) =>
+    inputOne ++ inputTwo == inputOne.union(inputTwo)
+  }
+
+  property("subtract") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K]) =>
+    val subtracted = inputOne.diff(inputTwo)
+
+    subtracted.forall(inputOne.contains) && !subtracted.exists(inputTwo.contains)
+  }
+
+  property("subtractMaintainsSizeAndHashCode") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K]) =>
+    val subtracted = inputOne.diff(inputTwo)
+    convertToScalaSetAndCheckSize(subtracted) && convertToScalaSetAndCheckHashCode(subtracted)
+  }
+
+  property("subtractIdentityReference") = forAll { (inputShared: ChampHashSet[K]) =>
+    ChampHashSet.empty[K] == inputShared.diff(inputShared)
+  }
+
+  property("subtractIdentityMostlyReference") = forAll { (input: ChampHashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input.diff(inputCopy).isEmpty && inputCopy.diff(input).isEmpty
+  }
+
+  property("subtractIdentityStructural") = forAll { (inputShared: ChampHashSet[K]) =>
+    val builder = ChampHashSet.newBuilder[K]()
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result
+    ChampHashSet.empty[K] == inputShared.diff(duplicateSet)
+  }
+
+  property("subtract") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithoutShared = inputOne diff inputShared diff inputTwo
+    val twoWithoutShared = inputTwo diff inputShared diff inputOne
+
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val subtractedWithShared = oneWithShared diff twoWithShared
+
+    val predicate1 = !inputShared.exists(subtractedWithShared.contains)
+    val predicate2 = subtractedWithShared.forall(oneWithoutShared.contains)
+    val predicate3 = !subtractedWithShared.exists(twoWithoutShared.contains)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  property("subtractMaintainsSizeAndHashCode") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val subtractedWithShared = oneWithShared diff twoWithShared
+
+    convertToScalaSetAndCheckSize(subtractedWithShared) && convertToScalaSetAndCheckHashCode(subtractedWithShared)
+  }
+
+  property("subtractEqualToDefaultImplementation") = forAll { (inputOne: ChampHashSet[K], inputTwo: ChampHashSet[K], inputShared: ChampHashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+
+    val subtractNative = oneWithShared diff twoWithShared
+    val subtractDefault = doSubtract(oneWithShared, twoWithShared)
+
+    subtractDefault == subtractNative
+  }
+
+  property("iterator() equals reverseIterator().reverse()") = forAll { (input: ChampHashSet[K]) =>
+    val xs: List[K] = input.iterator()
+      .foldLeft(List.empty[K])((list: List[K], item: K) => list prepended item)
+
+    val ys: List[K] = input.reverseIterator()
+      .foldLeft(List.empty[K])((list: List[K], item: K) => list appended item)
+
+    xs == ys
+  }
+
+  property("smaller subsetOf larger") = forAll { (inputSet: ChampHashSet[K]) =>
+    if (inputSet.isEmpty) {
+      true
+    } else {
+      val randomSamples = scala.util.Random.nextInt(inputSet.size)
+      val randomIndices = ImmutableArray.fill(randomSamples)(scala.util.Random.nextInt(inputSet.size))
+
+      val inputArray = inputSet.toArray
+      val smallerSet = ChampHashSet.from(randomIndices.map(inputArray).toSet)
+
+      smallerSet.subsetOf(inputSet)
+    }
+  }
+
+}


### PR DESCRIPTION
This pull request contains reimplementations of immutable `HashSet` and `HashMap` using [Compressed Hash-Array Mapped Prefix-trees (CHAMP)](https://michael.steindorfer.name/publications/oopsla15.pdf). A prototype and preliminary evaluation of CHAMP data structures in collection-strawman was already discussed in issue #192.

The new implementations (`ChampHashSet` and `ChampHashMap`) currently exist next to the `HashMap` and `HashSet`. By default `immutable.Map` and `immutable.Set` now pickup the CHAMP versions, but I also implemented a JVM flag (`-Dstrawman.collection.immutable.useBaseline=true`) to default to the current `HashSet` and `HashMap` implementations. I assume that in the final version of the collections only one hash-map/set will ship, but for now, having a flag helps with comparing the different trade-offs and performance characteristics of the current and the new data structures.

The data structures contained in this pull request represent a first basic re-implementation of `HashSet` and `HashMap`. The data structures should be functionally complete at this point, however  there are still parts and operations that can benefit from (further) optimizations. I plan to continue working on those parts that still need attention, but in the meantime I request a review of the current state. 

Preliminary performance numbers of the new CHAMP data structures were presented in issue #192; those characteristics didn't change with the Scala re-implementaiton. (I can post further results here upon request, but you might be interested to give them a spin yourself.) Overall one can summarize that the CHAMP data structures significantly lower memory footprints and significantly improve all iteration-based operations and equality checks. Lookups slow down, but insertion and deletion also seem to benefit as well.

Note that the CHAMP design / implementation differs from the current hashed data structures by not memoizing the hash codes of the individual elements (which may change the performance of certain workloads). If necessary, CHAMP's design allows to modularly add memoizing the hash codes of the individual elements (at the expense of some memory savings); details are discussed in the [OOPSLA'15 paper](https://michael.steindorfer.name/publications/oopsla15.pdf). I plan to further explore the memoized approach in the context of collection-strawmen as well in the near future.

I'm looking forward to receiving feedback on the current implementation, to further improve the code based on your reviews.