### PR TITLE
Don’t force views elements prematurely.

### DIFF
--- a/collections/src/main/scala/strawman/collection/View.scala
+++ b/collections/src/main/scala/strawman/collection/View.scala
@@ -294,19 +294,7 @@ trait ArrayLike[+A] extends Any {
 }
 
 /** View defined in terms of indexing a range */
-trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, IndexedView[A]] { self =>
-
-  final override def toSeq: immutable.Seq[A] = to(immutable.IndexedSeq)
-
-  override protected[this] def fromSpecificIterable(it: Iterable[A]): IndexedView[A] =
-    it match {
-      case v: IndexedView[A] => v
-      case i: IndexedSeq[A] => i.view
-      case _ => it.to(IndexedSeq).view
-    }
-
-  override protected[this] def newSpecificBuilder(): Builder[A, IndexedView[A]] =
-    IndexedSeq.newBuilder[A]().mapResult(_.view)
+trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, View[A]] { self =>
 
   def iterator(): Iterator[A] = new AbstractIterator[A] {
     private var current = 0


### PR DESCRIPTION
`IndexedView[A]` was previously trying to return an `IndexedView[A]` on
transformation operations such as `filter` or `take`. Doing so sometimes
required to evaluate a views elements to build an indexed sequence
from which to get an `IndexedView` (see the last case):

~~~ scala
 override protected[this] def fromSpecificIterable(it: Iterable[A]): IndexedView[A] =
   it match {
     case v: IndexedView[A] => v
     case i: IndexedSeq[A] => i.view
     case _ => it.to(IndexedSeq).view
   }
~~~

Now `IndexedView[A]` returns only a `View[A]` on such operations.

Another solution would have been to have `IndexedView` based versions of all transformation operations that are `View` based (i.e. `IndexedView.Filter`, `IndexedView.Map`). The drawback of that solution would be that we would duplicate all transformation operations (we would have `View.Filter` *and* `IndexedView.Filter`, etc.), but the advantage would be that the fact that a collection is indexed would be preserved across transformations applied to its view.

---

I discovered this issue while benchmarking the following code:

~~~
      xs.view
        .filter(x => x % 2L == 0L)
        .map(x => x * x)
        .sum
~~~

When `xs` was an `IndexedSeq`, then it’s `filter` operation returned `fromSpecificIterable(View.Filter(…))`, which was converting the `View.Filter(…)` into a strict `IndexedSeq` to take its view.

As a consequence, that code was (up to 2×) slower than the same code using strict transformation operations only (in red on the following chart):

![sumofsquareseven](https://user-images.githubusercontent.com/332812/34984777-509f743c-fab2-11e7-9136-b87cb84ab9d6.png)

With this PR, the version that uses views rather than strict transformation is slightly faster but still a bit slower than the strict version:

![sumofsquareseven-after](https://user-images.githubusercontent.com/332812/34984893-a4029ee2-fab2-11e7-81b0-62b113820e80.png)

I’ve run a profiler and noticed that most of the time is spent on the `hasNext` operation. It is not clear to me why the view based version is still slower because in the strict version we also iterate on the same transformations and call the same `hasNext` operations…