### PR TITLE
Optimize slice operation in ImmutableArray

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -10,7 +10,7 @@ import scala.Predef.{intWrapper, $conforms}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(2)
 @Warmup(iterations = 8)
 @Measurement(iterations = 8)
 @State(Scope.Benchmark)
@@ -207,7 +207,7 @@ class ImmutableArrayBenchmark {
   def access_tail(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)
+  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)*/
 
   @Benchmark
   @OperationsPerInvocation(100)
@@ -298,5 +298,5 @@ class ImmutableArrayBenchmark {
   def transform_groupBy(bh: Blackhole): Unit = {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
-  }
+  }*/
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -10,7 +10,7 @@ import scala.Predef.{intWrapper, $conforms}
 
 @BenchmarkMode(scala.Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(2)
+@Fork(1)
 @Warmup(iterations = 8)
 @Measurement(iterations = 8)
 @State(Scope.Benchmark)
@@ -207,7 +207,7 @@ class ImmutableArrayBenchmark {
   def access_tail(bh: Blackhole): Unit = bh.consume(xs.tail)
 
   @Benchmark
-  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)*/
+  def access_init(bh: Blackhole): Unit = bh.consume(xs.init)
 
   @Benchmark
   @OperationsPerInvocation(100)
@@ -298,5 +298,5 @@ class ImmutableArrayBenchmark {
   def transform_groupBy(bh: Blackhole): Unit = {
     val result = xs.groupBy(_ % 5)
     bh.consume(result)
-  }*/
+  }
 }

--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/ImmutableArrayBenchmark.scala
@@ -220,6 +220,16 @@ class ImmutableArrayBenchmark {
   }
 
   @Benchmark
+  @OperationsPerInvocation(100)
+  def access_slice_empty(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < 100) {
+      bh.consume(xs.slice(size, size  - size / (i + 1)))
+      i += 1
+    }
+  }
+
+  @Benchmark
   @OperationsPerInvocation(1000)
   def transform_updateLast(bh: Blackhole): Unit = {
     var i = 0

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -191,7 +191,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[T] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofRef(Arrays.copyOfRange[T](unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofRef(Arrays.copyOfRange[T](unsafeArray, lo, hi))
     }
   }
 
@@ -209,7 +212,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Byte] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofByte(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofByte(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -227,7 +233,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Short] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofShort(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofShort(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -245,7 +254,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Char] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofChar(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofChar(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -263,7 +275,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Int] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofInt(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofInt(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -281,7 +296,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Long] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofLong(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofLong(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -299,7 +317,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Float] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofFloat(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofFloat(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -317,7 +338,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Double] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofDouble(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofDouble(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -335,7 +359,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def slice(from: Int, until: Int): ImmutableArray[Boolean] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      new ofBoolean(Arrays.copyOfRange(unsafeArray, lo, hi))
+      if (lo >= hi)
+        emptyImpl
+      else
+        new ofBoolean(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -356,9 +383,13 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       // cant use util.Arrays.copyOfRange[Unit](repr, from, until) - Unit is special and doesnt compile
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
-      val slicedLenght = hi - lo
-      val res = new Array[Unit](slicedLenght)
-      new ofUnit(res)
+      val slicedLength = hi - lo
+      if (slicedLength <= 0)
+        emptyImpl
+      else {
+        val res = new Array[Unit](slicedLength)
+        new ofUnit(res)
+      }
     }
   }
 }

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -190,7 +190,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[T] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange[T](unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofRef(Arrays.copyOfRange[T](unsafeArray, lo, hi))
     }
   }
 
@@ -207,7 +208,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Byte] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofByte(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -224,7 +226,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Short] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofShort(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -241,7 +244,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Char] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofChar(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -258,7 +262,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Int] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofInt(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -275,7 +280,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Long] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofLong(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -292,7 +298,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Float] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofFloat(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -309,7 +316,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Double] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofDouble(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -326,7 +334,8 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
     override def slice(from: Int, until: Int): ImmutableArray[Boolean] = {
       val lo = scala.math.max(from, 0)
-      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+      val hi = scala.math.min(until, length)
+      new ofBoolean(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
   }
 
@@ -346,8 +355,9 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       // new ofUnit(util.Arrays.copyOfRange[Unit](array, from, until)) - Unit is special and doesnt compile
       // cant use util.Arrays.copyOfRange[Unit](repr, from, until) - Unit is special and doesnt compile
       val lo = scala.math.max(from, 0)
-      val res = new Array[Unit](until-lo)
-      System.arraycopy(unsafeArray, lo, res, 0, until-lo)
+      val hi = scala.math.min(until, length)
+      val slicedLenght = hi - lo
+      val res = new Array[Unit](slicedLenght)
       new ofUnit(res)
     }
   }

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -188,11 +188,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofRef[_] => Arrays.equals(unsafeArray.asInstanceOf[Array[AnyRef]], that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[T] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofRef[T] = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        emptyImpl.asInstanceOf[ofRef[T]]
       else
         new ofRef(Arrays.copyOfRange[T](unsafeArray, lo, hi))
     }
@@ -213,7 +213,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofByte(Array.emptyByteArray)
       else
         new ofByte(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -230,11 +230,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Short] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofShort = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofShort(Array.emptyShortArray)
       else
         new ofShort(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -251,11 +251,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Char] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofChar = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofChar(Array.emptyCharArray)
       else
         new ofChar(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -272,11 +272,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Int] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofInt = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofInt(Array.emptyIntArray)
       else
         new ofInt(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -293,11 +293,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Long] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofLong = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofLong(Array.emptyLongArray)
       else
         new ofLong(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -314,11 +314,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Float] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofFloat = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofFloat(Array.emptyFloatArray)
       else
         new ofFloat(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -335,11 +335,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Double] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofDouble = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofDouble(new Array[Double](0))
       else
         new ofDouble(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -356,11 +356,11 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Boolean] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofBoolean = {
       val lo = scala.math.max(from, 0)
       val hi = scala.math.min(until, length)
       if (lo >= hi)
-        emptyImpl
+        new ofBoolean(Array.emptyBooleanArray)
       else
         new ofBoolean(Arrays.copyOfRange(unsafeArray, lo, hi))
     }
@@ -377,7 +377,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _ => super.equals(that)
     }
-    override def slice(from: Int, until: Int): ImmutableArray[Unit] = {
+    override def slice(from: Int, until: Int): ImmutableArray.ofUnit = {
       // cant use
       // new ofUnit(util.Arrays.copyOfRange[Unit](array, from, until)) - Unit is special and doesnt compile
       // cant use util.Arrays.copyOfRange[Unit](repr, from, until) - Unit is special and doesnt compile
@@ -385,10 +385,9 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       val hi = scala.math.min(until, length)
       val slicedLength = hi - lo
       if (slicedLength <= 0)
-        emptyImpl
+        new ofUnit(new Array[Unit](0))
       else {
-        val res = new Array[Unit](slicedLength)
-        new ofUnit(res)
+        new ofUnit(new Array[Unit](slicedLength))
       }
     }
   }

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -11,6 +11,7 @@ import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
 import scala.Predef.intWrapper
 import java.util.Arrays
+import java.lang.System
 
 /**
   * An immutable array.
@@ -103,7 +104,7 @@ sealed abstract class ImmutableArray[+A]
 
   override def dropRight(n: Int): ImmutableArray[A] = ImmutableArray.unsafeWrapArray(new ArrayOps(unsafeArray).dropRight(n))
 
-  override def slice(from: Int, until: Int): ImmutableArray[A] = ImmutableArray.unsafeWrapArray(new ArrayOps(unsafeArray).slice(from, until))
+  override def slice(from: Int, until: Int): ImmutableArray[A]
 
   override def tail: ImmutableArray[A] = ImmutableArray.unsafeWrapArray(new ArrayOps(unsafeArray).tail)
 
@@ -187,6 +188,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofRef[_] => Arrays.equals(unsafeArray.asInstanceOf[Array[AnyRef]], that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
+    override def slice(from: Int, until: Int): ImmutableArray[T] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange[T](unsafeArray, lo, until))
+    }
   }
 
   @SerialVersionUID(3L)
@@ -199,6 +204,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
+    }
+    override def slice(from: Int, until: Int): ImmutableArray[Byte] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
     }
   }
 
@@ -213,6 +222,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def slice(from: Int, until: Int): ImmutableArray[Short] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+    }
   }
 
   @SerialVersionUID(3L)
@@ -225,6 +238,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
+    }
+    override def slice(from: Int, until: Int): ImmutableArray[Char] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
     }
   }
 
@@ -239,6 +256,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def slice(from: Int, until: Int): ImmutableArray[Int] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+    }
   }
 
   @SerialVersionUID(3L)
@@ -251,6 +272,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
+    }
+    override def slice(from: Int, until: Int): ImmutableArray[Long] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
     }
   }
 
@@ -265,6 +290,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def slice(from: Int, until: Int): ImmutableArray[Float] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+    }
   }
 
   @SerialVersionUID(3L)
@@ -277,6 +306,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def equals(that: Any) = that match {
       case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
+    }
+    override def slice(from: Int, until: Int): ImmutableArray[Double] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
     }
   }
 
@@ -291,6 +324,10 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
+    override def slice(from: Int, until: Int): ImmutableArray[Boolean] = {
+      val lo = scala.math.max(from, 0)
+      ImmutableArray.unsafeWrapArray(Arrays.copyOfRange(unsafeArray, lo, until))
+    }
   }
 
   @SerialVersionUID(3L)
@@ -303,6 +340,15 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     override def equals(that: Any) = that match {
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _ => super.equals(that)
+    }
+    override def slice(from: Int, until: Int): ImmutableArray[Unit] = {
+      // cant use
+      // new ofUnit(util.Arrays.copyOfRange[Unit](array, from, until)) - Unit is special and doesnt compile
+      // cant use util.Arrays.copyOfRange[Unit](repr, from, until) - Unit is special and doesnt compile
+      val lo = scala.math.max(from, 0)
+      val res = new Array[Unit](until-lo)
+      System.arraycopy(unsafeArray, lo, res, 0, until-lo)
+      new ofUnit(res)
     }
   }
 }


### PR DESCRIPTION
baseline performance (0a000621122dc58cccee08f41355e3bb940f0852):
```
[info] Benchmark                              (size)  Mode  Cnt        Score         Error  Units
[info] ImmutableArrayBenchmark.access_slice        0  avgt    8       38.393 ±       0.416  ns/op
[info] ImmutableArrayBenchmark.access_slice        1  avgt    8       39.797 ±       0.606  ns/op
[info] ImmutableArrayBenchmark.access_slice        2  avgt    8       38.203 ±       0.261  ns/op
[info] ImmutableArrayBenchmark.access_slice        3  avgt    8       37.194 ±       0.369  ns/op
[info] ImmutableArrayBenchmark.access_slice        4  avgt    8       41.499 ±       0.251  ns/op
[info] ImmutableArrayBenchmark.access_slice        7  avgt    8       40.420 ±       0.485  ns/op
[info] ImmutableArrayBenchmark.access_slice        8  avgt    8       37.346 ±       0.207  ns/op
[info] ImmutableArrayBenchmark.access_slice       15  avgt    8       41.066 ±       0.387  ns/op
[info] ImmutableArrayBenchmark.access_slice       16  avgt    8       38.310 ±       0.326  ns/op
[info] ImmutableArrayBenchmark.access_slice       17  avgt    8       40.797 ±       0.313  ns/op
[info] ImmutableArrayBenchmark.access_slice       39  avgt    8       42.464 ±       0.477  ns/op
[info] ImmutableArrayBenchmark.access_slice      282  avgt    8      107.206 ±       2.077  ns/op
[info] ImmutableArrayBenchmark.access_slice     4096  avgt    8     1483.075 ±      36.826  ns/op
[info] ImmutableArrayBenchmark.access_slice   131070  avgt    8    55750.166 ±    1819.028  ns/op
[info] ImmutableArrayBenchmark.access_slice  7312102  avgt    8  6388168.153 ± 7012236.507  ns/op
```

This PR improvement:
```
[info] Benchmark                              (size)  Mode  Cnt       Score       Error  Units
[info] ImmutableArrayBenchmark.access_slice        0  avgt    8       7.399 ±     0.096  ns/op
[info] ImmutableArrayBenchmark.access_slice        1  avgt    8       6.912 ±     0.084  ns/op
[info] ImmutableArrayBenchmark.access_slice        2  avgt    8       6.996 ±     0.021  ns/op
[info] ImmutableArrayBenchmark.access_slice        3  avgt    8       7.126 ±     0.078  ns/op
[info] ImmutableArrayBenchmark.access_slice        4  avgt    8       7.434 ±     0.028  ns/op
[info] ImmutableArrayBenchmark.access_slice        7  avgt    8       7.713 ±     0.063  ns/op
[info] ImmutableArrayBenchmark.access_slice        8  avgt    8       7.684 ±     0.110  ns/op
[info] ImmutableArrayBenchmark.access_slice       15  avgt    8       8.599 ±     0.100  ns/op
[info] ImmutableArrayBenchmark.access_slice       16  avgt    8       7.867 ±     0.090  ns/op
[info] ImmutableArrayBenchmark.access_slice       17  avgt    8       9.248 ±     0.097  ns/op
[info] ImmutableArrayBenchmark.access_slice       39  avgt    8      11.298 ±     0.548  ns/op
[info] ImmutableArrayBenchmark.access_slice      282  avgt    8      27.505 ±     1.063  ns/op
[info] ImmutableArrayBenchmark.access_slice     4096  avgt    8     310.161 ±    36.247  ns/op
[info] ImmutableArrayBenchmark.access_slice   131070  avgt    8    9640.269 ±   403.856  ns/op
[info] ImmutableArrayBenchmark.access_slice  7312102  avgt    8  676886.167 ± 22375.895  ns/op
```