### PR TITLE
Standardize on .size (but still offer .length)

### DIFF
--- a/collections/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/collections/src/main/scala/strawman/collection/ArrayOps.scala
@@ -33,7 +33,7 @@ class ArrayOps[A](val xs: Array[A]) extends AnyVal
   protected[this] def coll: Array[A] = xs
   override def toSeq: immutable.Seq[A] = fromIterable(toIterable)
 
-  def length = xs.length
+  protected def finiteSize = xs.length
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int) = xs.apply(i)
 

--- a/collections/src/main/scala/strawman/collection/IndexedSeq.scala
+++ b/collections/src/main/scala/strawman/collection/IndexedSeq.scala
@@ -13,12 +13,16 @@ trait IndexedSeq[+A] extends Seq[A] with IndexedSeqOps[A, IndexedSeq, IndexedSeq
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
 /** Base trait for indexed Seq operations */
-trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, CC, C] { self =>
+trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, CC, C] with ArrayLike[A] { self =>
 
   def iterator(): Iterator[A] = view.iterator()
 
+  final override def size: Int = finiteSize
+
+  final override def knownSize: Int = finiteSize
+
   override def reverseIterator(): Iterator[A] = new AbstractIterator[A] {
-    private var i = self.length
+    private var i = self.size
     def hasNext: Boolean = 0 < i
     def next(): A =
       if (0 < i) {
@@ -28,7 +32,7 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
   }
 
   override def view: IndexedView[A] = new IndexedView[A] {
-    def length: Int = self.length
+    protected def finiteSize: Int = self.size
     def apply(i: Int): A = self(i)
   }
 
@@ -41,9 +45,7 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
     * linear, immutable collections this should avoid making a copy. */
   override def dropRight(n: Int): C = fromSpecificIterable(view.dropRight(n))
 
-  override def lengthCompare(len: Int): Int = length - len
-
-  final override def knownSize: Int = length
+  override def lengthCompare(len: Int): Int = size - len
 
   override def search[B >: A](elem: B)(implicit ord: Ordering[B]): SearchResult =
     binarySearch(elem, 0, length)(ord)

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -272,10 +272,10 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
         val res = takeDestructively(count)
         // was: extra checks so we don't calculate length unless there's reason
         // but since we took the group eagerly, just use the fast length
-        val shortBy = count - res.length
+        val shortBy = count - res.size
         if (shortBy > 0 && pad.isDefined) res ++ padding(shortBy) else res
       }
-      lazy val len = xs.length
+      lazy val len = xs.size
       lazy val incomplete = len < count
 
       // if 0 elements are requested, or if the number of newly obtained
@@ -1147,7 +1147,7 @@ object Iterator {
   }
 
   def apply[A](xs: A*): Iterator[A] = new IndexedView[A] {
-    val length = xs.length
+    protected def finiteSize = xs.size
     def apply(n: Int) = xs(n)
   }.iterator()
 

--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -25,7 +25,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     def next() = { val r = current.head; current = current.tail; r }
   }
 
-  def length: Int = {
+  override def size: Int = {
     var these = toIterable
     var len = 0
     while (!these.isEmpty) {

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -82,13 +82,33 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
   * @define Coll `Seq`
   */
 trait SeqOps[+A, +CC[_], +C] extends Any
-  with IterableOps[A, CC, C]
-  with ArrayLike[A] {
+  with IterableOps[A, CC, C] {
 
   /**
     * @return This collection as a `Seq[A]`. This is equivalent to `to(Seq)` but might be faster.
     */
   def toSeq: Seq[A]
+
+  /** Selects an element by its index in the $coll.
+    *
+    * Example:
+    *
+    * {{{
+    *    scala> val x = List(1, 2, 3, 4, 5)
+    *    x: List[Int] = List(1, 2, 3, 4, 5)
+    *
+    *    scala> x(3)
+    *    res1: Int = 4
+    * }}}
+    *
+    *  @param  idx  The index to select.
+    *  @return the element of this $coll at index `idx`, where `0` indicates the first element.
+    *  @throws IndexOutOfBoundsException if `idx` does not satisfy `0 <= idx < length`.
+    */
+  def apply(idx: Int): A
+
+  /** Alias for `size` */
+  @`inline` final def length: Int = size
 
   /** A copy of the $coll with an element prepended.
     *
@@ -186,8 +206,6 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   // overrides of this method
   @`inline` final override def concat[B >: A](suffix: Iterable[B]): CC[B] = appendedAll(suffix)
 
-  final override def size: Int = length
-
   /** Selects all the elements of this $coll ignoring the duplicates.
     *
     * @return a new $coll consisting of all the elements of this $coll without duplicates.
@@ -247,7 +265,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
     */
   def endsWith[B >: A](that: Iterable[B]): Boolean = {
-    val i = iterator().drop(length - that.size)
+    val i = iterator().drop(size - that.size)
     val j = that.iterator()
     while (i.hasNext && j.hasNext)
       if (i.next() != j.next())
@@ -264,7 +282,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * @param    idx     the index to test
     * @return   `true` if this $coll contains an element at position `idx`, `false` otherwise.
     */
-  def isDefinedAt(idx: Int): Boolean = (idx >= 0) && (idx < length)
+  def isDefinedAt(idx: Int): Boolean = (idx >= 0) && (idx < size)
 
   /** A copy of this $coll with an element value appended until a given target length is reached.
    *
@@ -334,7 +352,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @return  the index `<= end` of the last element of this $coll that is equal (as determined by `==`)
     *           to `elem`, or `-1`, if none exists.
     */
-  def lastIndexOf[B >: A](elem: B, end: Int = length - 1): Int = lastIndexWhere(elem == _, end)
+  def lastIndexOf[B >: A](elem: B, end: Int = size - 1): Int = lastIndexWhere(elem == _, end)
 
   /** Finds index of last element satisfying some predicate before or at given end index.
     *
@@ -342,8 +360,8 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @return  the index `<= end` of the last element of this $coll that satisfies the predicate `p`,
     *           or `-1`, if none exists.
     */
-  def lastIndexWhere(p: A => Boolean, end: Int = length - 1): Int = {
-    var i = length - 1
+  def lastIndexWhere(p: A => Boolean, end: Int = size - 1): Int = {
+    var i = size - 1
     val it = reverseIterator()
     while (it.hasNext && { val elem = it.next(); (i > end || !p(elem)) }) i -= 1
     i
@@ -387,9 +405,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return  the last index `<= end` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` of no such subsequence exists.
    */
-  def lastIndexOfSlice[B >: A](that: Seq[B], end: Int = length - 1): Int = {
-    val l = length
-    val tl = that.length
+  def lastIndexOfSlice[B >: A](that: Seq[B], end: Int = size - 1): Int = {
+    val l = size
+    val tl = that.size
     val clippedL = math.min(l-tl, end)
 
     if (end < 0) -1
@@ -495,7 +513,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   private class CombinationsItr(n: Int) extends Iterator[C] {
     // generating all nums such that:
-    // (1) nums(0) + .. + nums(length-1) = n
+    // (1) nums(0) + .. + nums(size-1) = n
     // (2) 0 <= nums(i) <= cnts(i), where 0 <= i <= cnts.length-1
     private val (elms, cnts, nums) = init()
     private val offs = cnts.scanLeft(0)(_ + _)
@@ -574,7 +592,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *              sorted according to the ordering `ord`.
     */
   def sorted[B >: A](implicit ord: Ordering[B]): C = {
-    val len = this.length
+    val len = this.size
     val b = newSpecificBuilder()
     if (len == 1) b ++= toIterable
     else if (len > 1) {
@@ -629,7 +647,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  @example {{{
     *    val words = "The quick brown fox jumped over the lazy dog".split(' ')
     *    // this works because scala.Ordering will implicitly provide an Ordering[Tuple2[Int, Char]]
-    *    words.sortBy(x => (x.length, x.head))
+    *    words.sortBy(x => (x.size, x.head))
     *    res0: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
     *  }}}
     */
@@ -639,20 +657,20 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *
     *  @return  a `Range` value from `0` to one less than the length of this $coll.
     */
-  def indices: Range = Range(0, length)
+  def indices: Range = Range(0, size)
 
   /** Compares the length of this $coll to a test value.
     *
     *   @param   len   the test value that gets compared with the length.
     *   @return  A value `x` where
     *   {{{
-    *        x <  0       if this.length <  len
-    *        x == 0       if this.length == len
-    *        x >  0       if this.length >  len
+    *        x <  0       if this.size <  len
+    *        x == 0       if this.size == len
+    *        x >  0       if this.size >  len
     *   }}}
-    *  The method as implemented here does not call `length` directly; its running time
-    *  is `O(length min len)` instead of `O(length)`. The method should be overwritten
-    *  if computing `length` is cheap.
+    *  The method as implemented here does not call `size` directly; its running time
+    *  is `O(size min len)` instead of `O(size)`. The method should be overwritten
+    *  if computing `size` is cheap.
     */
   def lengthCompare(len: Int): Int = {
     if (len < 0) 1
@@ -928,13 +946,13 @@ object SeqOps {
   private def kmpOptimizeWord[B](W: Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedView[B] = W match {
     case iso: IndexedSeq[B] =>
       // Already optimized for indexing--use original (or custom view of original)
-      if (forward && n0==0 && n1==W.length) iso.view
+      if (forward && n0==0 && n1==W.size) iso.view
       else if (forward) new IndexedView[B] {
-        val length = n1 - n0
+        protected val finiteSize = n1 - n0
         def apply(x: Int) = iso(n0 + x)
       }
       else new IndexedView[B] {
-        def length = n1 - n0
+        protected val finiteSize = n1 - n0
         def apply(x: Int) = iso(n1 - 1 - x)
       }
     case _ =>
@@ -951,7 +969,7 @@ object SeqOps {
           i += delta
         }
 
-        val length = n1 - n0
+        protected val finiteSize = n1 - n0
         def apply(x: Int) = Warr(x).asInstanceOf[B]
       }
   }

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -43,7 +43,7 @@ final class StringOps(val s: String)
 
   protected[this] def newSpecificBuilder() = new StringBuilder
 
-  def length = s.length
+  protected def finiteSize = s.length
 
   @throws[StringIndexOutOfBoundsException]
   def apply(i: Int) = s.charAt(i)
@@ -153,7 +153,7 @@ final class StringOps(val s: String)
 
   override def slice(from: Int, until: Int): String = {
     val start = from max 0
-    val end   = until min length
+    val end   = until min finiteSize
 
     if (start >= end) newSpecificBuilder().result()
     else (newSpecificBuilder() ++= toString.substring(start, end)).result()
@@ -456,7 +456,7 @@ final class StringOps(val s: String)
 }
 
 case class StringView(s: String) extends IndexedView[Char] {
-  def length = s.length
+  protected def finiteSize = s.length
   @throws[StringIndexOutOfBoundsException]
   def apply(n: Int) = s.charAt(n)
   override def className = "StringView"

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -89,7 +89,7 @@ private[collection] trait Wrappers {
   }
 
   case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with SeqOps[A, mutable.Buffer, mutable.Buffer[A]] {
-    def length = underlying.size
+    override def size = underlying.size
     override def isEmpty = underlying.isEmpty
     override def iterator(): Iterator[A] = underlying.iterator().asScala
     def apply(i: Int) = underlying.get(i)

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -91,7 +91,7 @@ sealed abstract class ImmutableArray[+A]
   override def zip[B](that: collection.Iterable[B]): ImmutableArray[(A, B)] =
     that match {
       case bs: ImmutableArray[B] =>
-        ImmutableArray.tabulate(length min bs.length) { i =>
+        ImmutableArray.tabulate(finiteSize min bs.finiteSize) { i =>
           (apply(i), bs(i))
         }
       case _ =>
@@ -181,7 +181,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ImmutableArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](unsafeArray.getClass.getComponentType)
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): T = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -193,7 +193,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofByte(val unsafeArray: Array[Byte]) extends ImmutableArray[Byte] with Serializable {
     protected[this] def elemTag = ClassTag.Byte
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Byte = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -205,7 +205,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofShort(val unsafeArray: Array[Short]) extends ImmutableArray[Short] with Serializable {
     protected[this] def elemTag = ClassTag.Short
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Short = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -217,7 +217,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofChar(val unsafeArray: Array[Char]) extends ImmutableArray[Char] with Serializable {
     protected[this] def elemTag = ClassTag.Char
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Char = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -229,7 +229,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofInt(val unsafeArray: Array[Int]) extends ImmutableArray[Int] with Serializable {
     protected[this] def elemTag = ClassTag.Int
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Int = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -241,7 +241,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofLong(val unsafeArray: Array[Long]) extends ImmutableArray[Long] with Serializable {
     protected[this] def elemTag = ClassTag.Long
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Long = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -253,7 +253,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofFloat(val unsafeArray: Array[Float]) extends ImmutableArray[Float] with Serializable {
     protected[this] def elemTag = ClassTag.Float
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Float = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -265,7 +265,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofDouble(val unsafeArray: Array[Double]) extends ImmutableArray[Double] with Serializable {
     protected[this] def elemTag = ClassTag.Double
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Double = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -277,7 +277,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ImmutableArray[Boolean] with Serializable {
     protected[this] def elemTag = ClassTag.Boolean
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Boolean = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -289,7 +289,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofUnit(val unsafeArray: Array[Unit]) extends ImmutableArray[Unit] with Serializable {
     protected[this] def elemTag = ClassTag.Unit
-    def length: Int = unsafeArray.length
+    protected def finiteSize: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Unit = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)

--- a/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -72,11 +72,11 @@ sealed class NumericRange[T](
   import num._
 
   // See comment in Range for why this must be lazy.
-  override lazy val length: Int = NumericRange.count(start, end, step, isInclusive)
-  override def isEmpty = length == 0
+  override protected lazy val finiteSize: Int = NumericRange.count(start, end, step, isInclusive)
+  override def isEmpty = finiteSize == 0
   override def last: T =
-    if (length == 0) Nil.head
-    else locationAfterN(length - 1)
+    if (finiteSize == 0) Nil.head
+    else locationAfterN(finiteSize - 1)
   override def init: NumericRange[T] =
     if (isEmpty) Nil.init
     else new NumericRange(start, end - step, step, isInclusive)
@@ -100,14 +100,14 @@ sealed class NumericRange[T](
 
   @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
-    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    if (idx < 0 || idx >= finiteSize) throw new IndexOutOfBoundsException(idx.toString)
     else locationAfterN(idx)
   }
 
   override def foreach[@specialized(Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
-    while (count < length) {
+    while (count < finiteSize) {
       f(current)
       current += step
       count += 1
@@ -135,14 +135,14 @@ sealed class NumericRange[T](
   private def newEmptyRange(value: T) = NumericRange(value, value, step)
 
   override def take(n: Int): NumericRange[T] = {
-    if (n <= 0 || length == 0) newEmptyRange(start)
-    else if (n >= length) this
+    if (n <= 0 || finiteSize == 0) newEmptyRange(start)
+    else if (n >= finiteSize) this
     else new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
   }
 
   override def drop(n: Int): NumericRange[T] = {
-    if (n <= 0 || length == 0) this
-    else if (n >= length) newEmptyRange(end)
+    if (n <= 0 || finiteSize == 0) this
+    else if (n >= finiteSize) newEmptyRange(end)
     else copy(locationAfterN(n), end, step)
   }
 
@@ -276,7 +276,7 @@ sealed class NumericRange[T](
           var acc = num.zero
           var i = head
           var idx = 0
-          while(idx < length) {
+          while(idx < finiteSize) {
             acc = num.plus(acc, i)
             i = i + step
             idx = idx + 1
@@ -290,8 +290,8 @@ sealed class NumericRange[T](
   override lazy val hashCode: Int = super.hashCode()
   override def equals(other: Any): Boolean = other match {
     case x: NumericRange[_] =>
-      (x canEqual this) && (length == x.length) && (
-        (length == 0) ||                      // all empty sequences are equal
+      (x canEqual this) && (finiteSize == x.finiteSize) && (
+        (finiteSize == 0) ||                      // all empty sequences are equal
           (start == x.start && last == x.last)  // same length and same endpoints implies equality
         )
     case _ =>
@@ -340,8 +340,8 @@ object NumericRange {
           val stepint = num.toInt(step)
           if (step == num.fromInt(stepint)) {
             return {
-              if (isInclusive) Range.inclusive(startint, endint, stepint).length
-              else             Range          (startint, endint, stepint).length
+              if (isInclusive) Range.inclusive(startint, endint, stepint).size
+              else             Range          (startint, endint, stepint).size
             }
           }
         }

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -89,7 +89,7 @@ sealed abstract class Range(
     }
   }
 
-  def length = if (numRangeElements < 0) fail() else numRangeElements
+  protected def finiteSize: Int = if (numRangeElements < 0) fail() else numRangeElements
 
   // This field has a sensible value only for non-empty ranges
   private val lastElement = step match {

--- a/collections/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -170,7 +170,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
     if (subIter ne null) {
       val buff = ArrayBuffer.empty.++=(subIter)
       subIter = null
-      ((buff.iterator(), buff.length), this)
+      ((buff.iterator(), buff.size), this)
     }
     else {
       // otherwise find the topmost array stack element

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -78,9 +78,9 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 
   private[immutable] var dirty = false
 
-  def length: Int = endIndex - startIndex
+  protected def finiteSize: Int = endIndex - startIndex
 
-  override def lengthCompare(len: Int): Int = length - len
+  override def lengthCompare(len: Int): Int = finiteSize - len
 
   private[collection] def initIterator[B >: A](s: VectorIterator[B]): Unit = {
     s.initFrom(this)
@@ -163,7 +163,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 
   override def last: A = {
     if (isEmpty) throw new UnsupportedOperationException("empty.last")
-    apply(length - 1)
+    apply(finiteSize - 1)
   }
 
   override def init: Vector[A] = {

--- a/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
@@ -36,7 +36,7 @@ final class WrappedString(val self: String) extends AbstractSeq[Char] with Index
     val end = if (until > length) length else until
     new WrappedString(self.substring(start, end))
   }
-  override def length = self.length
+  def finiteSize = self.length
   override def toString = self
   override def view: StringView = new StringView(self)
 }

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -65,7 +65,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
 
   def update(n: Int, elem: A): Unit = array(n) = elem.asInstanceOf[AnyRef]
 
-  def length = end
+  protected def finiteSize = end
 
   override def view: ArrayBufferView[A] = new ArrayBufferView(array, end)
 
@@ -95,9 +95,9 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
   override def addAll(elems: IterableOnce[A]): this.type = {
     elems match {
       case elems: ArrayBuffer[_] =>
-        ensureSize(length + elems.length)
-        Array.copy(elems.array, 0, array, length, elems.length)
-        end = length + elems.length
+        ensureSize(size + elems.size)
+        Array.copy(elems.array, 0, array, size, elems.size)
+        end = size + elems.size
       case _ => super.addAll(elems)
     }
     this
@@ -121,7 +121,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
     elems match {
       case elems: collection.Iterable[A] =>
         val elemsLength = elems.size
-        ensureSize(length + elemsLength)
+        ensureSize(size + elemsLength)
         Array.copy(array, idx, array, idx + elemsLength, end - idx)
         end = end + elemsLength
         elems match {
@@ -189,7 +189,7 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }
 
-class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {
+class ArrayBufferView[A](val array: Array[AnyRef], protected val finiteSize: Int) extends IndexedView[A] {
   @throws[ArrayIndexOutOfBoundsException]
   def apply(n: Int) = array(n).asInstanceOf[A]
   override def className = "ArrayBufferView"

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
@@ -89,9 +89,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[T]): this.type = (xs.asInstanceOf[AnyRef]) match {
       case xs: ImmutableArray.ofRef[_] =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -138,9 +138,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Byte]): this.type = xs match {
       case xs: ImmutableArray.ofByte =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -187,9 +187,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Short]): this.type = xs match {
       case xs: ImmutableArray.ofShort =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -236,9 +236,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Char]): this.type = xs match {
       case xs: ImmutableArray.ofChar =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -285,9 +285,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Int]): this.type = xs match {
       case xs: ImmutableArray.ofInt =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -334,9 +334,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Long]): this.type = xs match {
       case xs: ImmutableArray.ofLong =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -383,9 +383,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Float]): this.type = xs match {
       case xs: ImmutableArray.ofFloat =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -432,9 +432,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Double]): this.type = xs match {
       case xs: ImmutableArray.ofDouble =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)
@@ -481,9 +481,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Boolean]): this.type = xs match {
       case xs: ImmutableArray.ofBoolean =>
-        ensureSize(this.size + xs.length)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
-        size += xs.length
+        ensureSize(this.size + xs.size)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
+        size += xs.size
         this
       case _ =>
         super.addAll(xs)

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -110,7 +110,7 @@ trait Buffer[A]
     if (idx < 0) this else takeInPlace(idx)
   }
   def padToInPlace(len: Int, elem: A): this.type = {
-    while (length < len) +=(elem)
+    while (size < len) +=(elem)
     this
   }
 }
@@ -145,10 +145,10 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
-    val n = patch.length min replaced
+    val n = patch.size min replaced
     var i = 0
     while (i < n) { update(from + i, patch(i)); i += 1 }
-    if (i < patch.length) insertAll(from + i, patch.iterator().drop(i))
+    if (i < patch.size) insertAll(from + i, patch.iterator().drop(i))
     else if (i < replaced) remove(from + i, replaced - i)
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -92,8 +92,7 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Cha
   protected[this] def newSpecificBuilder(): strawman.collection.mutable.Builder[Char, IndexedSeq[Char]] =
     iterableFactory.newBuilder()
 
-  //TODO In the old collections, StringBuilder extends Seq -- should it do the same here to get this method?
-  def length: Int = sb.length()
+  protected def finiteSize: Int = sb.length()
 
   def addOne(x: Char) = { sb.append(x); this }
 

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -54,7 +54,7 @@ class ListBuffer[A]
   @throws[IndexOutOfBoundsException]
   def apply(i: Int) = first.apply(i)
 
-  def length = len
+  override def size = len
   override def knownSize = len
 
   override def isEmpty: Boolean = len == 0
@@ -274,7 +274,7 @@ class ListBuffer[A]
   def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
     ensureUnaliased()
     val p = locate(from)
-    removeAfter(p, replaced `min` (length - from))
+    removeAfter(p, replaced `min` (len - from))
     insertAfter(p, patch.iterator())
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -150,7 +150,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 
   def result() = this
 
-  def length = sz
+  override def size: Int = sz
 
   def apply(idx: Int) =
     if (idx >= 0 && idx < sz) headptr(idx)

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -114,7 +114,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](array.getClass.getComponentType)
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): T = array(index).asInstanceOf[T]
     def update(index: Int, elem: T): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -126,7 +126,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {
     def elemTag = ClassTag.Byte
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Byte = array(index)
     def update(index: Int, elem: Byte): Unit = { array(index) = elem }
     override def hashCode = wrappedBytesHash(array)
@@ -138,7 +138,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofShort(val array: Array[Short]) extends WrappedArray[Short] with Serializable {
     def elemTag = ClassTag.Short
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Short = array(index)
     def update(index: Int, elem: Short): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -150,7 +150,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofChar(val array: Array[Char]) extends WrappedArray[Char] with Serializable {
     def elemTag = ClassTag.Char
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Char = array(index)
     def update(index: Int, elem: Char): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -162,7 +162,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofInt(val array: Array[Int]) extends WrappedArray[Int] with Serializable {
     def elemTag = ClassTag.Int
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Int = array(index)
     def update(index: Int, elem: Int): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -174,7 +174,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofLong(val array: Array[Long]) extends WrappedArray[Long] with Serializable {
     def elemTag = ClassTag.Long
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Long = array(index)
     def update(index: Int, elem: Long): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -186,7 +186,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofFloat(val array: Array[Float]) extends WrappedArray[Float] with Serializable {
     def elemTag = ClassTag.Float
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Float = array(index)
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -198,7 +198,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofDouble(val array: Array[Double]) extends WrappedArray[Double] with Serializable {
     def elemTag = ClassTag.Double
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Double = array(index)
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -210,7 +210,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofBoolean(val array: Array[Boolean]) extends WrappedArray[Boolean] with Serializable {
     def elemTag = ClassTag.Boolean
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Boolean = array(index)
     def update(index: Int, elem: Boolean): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -222,7 +222,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofUnit(val array: Array[Unit]) extends WrappedArray[Unit] with Serializable {
     def elemTag = ClassTag.Unit
-    def length: Int = array.length
+    protected def finiteSize: Int = array.length
     def apply(index: Int): Unit = array(index)
     def update(index: Int, elem: Unit): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)


### PR DESCRIPTION
Fixes #147.

The idea is to offer to users only one way to get the size of a collection: the `size` operation. Therefore, `length` is deprecated and `final` (it just calls `size`).

That being said, I found it convenient for indexed collections to have an abstract method giving the size so that implementors *have to* implement it instead of having to *remember* of overriding the `size` operation (whose default implementation is O(n)). Previously, indexed collections were using the `length` method in that way. I replaced it with a protected `finiteSize` method.