### PR TITLE
Add deprecated CanBuildFrom alias to BuildFrom

### DIFF
--- a/collections/src/main/scala/strawman/collection/generic/package.scala
+++ b/collections/src/main/scala/strawman/collection/generic/package.scala
@@ -5,4 +5,6 @@ import scala.deprecated
 package object generic {
   @deprecated("Clearable was moved from collection.generic to collection.mutable", "2.13.0")
   type Clearable = strawman.collection.mutable.Clearable
+  @deprecated("Use scala.collection.BuildFrom instead", "2.13.0")
+  type CanBuildFrom[-From, -A, +C] = strawman.collection.BuildFrom[From, A, C]
 }


### PR DESCRIPTION
That would allow a small subset of existing code to be source compatible with the new collections.

Typically, the following will cross compile:

~~~ scala
def foo[F[_], A, T](from: F[A])(implicit cbf: CanBuildFrom[F[A], A, T]) = {
  val builder = cbf(from)
  …
  builder.result
}
~~~

(Unfortunately, my guess is that most usages of `CanBuildFrom` will require adaptation, but at least that one would be compatible…)