### PR TITLE
Add collection.BitSet factory object (and other cross-compatibility improvements)

### DIFF
--- a/collections/src/main/scala/strawman/collection/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/BitSet.scala
@@ -1,7 +1,9 @@
 package strawman
 package collection
 
-import scala.{Array, Boolean, `inline`, Int, Long, Option, Ordering, Unit}
+import strawman.collection.mutable.Builder
+
+import scala.{Array, Boolean, Int, Long, Option, Ordering, Unit, `inline`}
 import scala.Predef.{assert, intWrapper}
 
 /** Base type of bitsets.
@@ -17,6 +19,12 @@ import scala.Predef.{assert, intWrapper}
   * @define Coll `BitSet`
   */
 trait BitSet extends SortedSet[Int] with BitSetOps[BitSet]
+
+object BitSet extends SpecificIterableFactory[Int, BitSet] {
+  def empty: BitSet = immutable.BitSet.empty
+  def newBuilder(): Builder[Int, BitSet] = immutable.BitSet.newBuilder()
+  def fromSpecific(it: IterableOnce[Int]): BitSet = immutable.BitSet.fromSpecific(it)
+}
 
 /** Base implementation type of bitsets */
 trait BitSetOps[+C <: BitSet with BitSetOps[C]]

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -138,6 +138,15 @@ final class StringOps(val s: String)
   def patch(from: Int, other: String, replaced: Int): String =
     fromSpecificIterable(new View.Patched(toIterable, from, other, replaced)) //TODO optimize
 
+  /** A copy of this string with one single replaced element.
+    *  @param  index  the position of the replacement
+    *  @param  elem   the replacing element
+    *  @return a new string which is a copy of this string with the element at position `index` replaced by `elem`.
+    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
+    */
+  def updated(index: Int, elem: Char): String =
+    fromSpecificIterable(View.Updated(toIterable, index, elem)) // TODO optimize
+
   override def toString = s
 
   override def mkString = toString

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.mutable.{ArrayBuffer, Builder}
 
-import scala.{Any, AnyRef, Boolean, Int, None, NoSuchElementException, noinline, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException}
+import scala.{Any, AnyRef, Boolean, Int, None, NoSuchElementException, noinline, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, deprecated}
 import scala.Predef.String
 import scala.annotation.tailrec
 
@@ -205,6 +205,9 @@ sealed abstract class LazyList[+A]
     */
   def lazyAppendAll[B >: A](suffix: => collection.IterableOnce[B]): LazyList[B] =
     if (isEmpty) LazyList.fromIterator(suffix.iterator()) else LazyList.cons(head, tail.lazyAppendAll(suffix))
+
+  @deprecated("append has been renamed to lazyAppendAll", "2.13.0")
+  def append[B >: A](rest: => collection.IterableOnce[B]): LazyList[B] = lazyAppendAll(rest)
 
   override def className = "LazyList"
 


### PR DESCRIPTION
I’ve started with the `collection.BitSet` object and then found a couple other issues. I’ve added commits that address them.

In summary, this PR:

- Adds the `collection.BitSet` object (like in the current collections),
- Adds an overload for the `updated` operation on `StringOps`,
- Pulls up the `fill` and `tabulate` operations from `SeqFactory` to `IterableFactoryLike`. The `fill` method makes no sense on `Set` collections but … we have it in 2.12, so it’s simpler to just keep it…
- Adds an `append` alias for the `lazyAppendAll` in `LazyList`.