### PR TITLE
Generalize LazyList to allow implementation of Stream

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -7,6 +7,7 @@ import strawman.collection.mutable.{ArrayBuffer, Builder}
 import scala.{Any, AnyRef, Boolean, Int, None, NoSuchElementException, noinline, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, deprecated}
 import scala.Predef.String
 import scala.annotation.tailrec
+import scala.annotation.unchecked.uncheckedVariance
 
 /**  The class `LazyList` implements lazy lists where elements
   *  are only evaluated when they are needed. Here is an example:
@@ -182,52 +183,15 @@ import scala.annotation.tailrec
   *  @define orderDependent
   *  @define orderDependentFold
   */
-sealed abstract class LazyList[+A]
-  extends LinearSeq[A]
-     with LinearSeqOps[A, LazyList, LazyList[A]] {
-
-  /** Force the evaluation of both the head and the tail of this `LazyList` */
-  def force: LazyList.Evaluated[A]
-
-  override def nonEmpty: Boolean = !isEmpty
-
-  def iterableFactory: SeqFactory[LazyList] = LazyList
+sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, LazyList, LazyList[A]] {
+  def iterableFactory: LazyListFactory[LazyList] = LazyList
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
 
   protected[this] def newSpecificBuilder(): Builder[A, LazyList[A]] =
     IndexedSeq.newBuilder().mapResult(_.to(LazyList))
 
-  /** The stream resulting from the concatenation of this stream with the argument stream.
-    *
-    * @param suffix The collection that gets appended to this lazy list
-    * @return The lazy list containing elements of this lazy list and the iterable object.
-    */
-  def lazyAppendAll[B >: A](suffix: => collection.IterableOnce[B]): LazyList[B] =
-    if (isEmpty) LazyList.fromIterator(suffix.iterator()) else LazyList.cons(head, tail.lazyAppendAll(suffix))
-
-  @deprecated("append has been renamed to lazyAppendAll", "2.13.0")
-  def append[B >: A](rest: => collection.IterableOnce[B]): LazyList[B] = lazyAppendAll(rest)
-
-  override def className = "LazyList"
-
-  override def equals(that: Any): Boolean =
-    if (this eq that.asInstanceOf[AnyRef]) true else super.equals(that)
-
-  override def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
-    @tailrec def lazyListEq(a: LazyList[_], b: LazyList[_]): Boolean =
-      if (a eq b) true else {
-        (a.force, b.force) match {
-          case (Some((ah, at)), Some((bh, bt))) => (ah == bh) && lazyListEq(at, bt)
-          case (None, None) => true
-          case _ => false
-        }
-      }
-    that match {
-      case that: LazyList[_] => lazyListEq(this, that)
-      case _ => super.sameElements(that)
-    }
-  }
+  protected[this] def cons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
 
   /** Apply the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
@@ -261,10 +225,52 @@ sealed abstract class LazyList[+A]
     if (this.isEmpty) z
     else tail.foldLeft(op(z, head))(op)
   }
+}
 
-  override def scanLeft[B](z: B)(op: (B, A) => B): LazyList[B] =
-    if (isEmpty) z +: LazyList.empty
-    else LazyList.cons(z, tail.scanLeft(op(z, head))(op))
+sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]], +C <: CC[A]] extends LinearSeqOps[A, CC, C] {
+
+  def iterableFactory: LazyListFactory[CC]
+
+  def tail: C
+
+  protected[this] def cons[T](hd: => T, tl: => CC[T]): CC[T]
+
+  /** Force the evaluation of both the head and the tail of this `LazyList` */
+  def force: Option[(A, CC[A])]
+
+  override def nonEmpty: Boolean = !isEmpty
+
+  /** The stream resulting from the concatenation of this stream with the argument stream.
+    *
+    * @param suffix The collection that gets appended to this lazy list
+    * @return The lazy list containing elements of this lazy list and the iterable object.
+    */
+  def lazyAppendAll[B >: A](suffix: => collection.IterableOnce[B]): CC[B] =
+    if (isEmpty) iterableFactory.from(suffix.iterator()) else cons[B](head, tail.lazyAppendAll(suffix))
+
+  override def className = "LazyList"
+
+  override def equals(that: Any): Boolean =
+    if (this eq that.asInstanceOf[AnyRef]) true else super.equals(that)
+
+  override def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
+    @tailrec def lazyListEq(a: CC[_], b: CC[_]): Boolean =
+      if (a eq b) true else {
+        (a.force, b.force) match {
+          case (Some((ah, at)), Some((bh, bt))) => (ah == bh) && lazyListEq(at, bt)
+          case (None, None) => true
+          case _ => false
+        }
+      }
+    that match {
+      case that: LazyListOps[_, _, _] => lazyListEq(coll, that.asInstanceOf[CC[_]])
+      case _ => super.sameElements(that)
+    }
+  }
+
+  override def scanLeft[B](z: B)(op: (B, A) => B): CC[B] =
+    if (isEmpty) z +: iterableFactory.empty
+    else cons(z, tail.scanLeft(op(z, head))(op))
 
   /** LazyList specialization of reduceLeft which allows GC to collect
     *  along the way.
@@ -277,7 +283,7 @@ sealed abstract class LazyList[+A]
     if (this.isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
     else {
       var reducedRes: B = this.head
-      var left = this.tail
+      var left: CC[A] = this.tail
       while (!left.isEmpty) {
         reducedRes = f(reducedRes, left.head)
         left = left.tail
@@ -286,38 +292,38 @@ sealed abstract class LazyList[+A]
     }
   }
 
-  override def partition(p: A => Boolean): (LazyList[A], LazyList[A]) = (filter(p(_)), filterNot(p(_)))
+  override def partition(p: A => Boolean): (C, C) = (filter(p(_)), filterNot(p(_)))
 
-  override def filter(pred: A => Boolean): LazyList[A] = filterImpl(pred, isFlipped = false)
+  override def filter(pred: A => Boolean): C = filterImpl(pred, isFlipped = false)
 
-  override def filterNot(pred: A => Boolean): LazyList[A] = filterImpl(pred, isFlipped = true)
+  override def filterNot(pred: A => Boolean): C = filterImpl(pred, isFlipped = true)
 
-  private[immutable] def filterImpl(p: A => Boolean, isFlipped: Boolean): LazyList[A] = {
+  private[immutable] def filterImpl(p: A => Boolean, isFlipped: Boolean): C = {
     // optimization: drop leading prefix of elems for which f returns false
     // var rest = this dropWhile (!p(_)) - forget DRY principle - GC can't collect otherwise
-    var rest = this
+    var rest: CC[A] = coll
     while (rest.nonEmpty && p(rest.head) == isFlipped) rest = rest.tail
     // private utility func to avoid `this` on stack (would be needed for the lazy arg)
-    if (rest.nonEmpty) LazyList.filteredTail(rest, p, isFlipped)
-    else LazyList.Empty
+    (if (rest.nonEmpty) iterableFactory.filteredTail(rest, p, isFlipped)
+    else iterableFactory.empty).asInstanceOf[C]
   }
 
   /** A FilterMonadic which allows GC of the head of stream during processing */
   @noinline // Workaround scala/bug#9137, see https://github.com/scala/scala/pull/4284#issuecomment-73180791
-  override final def withFilter(p: A => Boolean): collection.WithFilter[A, LazyList] =
-    new LazyList.WithFilter(this, p)
+  override final def withFilter(p: A => Boolean): collection.WithFilter[A, CC] =
+  iterableFactory.withFilter(coll, p)
 
-  override final def prepended[B >: A](elem: B): LazyList[B] = LazyList.cons(elem, this)
+  override final def prepended[B >: A](elem: B): CC[B] = cons(elem, coll)
 
-  override final def map[B](f: A => B): LazyList[B] =
-    if (isEmpty) LazyList.empty
-    else LazyList.cons(f(head), tail.map(f))
+  override final def map[B](f: A => B): CC[B] =
+    if (isEmpty) iterableFactory.empty
+    else cons(f(head), tail.map(f))
 
-  override final def collect[B](pf: PartialFunction[A, B]): LazyList[B] = {
+  override final def collect[B](pf: PartialFunction[A, B]): CC[B] = {
     // this implementation avoids:
     // 1) stackoverflows (could be achieved with tailrec, too)
     // 2) out of memory errors for big lazy lists (`this` reference can be eliminated from the stack)
-    var rest: LazyList[A] = this
+    var rest: CC[A] = coll
 
     // Avoids calling both `pf.isDefined` and `pf.apply`.
     var newHead: B = null.asInstanceOf[B]
@@ -327,34 +333,115 @@ sealed abstract class LazyList[+A]
 
     //  without the call to the companion object, a thunk is created for the tail of the new lazy list,
     //  and the closure of the thunk will reference `this`
-    if (rest.isEmpty) LazyList.Empty
-    else LazyList.collectedTail(newHead, rest, pf)
+    if (rest.isEmpty) iterableFactory.empty
+    else iterableFactory.collectedTail(newHead, rest, pf)
   }
 
   // optimisations are not for speed, but for functionality
   // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)
-  override final def flatMap[B](f: A => IterableOnce[B]): LazyList[B] =
-    if (isEmpty) LazyList.Empty
-    else {
-      // establish !prefix.isEmpty || nonEmptyPrefix.isEmpty
-      var nonEmptyPrefix = this
-      var prefix = LazyList.fromIterator(f(nonEmptyPrefix.head).iterator())
-      while (!nonEmptyPrefix.isEmpty && prefix.isEmpty) {
-        nonEmptyPrefix = nonEmptyPrefix.tail
-        if(!nonEmptyPrefix.isEmpty)
-          prefix = LazyList.fromIterator(f(nonEmptyPrefix.head).iterator())
-      }
-
-      if (nonEmptyPrefix.isEmpty) LazyList.empty
-      else prefix.lazyAppendAll(nonEmptyPrefix.tail.flatMap(f))
+  override final def flatMap[B](f: A => IterableOnce[B]): CC[B] =
+  if (isEmpty) iterableFactory.empty
+  else {
+    // establish !prefix.isEmpty || nonEmptyPrefix.isEmpty
+    var nonEmptyPrefix: CC[A] = coll
+    var prefix = iterableFactory.from(f(nonEmptyPrefix.head).iterator())
+    while (!nonEmptyPrefix.isEmpty && prefix.isEmpty) {
+      nonEmptyPrefix = nonEmptyPrefix.tail
+      if(!nonEmptyPrefix.isEmpty)
+        prefix = iterableFactory.from(f(nonEmptyPrefix.head).iterator())
     }
 
-  override final def zip[B](that: collection.Iterable[B]): LazyList[(A, B)] =
-    if (this.isEmpty || that.isEmpty) LazyList.empty
-    else LazyList.cons((this.head, that.head), this.tail.zip(that.tail))
+    if (nonEmptyPrefix.isEmpty) iterableFactory.empty
+    else prefix.lazyAppendAll(nonEmptyPrefix.tail.flatMap(f))
+  }
 
-  override final def zipWithIndex: LazyList[(A, Int)] = this.zip(LazyList.from(0))
+  override final def zip[B](that: collection.Iterable[B]): CC[(A, B)] =
+    if (this.isEmpty || that.isEmpty) iterableFactory.empty
+    else cons[(A, B)]((this.head, that.head), this.tail.zip(that.tail))
 
+  override final def zipWithIndex: CC[(A, Int)] = this.zip(LazyList.from(0))
+
+}
+
+sealed private[immutable] trait LazyListFactory[+CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]]] extends SeqFactory[CC] {
+
+  protected[this] def newCons[T](hd: => T, tl: => CC[T]): CC[T]
+
+  private[immutable] def withFilter[A](l: CC[A] @uncheckedVariance, p: A => Boolean): collection.WithFilter[A, CC] =
+    new WithFilter[A](l, p)
+
+  private[this] final class WithFilter[A](l: CC[A] @uncheckedVariance, p: A => Boolean) extends collection.WithFilter[A, CC] {
+    private[this] var s = l                                                // set to null to allow GC after filtered
+    private[this] lazy val filtered: CC[A] = { val f = s.filter(p); s = null.asInstanceOf[CC[A]]; f } // don't set to null if throw during filter
+    def map[B](f: A => B): CC[B] = filtered.map(f)
+    def flatMap[B](f: A => IterableOnce[B]): CC[B] = filtered.flatMap(f)
+    def foreach[U](f: A => U): Unit = filtered.foreach(f)
+    def withFilter(q: A => Boolean): collection.WithFilter[A, CC] = new WithFilter(filtered, q)
+  }
+
+  /** An infinite LazyList that repeatedly applies a given function to a start value.
+    *
+    *  @param start the start value of the LazyList
+    *  @param f     the function that's repeatedly applied
+    *  @return      the LazyList returning the infinite sequence of values `start, f(start), f(f(start)), ...`
+    */
+  def iterate[A](start: => A)(f: A => A): CC[A] = newCons(start, iterate(f(start))(f))
+
+  /**
+    * Create an infinite LazyList starting at `start` and incrementing by
+    * step `step`.
+    *
+    * @param start the start value of the LazyList
+    * @param step the increment value of the LazyList
+    * @return the LazyList starting at value `start`.
+    */
+  def from(start: Int, step: Int): CC[Int] =
+    newCons(start, from(start + step, step))
+
+  /**
+    * Create an infinite LazyList starting at `start` and incrementing by `1`.
+    *
+    * @param start the start value of the LazyList
+    * @return the LazyList starting at value `start`.
+    */
+  def from(start: Int): CC[Int] = from(start, 1)
+
+  /**
+    * Create an infinite LazyList containing the given element expression (which
+    * is computed for each occurrence).
+    *
+    * @param elem the element composing the resulting LazyList
+    * @return the LazyList containing an infinite number of elem
+    */
+  def continually[A](elem: => A): CC[A] = newCons(elem, continually(elem))
+
+  /**
+    * @return a LazyList by using a function `f` producing elements of
+    *         type `A` and updating an internal state `S`.
+    * @param init State initial value
+    * @param f    Computes the next element (or returns `None` to signal
+    *             the end of the collection)
+    * @tparam A   Type of the elements
+    * @tparam S   Type of the internal state
+    */
+  def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = {
+    def loop(s: S): CC[A] = {
+      f(s).fold(empty[A])(as => newCons(as._1, loop(as._2)))
+    }
+    loop(init)
+  }
+
+  def newBuilder[A](): Builder[A, CC[A]] = ArrayBuffer.newBuilder[A]().mapResult(array => from(array))
+
+  private[immutable] def filteredTail[A](lazyList: CC[A] @uncheckedVariance, p: A => Boolean, isFlipped: Boolean) = {
+    newCons(lazyList.head, lazyList.tail.filterImpl(p, isFlipped))
+  }
+
+  private[immutable] def collectedTail[A, B](head: B, stream: CC[A] @uncheckedVariance, pf: PartialFunction[A, B]) = {
+    newCons(head, stream.tail.collect(pf))
+  }
+
+  type Evaluated[+A] <: Option[(A, CC[A])]
 }
 
 /**
@@ -362,7 +449,9 @@ sealed abstract class LazyList[+A]
   * @define coll lazy list
   * @define Coll `LazyList`
   */
-object LazyList extends SeqFactory[LazyList] {
+object LazyList extends LazyListFactory[LazyList] {
+
+  protected[this] def newCons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
 
   type Evaluated[+A] = Option[(A, LazyList[A])]
 
@@ -405,11 +494,11 @@ object LazyList extends SeqFactory[LazyList] {
     def unapply[A](xs: LazyList[A]): Option[(A, LazyList[A])] = #::.unapply(xs)
   }
 
-  implicit class Deferrer[A](l: => LazyList[A]) {
+  implicit final class Deferrer[A](l: => LazyList[A]) {
     /** Construct a LazyList consisting of a given first element followed by elements
       *  from another LazyList.
       */
-    def #:: [B >: A](elem: => B): LazyList[B] = cons(elem, l)
+    def #:: [B >: A](elem: => B): LazyList[B] = newCons(elem, l)
     /** Construct a LazyList consisting of the concatenation of the given LazyList and
       *  another LazyList.
       */
@@ -442,76 +531,128 @@ object LazyList extends SeqFactory[LazyList] {
     } else LazyList.Empty
 
   def empty[A]: LazyList[A] = Empty
+}
 
-  /** An infinite LazyList that repeatedly applies a given function to a start value.
-   *
-   *  @param start the start value of the LazyList
-   *  @param f     the function that's repeatedly applied
-   *  @return      the LazyList returning the infinite sequence of values `start, f(start), f(f(start)), ...`
-   */
-  def iterate[A](start: => A)(f: A => A): LazyList[A] = cons(start, iterate(f(start))(f))
+@deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")
+sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream, Stream[A]] {
+  def iterableFactory: LazyListFactory[Stream] = Stream
 
-  /**
-    * Create an infinite LazyList starting at `start` and incrementing by
-    * step `step`.
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): Stream[A] = fromIterable(coll)
+
+  protected[this] def newSpecificBuilder(): Builder[A, Stream[A]] =
+    IndexedSeq.newBuilder().mapResult(_.to(Stream))
+
+  protected[this] def cons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
+
+  /** Apply the given function `f` to each element of this linear sequence
+    * (while respecting the order of the elements).
     *
-    * @param start the start value of the LazyList
-    * @param step the increment value of the LazyList
-    * @return the LazyList starting at value `start`.
+    *  @param f The treatment to apply to each element.
+    *  @note  Overridden here as final to trigger tail-call optimization, which
+    *  replaces 'this' with 'tail' at each iteration. This is absolutely
+    *  necessary for allowing the GC to collect the underlying LazyList as elements
+    *  are consumed.
+    *  @note  This function will force the realization of the entire LazyList
+    *  unless the `f` throws an exception.
     */
-  def from(start: Int, step: Int): LazyList[Int] =
-    cons(start, from(start + step, step))
-
-  /**
-   * Create an infinite LazyList starting at `start` and incrementing by `1`.
-   *
-   * @param start the start value of the LazyList
-   * @return the LazyList starting at value `start`.
-   */
-  def from(start: Int): LazyList[Int] = from(start, 1)
-
-  /**
-   * Create an infinite LazyList containing the given element expression (which
-   * is computed for each occurrence).
-   *
-   * @param elem the element composing the resulting LazyList
-   * @return the LazyList containing an infinite number of elem
-   */
-  def continually[A](elem: => A): LazyList[A] = cons(elem, continually(elem))
-
-  /**
-    * @return a LazyList by using a function `f` producing elements of
-    *         type `A` and updating an internal state `S`.
-    * @param init State initial value
-    * @param f    Computes the next element (or returns `None` to signal
-    *             the end of the collection)
-    * @tparam A   Type of the elements
-    * @tparam S   Type of the internal state
-    */
-  def unfold[A, S](init: S)(f: S => Option[(A, S)]): LazyList[A] = {
-    def loop(s: S): LazyList[A] = {
-      f(s).fold(empty[A])(as => cons(as._1, loop(as._2)))
+  @tailrec
+  override final def foreach[U](f: A => U): Unit = {
+    if (!this.isEmpty) {
+      f(head)
+      tail.foreach(f)
     }
-    loop(init)
   }
 
-  def newBuilder[A](): Builder[A, LazyList[A]] = ArrayBuffer.newBuilder[A]().mapResult(array => from(array))
+  /** LazyList specialization of foldLeft which allows GC to collect along the
+    * way.
+    *
+    * @tparam B The type of value being accumulated.
+    * @param z The initial value seeded into the function `op`.
+    * @param op The operation to perform on successive elements of the `LazyList`.
+    * @return The accumulated value from successive applications of `op`.
+    */
+  @tailrec
+  override final def foldLeft[B](z: B)(op: (B, A) => B): B = {
+    if (this.isEmpty) z
+    else tail.foldLeft(op(z, head))(op)
+  }
+}
 
-  private[immutable] def filteredTail[A](lazyList: LazyList[A], p: A => Boolean, isFlipped: Boolean) = {
-    cons(lazyList.head, lazyList.tail.filterImpl(p, isFlipped))
+@deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")
+object Stream extends LazyListFactory[Stream] {
+
+  protected[this] def newCons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
+
+  type Evaluated[+A] = Option[(A, Stream[A])]
+
+  object Empty extends Stream[Nothing] {
+    override def isEmpty: Boolean = true
+    override def head: Nothing = throw new NoSuchElementException("head of empty lazy list")
+    override def tail: Stream[Nothing] = throw new UnsupportedOperationException("tail of empty lazy list")
+    def force: Evaluated[Nothing] = None
+    override def toString: String = "Empty"
   }
 
-  private[immutable] def collectedTail[A, B](head: B, stream: LazyList[A], pf: PartialFunction[A, B]) = {
-    cons(head, stream.tail.collect(pf))
+  final class Cons[A](override val head: A, tl: => Stream[A]) extends Stream[A] {
+    private[this] var tlEvaluated: Boolean = false
+    override def isEmpty: Boolean = false
+    override lazy val tail: Stream[A] = {
+      tlEvaluated = true
+      tl
+    }
+    def force: Evaluated[A] = Some((head, tail))
+    override def toString: String =
+      s"$head #:: ${if (tlEvaluated) tail.toString else "?"}"
   }
 
-  private[immutable] class WithFilter[A](l: LazyList[A], p: A => Boolean) extends collection.WithFilter[A, LazyList] {
-    private[this] var s = l                                                // set to null to allow GC after filtered
-    private[this] lazy val filtered = { val f = s.filter(p); s = null; f } // don't set to null if throw during filter
-    def map[B](f: A => B): LazyList[B] = filtered.map(f)
-    def flatMap[B](f: A => IterableOnce[B]): LazyList[B] = filtered.flatMap(f)
-    def foreach[U](f: A => U): Unit = filtered.foreach(f)
-    def withFilter(q: A => Boolean): WithFilter[A] = new WithFilter(filtered, q)
+  /** An alternative way of building and matching Streams using Stream.cons(hd, tl).
+    */
+  object cons {
+    /** A lazy list consisting of a given first element and remaining elements
+      *  @param hd   The first element of the result lazy list
+      *  @param tl   The remaining elements of the result lazy list
+      */
+    def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
+
+    /** Maps a lazy list to its head and tail */
+    def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
   }
 
+  implicit final class Deferrer[A](l: => Stream[A]) {
+    /** Construct a Stream consisting of a given first element followed by elements
+      *  from another Stream.
+      */
+    def #:: [B >: A](elem: => B): Stream[B] = newCons(elem, l)
+    /** Construct a Stream consisting of the concatenation of the given Stream and
+      *  another Stream.
+      */
+    def #:::[B >: A](prefix: Stream[B]): Stream[B] = prefix lazyAppendAll l
+  }
+
+  object #:: {
+    def unapply[A](s: Stream[A]): Evaluated[A] = s.force
+  }
+
+  def from[A](coll: collection.IterableOnce[A]): Stream[A] = coll match {
+    case coll: Stream[A] => coll
+    case _ => fromIterator(coll.iterator())
+  }
+
+  /**
+    * @return A `Stream[A]` that gets its elements from the given `Iterator`.
+    *
+    * @param it Source iterator
+    * @tparam A type of elements
+    */
+  // Note that the resulting `Stream` will be effectively iterable more than once because
+  // `Stream` memoizes its elements
+  def fromIterator[A](it: Iterator[A]): Stream[A] =
+    if (it.hasNext) {
+      // Be sure that `it.next()` is called even when the `head`
+      // of our constructed lazy list is not evaluated (e.g. when one calls `drop`).
+      lazy val evaluatedElem = it.next()
+      new Stream.Cons(evaluatedElem, { evaluatedElem; fromIterator(it) })
+    } else Stream.Empty
+
+  def empty[A]: Stream[A] = Empty
 }

--- a/collections/src/test/scala/strawman/collection/test/Test.scala
+++ b/collections/src/test/scala/strawman/collection/test/Test.scala
@@ -6,7 +6,7 @@ import java.lang.String
 import scala.{Any, Array, Boolean, Char, Either, Int, Left, Nothing, Option, StringContext, Unit}
 import scala.Predef.{assert, charWrapper, identity, println, $conforms}
 import collection._
-import collection.immutable.{ImmutableArray, LazyList, List, Nil, Range, Vector}
+import collection.immutable.{ImmutableArray, List, Nil, Range, Vector, Stream}
 import collection.mutable.{ArrayBuffer, ListBuffer}
 import org.junit.Test
 import org.junit.Assert._
@@ -363,7 +363,7 @@ class StrawmanTest {
     println(xs16)
   }
 
-  def lazyListOps(xs: Seq[Int]): Unit = {
+  /*def lazyListOps(xs: Seq[Int]): Unit = {
     val x1 = xs.foldLeft("")(_ + _)
     val y1: String = x1
     val x2 = xs.foldRight("")(_ + _)
@@ -455,7 +455,7 @@ class StrawmanTest {
 
     // laziness may differ in dotty, so test only that we are as lazy as Stream
     import scala.collection.{immutable => old}
-    lazy val fibsStream: old.Stream[Int] = 0 #:: 1 #:: fibsStream.zip(fibsStream.tail).map { n => n._1 + n._2 }
+    lazy val fibsStream: Stream[Int] = 0 #:: 1 #:: fibsStream.zip(fibsStream.tail).map { n => n._1 + n._2 }
     if(old.List(0,1,1,2)==fibsStream.take(4).toList) {
       lazy val fibs: LazyList[Int] = 0 #:: 1 #:: fibs.zip(fibs.tail).map { n => n._1 + n._2 }
       assert(List(0, 1, 1, 2) == fibs.take(4).to(List))
@@ -465,10 +465,10 @@ class StrawmanTest {
     var lazeCountL = 0
     def lazeL(i: Int) = {lazeCountL += 1; i}
     def lazeS(i: Int) = {lazeCountS += 1; i}
-    val xs20 = lazeS(1) #:: lazeS(2) #:: lazeS(3) #:: old.Stream.empty
+    val xs20 = lazeS(1) #:: lazeS(2) #:: lazeS(3) #:: Stream.empty
     val xs21 = lazeL(1) #:: lazeL(2) #:: lazeL(3) #:: LazyList.empty
     assert(lazeCountS==lazeCountL)
-  }
+  }*/
 
   def sortedSets(xs: immutable.SortedSet[Int]): Unit = {
     iterableOps(xs)
@@ -536,9 +536,9 @@ class StrawmanTest {
   @Test
   def distinct(): Unit = {
     // Lazy collections distinct
-    assert(LazyList[Int]().distinct.isEmpty)
+    /*assert(LazyList[Int]().distinct.isEmpty)
     assert(LazyList(1,1,1,1).distinct.equals(LazyList(1)))
-    assert(LazyList(1,2,3,1).distinct.equals(LazyList(1,2,3)))
+    assert(LazyList(1,2,3,1).distinct.equals(LazyList(1,2,3)))*/
 
     // Strict collections distinct
     assert(List().distinct.equals(List()))
@@ -550,8 +550,8 @@ class StrawmanTest {
   def linearSeqSize(): Unit = {
     val list = 1 :: 2 :: 3 :: Nil
     assert(list.length == list.size && list.size == 3)
-    val lazyList = 1 #:: 2 #:: 3 #:: LazyList.Empty
-    assert(lazyList.length == lazyList.size && lazyList.size == 3)
+    //val lazyList = 1 #:: 2 #:: 3 #:: LazyList.Empty
+    //assert(lazyList.length == lazyList.size && lazyList.size == 3)
   }
 
   @Test
@@ -573,14 +573,14 @@ class StrawmanTest {
   def mainTest(): Unit = {
     val ints = List(1, 2, 3)
     val intsVec = ints.to(Vector)
-    val intsLzy = ints.to(LazyList)
+    //val intsLzy = ints.to(LazyList)
     val intsArr = ints.to(ImmutableArray)
     val intsBuf = ints.to(ArrayBuffer)
     val intsListBuf = ints.to(ListBuffer)
     val intsView = ints.view
     seqOps(ints)
     seqOps(intsVec)
-    seqOps(intsLzy)
+    //seqOps(intsLzy)
     seqOps(intsArr)
     seqOps(intsBuf)
     seqOps(intsListBuf)
@@ -589,10 +589,10 @@ class StrawmanTest {
     arrayOps(Array(1, 2, 3))
     immutableSeqOps(ints)
     immutableSeqOps(intsVec)
-    immutableSeqOps(intsLzy)
+    //immutableSeqOps(intsLzy)
     immutableSeqOps(intsArr)
     immutableArrayOps(intsArr)
-    lazyListOps(intsLzy)
+    //lazyListOps(intsLzy)
     distinct()
     linearSeqSize()
   }

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -2,7 +2,7 @@ package strawman.collection.immutable
 
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.{Test, Ignore}
 import org.junit.Assert._
 
 import scala.ref.WeakReference
@@ -122,5 +122,13 @@ class LazyListTest {
   def t9886: Unit = {
     assertEquals(LazyList(None, Some(1)), None #:: LazyList(Some(1)))
     assertEquals(LazyList(None, Some(1)), LazyList(None) #::: LazyList(Some(1)))
+  }
+
+  @Test
+  def testLazyListDoesNotForceHead: Unit = {
+    var i = 0
+    def f: Int = { i += 1; i }
+    val s = LazyList.empty.#::(f).#::(f).#::(f)
+    assertEquals(0, i)
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -1,0 +1,134 @@
+package strawman.collection.immutable
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.ref.WeakReference
+import scala.util.Try
+
+@RunWith(classOf[JUnit4])
+class StreamTest {
+
+  @Test
+  def t6727_and_t6440_and_8627(): Unit = {
+    assertTrue(Stream.continually(()).filter(_ => true).take(2) == Seq((), ()))
+    assertTrue(Stream.continually(()).filterNot(_ => false).take(2) == Seq((), ()))
+    assertTrue(Stream(1,2,3,4,5).filter(_ < 4) == Seq(1,2,3))
+    assertTrue(Stream(1,2,3,4,5).filterNot(_ > 4) == Seq(1,2,3,4))
+    assertTrue(Stream.from(1).filter(_ > 4).take(3) == Seq(5,6,7))
+    assertTrue(Stream.from(1).filterNot(_ <= 4).take(3) == Seq(5,6,7))
+  }
+
+  /** Test helper to verify that the given Stream operation allows
+    * GC of the head during processing of the tail.
+    */
+  def assertStreamOpAllowsGC(op: (=> Stream[Int], Int => Unit) => Any, f: Int => Unit): Unit = {
+    val msgSuccessGC = "GC success"
+    val msgFailureGC = "GC failure"
+
+    // A Stream of 500 elements at most. We will test that the head can be collected
+    // while processing the tail. After each element we will GC and wait 10 ms, so a
+    // failure to collect will take roughly 5 seconds.
+    val ref = WeakReference( Stream.from(1).take(500) )
+
+    def gcAndThrowIfCollected(n: Int): Unit = {
+      System.gc()                                                   // try to GC
+      Thread.sleep(10)                                              // give it 10 ms
+      if (ref.get.isEmpty) throw new RuntimeException(msgSuccessGC) // we're done if head collected
+      f(n)
+    }
+
+    val res = Try { op(ref(), gcAndThrowIfCollected) }.failed       // success is indicated by an
+    val msg = res.map(_.getMessage).getOrElse(msgFailureGC)         // exception with expected message
+    // failure is indicated by no
+    assertTrue(msg == msgSuccessGC)                                 // exception, or one with different message
+  }
+
+  @Test
+  def foreach_allows_GC(): Unit = {
+    assertStreamOpAllowsGC(_.foreach(_), _ => ())
+  }
+
+  @Test
+  def filter_all_foreach_allows_GC(): Unit = {
+    assertStreamOpAllowsGC(_.filter(_ => true).foreach(_), _ => ())
+  }
+
+  @Test // scala/bug#8990
+  def withFilter_after_first_foreach_allows_GC: Unit = {
+    assertStreamOpAllowsGC(_.withFilter(_ > 1).foreach(_), _ => ())
+  }
+
+  @Test // scala/bug#8990
+  def withFilter_after_first_withFilter_foreach_allows_GC: Unit = {
+    assertStreamOpAllowsGC(_.withFilter(_ > 1).withFilter(_ < 100).foreach(_), _ => ())
+  }
+
+  @Test // scala/bug#8990
+  def withFilter_can_retry_after_exception_thrown_in_filter: Unit = {
+    // use mutable state to control an intermittent failure in filtering the Stream
+    var shouldThrow = true
+
+    val wf = Stream.from(1).take(10).withFilter { n =>
+      if (shouldThrow && n == 5) throw new RuntimeException("n == 5") else n > 5
+    }
+
+    assertEquals(true, Try { wf.map(identity) }.isFailure) // throws on n == 5
+
+    shouldThrow = false                              // won't throw next time
+
+    assertEquals(5,  wf.map(identity).length)       // success instead of NPE
+  }
+
+  /** Test helper to verify that the given Stream operation is properly lazy in the tail */
+  def assertStreamOpLazyInTail(op: (=> Stream[Int]) => Stream[Int], expectedEvaluated: List[Int]): Unit = {
+    // mutable state to record every strict evaluation
+    var evaluated: List[Int] = Nil
+
+    def trackEffectsOnNaturals: Stream[Int] = {
+      def loop(i: Int): Stream[Int] = { evaluated ++= List(i); Stream.cons(i, loop(i + 1)) }
+      loop(1)
+    }
+
+    // call op on a Stream which records every strict evaluation
+    val result = op(trackEffectsOnNaturals)
+
+    assertEquals(expectedEvaluated, evaluated)
+  }
+
+  @Test // scala/bug#9134
+  def filter_map_properly_lazy_in_tail: Unit = {
+    assertStreamOpLazyInTail(_.filter(_ % 2 == 0).map(identity), List(1, 2))
+  }
+
+  @Test // scala/bug#9134
+  def withFilter_map_properly_lazy_in_tail: Unit = {
+    assertStreamOpLazyInTail(_.withFilter(_ % 2 == 0).map(identity), List(1, 2))
+  }
+
+  @Test // scala/bug#6881
+  def test_reference_equality: Unit = {
+    // Make sure we're tested with reference equality
+    val s = Stream.from(0)
+    assert(s == s, "Referentially identical Streams should be equal (==)")
+    assert(s equals s, "Referentially identical Streams should be equal (equals)")
+    assert((0 #:: 1 #:: s) == (0 #:: 1 #:: s), "Cons of referentially identical Streams should be equal (==)")
+    assert((0 #:: 1 #:: s) equals (0 #:: 1 #:: s), "Cons of referentially identical Streams should be equal (equals)")
+  }
+
+  @Test
+  def t9886: Unit = {
+    assertEquals(Stream(None, Some(1)), None #:: Stream(Some(1)))
+    assertEquals(Stream(None, Some(1)), Stream(None) #::: Stream(Some(1)))
+  }
+
+  @Test
+  def testStreamForcesHead: Unit = {
+    var i = 0
+    def f: Int = { i += 1; i }
+    val s = f #:: f #:: f #:: Stream.empty
+    assertEquals(1, i)
+  }
+}


### PR DESCRIPTION
Since the semantics are subtly different we should add a deprecated `Stream` with the expected semantics rather than aliasing to `LazyList`