### PR TITLE
Introduce a deprecated MultiMap implementation

### DIFF
--- a/collections-compat/src/main/scala-2.11-2.12/scala/collection/compat/mutable/package.scala
+++ b/collections-compat/src/main/scala-2.11-2.12/scala/collection/compat/mutable/package.scala
@@ -1,0 +1,7 @@
+package scala.collection.compat
+
+package object mutable {
+
+  type MultiMap[A, B] = scala.collection.mutable.MultiMap[A, B]
+
+}

--- a/collections-compat/src/main/scala-2.13/scala/collection/compat/mutable/package.scala
+++ b/collections-compat/src/main/scala-2.13/scala/collection/compat/mutable/package.scala
@@ -1,0 +1,7 @@
+package scala.collection.compat
+
+package object mutable {
+
+  type MultiMap[A, B] = scala.collection.mutable.DeprecatedMultiMap[A, B]
+
+}

--- a/collections/src/main/scala/strawman/collection/mutable/DeprecatedMultiMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/DeprecatedMultiMap.scala
@@ -1,0 +1,108 @@
+package strawman.collection.mutable
+
+import scala.{Boolean, None, Some, deprecated}
+
+/** A trait for mutable maps with multiple values assigned to a key.
+  *
+  *  This class is typically used as a mixin. It turns maps which map `A`
+  *  to `Set[B]` objects into multimaps that map `A` to `B` objects.
+  *
+  *  @example {{{
+  *  // first import all necessary types from package `collection.mutable`
+  *  import collection.mutable.{ HashMap, MultiMap, Set }
+  *
+  *  // to create a `MultiMap` the easiest way is to mixin it into a normal
+  *  // `Map` instance
+  *  val mm = new HashMap[Int, Set[String]] with MultiMap[Int, String]
+  *
+  *  // to add key-value pairs to a multimap it is important to use
+  *  // the method `addBinding` because standard methods like `+` will
+  *  // overwrite the complete key-value pair instead of adding the
+  *  // value to the existing key
+  *  mm.addBinding(1, "a")
+  *  mm.addBinding(2, "b")
+  *  mm.addBinding(1, "c")
+  *
+  *  // mm now contains `Map(2 -> Set(b), 1 -> Set(c, a))`
+  *
+  *  // to check if the multimap contains a value there is method
+  *  // `entryExists`, which allows to traverse the including set
+  *  mm.entryExists(1, _ == "a") == true
+  *  mm.entryExists(1, _ == "b") == false
+  *  mm.entryExists(2, _ == "b") == true
+  *
+  *  // to remove a previous added value there is the method `removeBinding`
+  *  mm.removeBinding(1, "a")
+  *  mm.entryExists(1, _ == "a") == false
+  *  }}}
+  *
+  *  @define coll multimap
+  *  @define Coll `MultiMap`
+  *  @author  Matthias Zenger
+  *  @author  Martin Odersky
+  *  @version 2.8
+  *  @since   1
+  */
+@deprecated("Use the MultiMap implementation provided by the collections-contrib module instead", "2.13.0")
+trait DeprecatedMultiMap[A, B] extends Map[A, Set[B]] {
+  /** Creates a new set.
+    *
+    *  Classes that use this trait as a mixin can override this method
+    *  to have the desired implementation of sets assigned to new keys.
+    *  By default this is `HashSet`.
+    *
+    *  @return An empty set of values of type `B`.
+    */
+  protected def makeSet: Set[B] = new HashSet[B]
+
+  /** Assigns the specified `value` to a specified `key`.  If the key
+    *  already has a binding to equal to `value`, nothing is changed;
+    *  otherwise a new binding is added for that `key`.
+    *
+    *  @param key    The key to which to bind the new value.
+    *  @param value  The value to bind to the key.
+    *  @return       A reference to this multimap.
+    */
+  def addBinding(key: A, value: B): this.type = {
+    get(key) match {
+      case None =>
+        val set = makeSet
+        set += value
+        this(key) = set
+      case Some(set) =>
+        set += value
+    }
+    this
+  }
+
+  /** Removes the binding of `value` to `key` if it exists, otherwise this
+    *  operation doesn't have any effect.
+    *
+    *  If this was the last value assigned to the specified key, the
+    *  set assigned to that key will be removed as well.
+    *
+    *  @param key     The key of the binding.
+    *  @param value   The value to remove.
+    *  @return        A reference to this multimap.
+    */
+  def removeBinding(key: A, value: B): this.type = {
+    get(key) match {
+      case None =>
+      case Some(set) =>
+        set -= value
+        if (set.isEmpty) this -= key
+    }
+    this
+  }
+
+  /** Checks if there exists a binding to `key` such that it satisfies the predicate `p`.
+    *
+    *  @param key   The key for which the predicate is checked.
+    *  @param p     The predicate which a value assigned to the key must satisfy.
+    *  @return      A boolean if such a binding exists
+    */
+  def entryExists(key: A, p: B => Boolean): Boolean = get(key) match {
+    case None => false
+    case Some(set) => set exists p
+  }
+}

--- a/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_mutableMultiMap.scala
+++ b/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_mutableMultiMap.scala
@@ -1,0 +1,13 @@
+/*
+rule = "scala:fix.Collectionstrawman_v0"
+ */
+package fix
+
+import scala.collection.mutable
+
+object Collectionstrawman_v0_mutableMultiMap {
+
+  val xs: mutable.MultiMap[Int, String] =
+    new mutable.HashMap[Int, mutable.Set[String]] with mutable.MultiMap[Int, String]
+
+}

--- a/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_mutableMultiMap.scala
+++ b/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_mutableMultiMap.scala
@@ -1,0 +1,10 @@
+package fix
+
+import scala.collection.mutable
+
+object Collectionstrawman_v0_mutableMultiMap {
+
+  val xs: mutable.DeprecatedMultiMap[Int, String] =
+    new mutable.HashMap[Int, mutable.Set[String]] with mutable.DeprecatedMultiMap[Int, String]
+
+}

--- a/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -96,10 +96,14 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
         ctx.replaceTree(t, q"$buffer ++= $collection".syntax)
     }.asPatch
 
+  def replaceMultiMap(ctx: RuleCtx): Patch =
+    ctx.replaceSymbols("scala.collection.mutable.MultiMap" -> "scala.collection.mutable.DeprecatedMultiMap")
+
   override def fix(ctx: RuleCtx): Patch = {
     replaceToList(ctx) +
       replaceSymbols(ctx) +
       replaceTupleZipped(ctx) +
-      replaceCopyToBuffer(ctx)
+      replaceCopyToBuffer(ctx) +
+      replaceMultiMap(ctx)
   }
 }


### PR DESCRIPTION
This change can be controversial.

In 2.12 we have a `mutable.MultiMap` trait (see API [here](http://scala-lang.org/api/current/scala/collection/mutable/MultiMap.html)).

In 2.13 I introduced a `mutable.MultiMap` collection that has the _same name_ but a _different usage_ (see API [here](https://static.javadoc.io/ch.epfl.scala/collections-contrib_2.12/0.8.0/strawman/collection/mutable/MultiMap.html)). Thus, these two `MultiMap` are incompatible. One solution could have been to name the new `MultiMap` differently but … it really is a `MultiMap` so I’m not sure we should use a different name… Also, I think I should remind why in the first place I decided to go with different approach for `MultiMap`: I think the existing `MultiMap` is confusing and doesn’t provide the level of support that users would expect. Indeed when you use it it is very easy to mistakenly call the wrong `update` operation (instead of `addBinding`) and it doesn’t work with sorted maps and lacks transformation operations (it only provides three operations).

So, this PR brings solutions to help migration and to support cross-compatibility between Scala versions.

---

For users upgrading from 2.12 to 2.13, the scalafix migration rule will replace `collection.mutable.MultiMap` (in 2.12) with `collection.mutable.DeprecatedMultiMap` (in 2.13), which is a copy of the existing `MultiMap`, but deprecated.
Their code will still compile, with a warning inviting them to migrate to the new `collection.mutable.MultiMap` type.

---

For users who want their project to compile for _both_ 2.12 and 2.13, they will have to add the following import:

~~~ scala
import collection.compat.mutable.MultiMap
~~~

This import is an alias to `collection.mutable.MultiMap` in 2.12 and to `collection.mutable.DeprecatedMultiMap` in 2.13. Note that people will have to add a dependency on an extra `collections-compat` module (that we might have to introduce anyway, to support the `to` operation in cross-compatible way).