### PR TITLE
Add Factory and BuildFrom instances for String and Array

### DIFF
--- a/collections/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/collections/src/main/scala/strawman/collection/BuildFrom.scala
@@ -1,8 +1,10 @@
 package strawman.collection
 
-import scala.{Any, Ordering, deprecated, `inline`}
-
+import scala.{Any, Array, Char, Ordering, `inline`, deprecated}
+import scala.Predef.String
 import strawman.collection.mutable.Builder
+
+import scala.reflect.ClassTag
 
 /** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
   * Implicit instances of `BuildFrom` are available for all collection types.
@@ -41,6 +43,19 @@ object BuildFrom extends BuildFromLowPriority {
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = from.sortedIterableFactory.newBuilder[A]()
     def fromSpecificIterable(from: CC[A0])(it: Iterable[A]): CC[A] = from.sortedIterableFactory.from(it)
   }
+
+  implicit val buildFromString: BuildFrom[String, Char, String] =
+    new BuildFrom[String, Char, String] {
+      def fromSpecificIterable(from: String)(it: Iterable[Char]): String = Factory.stringFactory.fromSpecific(it)
+      def newBuilder(from: String): Builder[Char, String] = Factory.stringFactory.newBuilder()
+    }
+
+  implicit def buildFromArray[A : ClassTag]: BuildFrom[Array[_], A, Array[A]] =
+    new BuildFrom[Array[_], A, Array[A]] {
+      def fromSpecificIterable(from: Array[_])(it: Iterable[A]): Array[A] = Factory.arrayFactory[A].fromSpecific(it)
+      def newBuilder(from: Array[_]): Builder[A, Array[A]] = Factory.arrayFactory[A].newBuilder()
+    }
+
 }
 
 trait BuildFromLowPriority {

--- a/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
@@ -148,4 +148,7 @@ class BuildFromTest {
     val xs9: immutable.TreeMap[String, Int] = xs7
     val xs10: immutable.TreeMap[Int, Boolean] = xs8
   }
+
+  implicitly[BuildFrom[String, Char, String]]
+  implicitly[BuildFrom[Array[Int], Char, Array[Char]]]
 }

--- a/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
@@ -97,4 +97,7 @@ class FactoriesTest {
     seqFactories.foreach(tabulate)
   }
 
+  implicitly[Factory[Char, String]]
+  implicitly[Factory[Char, Array[Char]]]
+
 }


### PR DESCRIPTION
Fixes #363.

~~~
scala> import strawman.collection.{ Factory, BuildFrom }
import strawman.collection.{Factory, BuildFrom}

scala> implicitly[Factory[Char, String]]
res0: strawman.collection.Factory[Char,String] = strawman.collection.Factory$$anon$1@b2b85c1

scala> implicitly[Factory[Char, Array[Char]]]
res1: strawman.collection.Factory[Char,Array[Char]] = strawman.collection.Factory$$anon$2@3f9fad3c

scala> implicitly[BuildFrom[String, Char, String]]
res2: strawman.collection.BuildFrom[String,Char,String] = strawman.collection.BuildFrom$$anon$4@14687755

scala> implicitly[BuildFrom[Array[Int], Char, Array[Char]]]
res3: strawman.collection.BuildFrom[Array[Int],Char,Array[Char]] = strawman.collection.BuildFrom$$anon$5@4d7234de
~~~