### PR TITLE
implicitNotFound for BuildFrom

### DIFF
--- a/collections/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/collections/src/main/scala/strawman/collection/BuildFrom.scala
@@ -3,6 +3,7 @@ package strawman.collection
 import scala.{Any, Ordering, deprecated, `inline`}
 
 import strawman.collection.mutable.Builder
+import scala.annotation.implicitNotFound
 
 /** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
   * Implicit instances of `BuildFrom` are available for all collection types.
@@ -11,6 +12,7 @@ import strawman.collection.mutable.Builder
   * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
   * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
   */
+@implicitNotFound(msg = "Cannot construct a collection of type ${C} with elements of type ${A} based on a collection of type ${From}.")
 trait BuildFrom[-From, -A, +C] extends Any {
   def fromSpecificIterable(from: From)(it: Iterable[A]): C
 


### PR DESCRIPTION
```
scala> class Lst[+A] {
     |   def map[B, That](f: A => B)(implicit bf: strawman.collection.BuildFrom[Lst[A], B, That]): That = scala.Predef.???
     | }
defined class Lst

scala> object Test {
     |   def foo(l: Lst[scala.Int]) = l.map[scala.Int, Lst[scala.Predef.String]](x => 1)
     | }
         def foo(l: Lst[scala.Int]) = l.map[scala.Int, Lst[scala.Predef.String]](x => 1)
                                                                                ^
On line 2: error: Cannot construct a collection of type Lst[String] with elements of type Int based on a collection of type Lst[Int].
```

This is an existing test case in scala/scala: https://github.com/scala/scala/blob/2.13.x/test/files/neg/t2462a.check