### PR TITLE
Add search methods from scala.collection.Searching

### DIFF
--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -345,6 +345,10 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   /** A view over the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => iterator())
 
+  /** A view over a slice of the elements of this collection. */
+  @deprecated("Use .view.slice(from, until) instead of .view(from, until)", "2.13.0")
+  @`inline` final def view(from: Int, until: Int): View[A] = view.slice(from, until)
+
   /** Given a collection factory `factory`, convert this collection to the appropriate
     * representation for the current element type `A`. Example uses:
     *

--- a/collections/src/main/scala/strawman/collection/Searching.scala
+++ b/collections/src/main/scala/strawman/collection/Searching.scala
@@ -1,0 +1,33 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman.collection
+
+import scala.{Int, deprecated, AnyVal}
+import scala.language.implicitConversions
+import scala.math.Ordering
+import strawman.collection.generic.IsSeqLike
+
+object Searching {
+  sealed abstract class SearchResult {
+    def insertionPoint: Int
+  }
+
+  case class Found(foundIndex: Int) extends SearchResult {
+    override def insertionPoint = foundIndex
+  }
+
+  case class InsertionPoint(insertionPoint: Int) extends SearchResult
+
+  @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
+  class SearchImpl[A, Repr](private val coll: SeqOps[A, Seq, Repr]) extends AnyVal
+
+  @deprecated("Search methods are defined directly on SeqOps and do not require scala.collection.Searching any more", "2.13.0")
+  implicit def search[Repr, A](coll: Repr)(implicit fr: IsSeqLike[Repr]): SearchImpl[fr.A, Repr] =
+    new SearchImpl(fr.conversion(coll))
+}

--- a/collections/src/main/scala/strawman/collection/generic/IsIterableLike.scala
+++ b/collections/src/main/scala/strawman/collection/generic/IsIterableLike.scala
@@ -13,7 +13,7 @@ import scala.Predef.{String, implicitly}
  *  extension methods that work both on collection types and on `String`s (`String`s
  *  do not extend `Iterable`, but can be converted to `Iterable`)
  *
- * `IsIterable` provides two members:
+ * `IsIterableLike` provides two members:
  *
  *  1. type member `A`, which represents the element type of the target `Iterable[A]`
  *  1. value member `conversion`, which provides a way to convert between the type we wish to add extension methods to, `Repr`, and `Iterable[A]`.

--- a/collections/src/main/scala/strawman/collection/generic/IsSeqLike.scala
+++ b/collections/src/main/scala/strawman/collection/generic/IsSeqLike.scala
@@ -1,0 +1,37 @@
+package strawman.collection
+package generic
+
+import scala.{Any, Char}
+import scala.Predef.{String, implicitly}
+
+/** Type class witnessing that a collection representation type `Repr` has
+  * elements of type `A` and has a conversion to `SeqOps[A, Seq, Repr]`.
+  *
+  * This type enables simple enrichment of `Seq`s with extension methods which
+  * can make full use of the mechanics of the Scala collections framework in
+  * their implementation.
+  *
+  * @see [[scala.collection.generic.IsIterableLike]]
+  */
+trait IsSeqLike[Repr] {
+  /** The type of elements we can traverse over. */
+  type A
+  /** A conversion from the representation type `Repr` to `SeqOps[A, Seq, Repr]`. */
+  val conversion: Repr => SeqOps[A, Seq, Repr]
+}
+
+object IsSeqLike {
+  import scala.language.higherKinds
+
+  implicit val stringRepr: IsSeqLike[String] { type A = Char } =
+    new IsSeqLike[String] {
+      type A = Char
+      val conversion = implicitly[String => SeqOps[Char, Seq, String]]
+    }
+
+  implicit def SeqRepr[C[X] <: Seq[X], A0](implicit conv: C[A0] => SeqOps[A0, C, C[A0]]): IsSeqLike[C[A0]] { type A = A0 } =
+    new IsSeqLike[C[A0]] {
+      type A = A0
+      val conversion = conv
+    }
+}


### PR DESCRIPTION
It is not clear from https://github.com/scala/scala/pull/903 why these
methods were not added directly to the collection classes, so that is
what I’m doing here.

`Searching` still exists and contains `SearchResult` and its subtypes.
We should consider moving `SearchResult` directly into the package
and `Found` and `InsertionPoint` into its companion object.