### PR TITLE
Fix serialization issues in HashMap, LinkedHashMap, HashSet and LinkedHashSet

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -5,7 +5,7 @@ package immutable
 import mutable.{Builder, ImmutableBuilder}
 import immutable.{RedBlackTree => RB}
 
-import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Some, Unit}
+import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Serializable, SerialVersionUID, Some, Unit}
 
 /** This class implements immutable sorted sets using a tree.
   *
@@ -25,11 +25,13 @@ import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Some, 
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(-5685982407650748405L)
 final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
     with StrictOptimizedIterableOps[A, Set, TreeSet[A]]
-    with StrictOptimizedSortedSetOps[A, TreeSet, TreeSet[A]] {
+    with StrictOptimizedSortedSetOps[A, TreeSet, TreeSet[A]]
+    with Serializable {
 
   if (ordering eq null) throw new NullPointerException("ordering must not be null")
 

--- a/collections/src/main/scala/strawman/collection/mutable/FlatHashTable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/FlatHashTable.scala
@@ -26,25 +26,25 @@ private[mutable] final class FlatHashTable[A] extends FlatHashTable.HashUtils[A]
 
   private def tableDebug = false
 
-  @transient private[collection] var _loadFactor = defaultLoadFactor
+  private[collection] var _loadFactor = defaultLoadFactor
 
   /** The actual hash table.
    */
-  @transient var table: Array[AnyRef] = new Array(initialCapacity)
+  var table: Array[AnyRef] = new Array(initialCapacity)
 
   /** The number of mappings contained in this hash table.
    */
-  @transient protected var tableSize = 0
+  protected var tableSize = 0
 
   /** The next size value at which to resize (capacity * load factor).
    */
-  @transient protected var threshold: Int = newThreshold(_loadFactor, initialCapacity)
+  protected var threshold: Int = newThreshold(_loadFactor, initialCapacity)
 
   /** The array keeping track of number of elements in 32 element blocks.
    */
-  @transient protected var sizemap: Array[Int] = null
+  protected var sizemap: Array[Int] = null
 
-  @transient protected var seedvalue: Int = tableSizeSeed
+  protected var seedvalue: Int = tableSizeSeed
 
   protected def capacity(expectedSize: Int) = HashTable.nextPositivePowerOfTwo(expectedSize)
 
@@ -66,8 +66,6 @@ private[mutable] final class FlatHashTable[A] extends FlatHashTable.HashUtils[A]
    * The serialization format expected is the one produced by `serializeTo`.
    */
   def init(in: java.io.ObjectInputStream, f: A => Unit): Unit = {
-    in.defaultReadObject
-
     _loadFactor = in.readInt()
     assert(_loadFactor > 0)
 
@@ -98,7 +96,6 @@ private[mutable] final class FlatHashTable[A] extends FlatHashTable.HashUtils[A]
    * to the stream. To deserialize, `init` should be used.
    */
   def serializeTo(out: java.io.ObjectOutputStream) = {
-    out.defaultWriteObject
     out.writeInt(_loadFactor)
     out.writeInt(tableSize)
     out.writeInt(seedvalue)

--- a/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -2,7 +2,7 @@ package strawman
 package collection
 package mutable
 
-import scala.{Any, Boolean, Option, Serializable, SerialVersionUID, Unit}
+import scala.{Any, Boolean, Option, Serializable, SerialVersionUID, transient, Unit}
 
 /** This class implements mutable sets using a hashtable.
   *
@@ -25,7 +25,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
     with StrictOptimizedIterableOps[A, HashSet, HashSet[A]]
     with Serializable {
 
-  private[this] val table = new FlatHashTable[A]
+  @transient private[this] var table = new FlatHashTable[A]
 
   def this() = this(null)
 
@@ -65,14 +65,16 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
     }
   }
 
-  private def writeObject(s: java.io.ObjectOutputStream): Unit = {
-    table.serializeTo(s)
+  private def writeObject(out: java.io.ObjectOutputStream): Unit = {
+    out.defaultWriteObject()
+    table.serializeTo(out)
   }
 
   private def readObject(in: java.io.ObjectInputStream): Unit = {
+    in.defaultReadObject()
+    table = new FlatHashTable[A]
     table.init(in, x => ())
   }
-
 }
 
 /**

--- a/collections/src/main/scala/strawman/collection/mutable/HashTable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashTable.scala
@@ -45,27 +45,27 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
   // However, I'm afraid it's too late now for such breaking change.
   import HashTable._
 
-  @transient protected var _loadFactor = defaultLoadFactor
+  protected var _loadFactor = defaultLoadFactor
 
   /** The actual hash table.
    */
-  @transient protected[collection] var table: Array[HashEntry[A, Entry]] = new Array(initialCapacity)
+  protected[collection] var table: Array[HashEntry[A, Entry]] = new Array(initialCapacity)
 
   /** The number of mappings contained in this hash table.
    */
-  @transient protected[collection] var tableSize: Int = 0
+  protected[collection] var tableSize: Int = 0
 
   final def size: Int = tableSize
 
   /** The next size value at which to resize (capacity * load factor).
    */
-  @transient protected[collection] var threshold: Int = initialThreshold(_loadFactor)
+  protected[collection] var threshold: Int = initialThreshold(_loadFactor)
 
   /** The array keeping track of the number of elements in 32 element blocks.
    */
-  @transient protected var sizemap: Array[Int] = null
+  protected var sizemap: Array[Int] = null
 
-  @transient protected var seedvalue: Int = tableSizeSeed
+  protected var seedvalue: Int = tableSizeSeed
 
   protected def tableSizeSeed = Integer.bitCount(table.length - 1)
 
@@ -92,8 +92,6 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
    * entry to be read from the input stream.
    */
   private[collection] def init(in: java.io.ObjectInputStream, readEntry: => Entry): Unit = {
-    in.defaultReadObject
-
     _loadFactor = in.readInt()
     assert(_loadFactor > 0)
 
@@ -125,7 +123,6 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
    * deserialize, `init` should be used.
    */
   private[collection] def serializeTo(out: java.io.ObjectOutputStream, writeEntry: Entry => Unit): Unit = {
-    out.defaultWriteObject
     out.writeInt(_loadFactor)
     out.writeInt(tableSize)
     out.writeInt(seedvalue)

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -54,7 +54,9 @@ class LinkedHashMap[K, V]
 
   type Entry = LinkedHashMap.LinkedEntry[K, V]
 
-  private[this] val table: HashTable[K, V, Entry] =
+  @transient private[this] var table: HashTable[K, V, Entry] = newHashTable
+
+  private def newHashTable =
     new HashTable[K, V, Entry] {
       def createNewEntry(key: K, value: V): Entry = {
         val e = new Entry(key, value.asInstanceOf[V])
@@ -162,6 +164,7 @@ class LinkedHashMap[K, V]
   }
 
   private def writeObject(out: java.io.ObjectOutputStream): Unit = {
+    out.defaultWriteObject()
     table.serializeTo(out, { entry =>
       out.writeObject(entry.key)
       out.writeObject(entry.value)
@@ -169,10 +172,9 @@ class LinkedHashMap[K, V]
   }
 
   private def readObject(in: java.io.ObjectInputStream): Unit = {
-    firstEntry = null
-    lastEntry = null
+    in.defaultReadObject()
+    table = newHashTable
     table.init(in, table.createNewEntry(in.readObject().asInstanceOf[K], in.readObject().asInstanceOf[V]))
   }
-
 }
 

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
@@ -34,8 +34,9 @@ class LinkedHashSet[A]
 
   @transient protected var firstEntry: Entry = null
   @transient protected var lastEntry: Entry = null
+  @transient private[this] var table: HashTable[A, AnyRef, Entry] = newHashTable
 
-  private[this] var table: HashTable[A, AnyRef, Entry] =
+  private def newHashTable =
     new HashTable[A, AnyRef, Entry] {
       def createNewEntry(key: A, value: AnyRef) = {
         val e = new Entry(key)
@@ -114,15 +115,15 @@ class LinkedHashSet[A]
   }
 
   private def writeObject(out: java.io.ObjectOutputStream): Unit = {
+    out.defaultWriteObject()
     table.serializeTo(out, { e => out.writeObject(e.key) })
   }
 
   private def readObject(in: java.io.ObjectInputStream): Unit = {
-    firstEntry = null
-    lastEntry = null
+    in.defaultReadObject()
+    table = newHashTable
     table.init(in, table.createNewEntry(in.readObject().asInstanceOf[A], null))
   }
-
 }
 
 /** $factoryInfo
@@ -148,6 +149,5 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
     var earlier: Entry[A] = null
     var later: Entry[A] = null
   }
-
 }
 

--- a/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
@@ -58,11 +58,11 @@ class SerializationTest {
     assertEqualsAfterDeserialization(BitSet(1, 2, 3))
   }
 
-//  @Test
-//  def treeSet(): Unit = {
-//    assertEqualsAfterDeserialization(TreeSet.empty)
-//    assertEqualsAfterDeserialization(TreeSet(1, 2, 3))
-//  }
+  @Test
+  def treeSet(): Unit = {
+    assertEqualsAfterDeserialization(TreeSet.empty[Int])
+    assertEqualsAfterDeserialization(TreeSet(1, 2, 3))
+  }
 
 //  @Test
 //  def lazyList(): Unit = {

--- a/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
@@ -1,0 +1,120 @@
+package strawman.collection.immutable
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class SerializationTest {
+
+  @Test
+  def immutableArray(): Unit = {
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array("1", "2", "3")))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Int.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Long.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Double.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Float.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Char.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Byte.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(Short.MinValue)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(true)))
+    assertEqualsAfterDeserialization(ImmutableArray.unsafeWrapArray(Array(())))
+  }
+
+  @Test
+  def hashMap(): Unit = {
+    assertEqualsAfterDeserialization(HashMap.empty[Int, String])
+    assertEqualsAfterDeserialization(HashMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+    @Test
+    def intMap(): Unit = {
+      assertEqualsAfterDeserialization(IntMap.empty[String])
+      assertEqualsAfterDeserialization(IntMap(1 -> "one", 2 -> "two", 3 -> "three"))
+    }
+
+  @Test
+  def longMap(): Unit = {
+    assertEqualsAfterDeserialization(LongMap.empty[String])
+    assertEqualsAfterDeserialization(LongMap(1L -> "one", 2L -> "two", 3L -> "three"))
+  }
+
+  @Test
+  def treeMap(): Unit = {
+    assertEqualsAfterDeserialization(TreeMap.empty[Int, String])
+    assertEqualsAfterDeserialization(TreeMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+  @Test
+  def hashSet(): Unit = {
+    assertEqualsAfterDeserialization(HashSet.empty[Int])
+    assertEqualsAfterDeserialization(HashSet(1, 2, 3))
+  }
+
+  @Test
+  def bitSet(): Unit = {
+    assertEqualsAfterDeserialization(BitSet.empty)
+    assertEqualsAfterDeserialization(BitSet(1, 2, 3))
+  }
+
+//  @Test
+//  def treeSet(): Unit = {
+//    assertEqualsAfterDeserialization(TreeSet.empty)
+//    assertEqualsAfterDeserialization(TreeSet(1, 2, 3))
+//  }
+
+//  @Test
+//  def lazyList(): Unit = {
+//    assertEqualsAfterDeserialization(LazyList.empty)
+//    assertEqualsAfterDeserialization(LazyList.from(1))
+//  }
+
+  @Test
+  def list(): Unit = {
+    assertEqualsAfterDeserialization(Nil)
+    assertEqualsAfterDeserialization(List(1, 2, 3))
+  }
+
+  @Test
+  def listMap(): Unit = {
+    assertEqualsAfterDeserialization(ListMap.empty[Int, String])
+    assertEqualsAfterDeserialization(ListMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+  @Test
+  def listSet(): Unit = {
+    assertEqualsAfterDeserialization(ListSet.empty[Int])
+    assertEqualsAfterDeserialization(ListSet(1, 2, 3))
+  }
+
+  @Test
+  def numericRange(): Unit = {
+    assertEqualsAfterDeserialization(NumericRange(start = 0, end = 10, step = 1))
+  }
+
+  @Test
+  def range(): Unit = {
+    assertEqualsAfterDeserialization(Range(start = 0, end = 10, step = 1))
+  }
+
+  @Test
+  def vector(): Unit = {
+    assertEqualsAfterDeserialization(Vector.empty[Int])
+    assertEqualsAfterDeserialization(Vector(1, 2, 3))
+  }
+
+  private def assertEqualsAfterDeserialization[A](original: Iterable[A]): Unit = {
+    val after = serializeDeserialize(original)
+    assertEquals(original, after)
+  }
+
+  private def serializeDeserialize[T <: AnyRef](obj: T): T = {
+    import java.io._
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/mutable/SerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/SerializationTest.scala
@@ -1,0 +1,91 @@
+package strawman.collection.mutable
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.mutable
+
+@RunWith(classOf[JUnit4])
+class SerializationTest {
+
+  @Test
+  def arrayBuffer(): Unit = {
+    assertEqualsAfterDeserialization(mutable.ArrayBuffer.empty[Int])
+    assertEqualsAfterDeserialization(mutable.ArrayBuffer(1, 2, 3))
+  }
+
+  @Test
+  def listBuffer(): Unit = {
+    assertEqualsAfterDeserialization(mutable.ListBuffer.empty[Int])
+    assertEqualsAfterDeserialization(mutable.ListBuffer(1, 2, 3))
+  }
+
+  @Test
+  def hashMap(): Unit = {
+    assertEqualsAfterDeserialization(mutable.HashMap.empty[Int, String])
+    assertEqualsAfterDeserialization(mutable.HashMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+  @Test
+  def linkedHashMap(): Unit = {
+    assertEqualsAfterDeserialization(mutable.LinkedHashMap.empty[Int, String])
+    assertEqualsAfterDeserialization(mutable.LinkedHashMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+  @Test
+  def longMap(): Unit = {
+    assertEqualsAfterDeserialization(mutable.LongMap.empty[String])
+    assertEqualsAfterDeserialization(mutable.LongMap(1L -> "one", 2L -> "two", 3L -> "three"))
+  }
+
+  @Test
+  def treeMap(): Unit = {
+    assertEqualsAfterDeserialization(mutable.TreeMap.empty[Int, String])
+    assertEqualsAfterDeserialization(mutable.TreeMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
+
+  @Test
+  def anyRefMap(): Unit = {
+    assertEqualsAfterDeserialization(mutable.AnyRefMap.empty[String, String])
+    assertEqualsAfterDeserialization(mutable.AnyRefMap("1" -> "one", "2" -> "two", "3" -> "three"))
+  }
+
+  @Test
+  def hashSet(): Unit = {
+    assertEqualsAfterDeserialization(mutable.HashSet.empty[Int])
+    assertEqualsAfterDeserialization(mutable.HashSet(1, 2, 3))
+  }
+
+  @Test
+  def linkedHashSet(): Unit = {
+    assertEqualsAfterDeserialization(mutable.LinkedHashSet.empty[Int])
+    assertEqualsAfterDeserialization(mutable.LinkedHashSet(1, 2, 3))
+  }
+
+  @Test
+  def bitSet(): Unit = {
+    assertEqualsAfterDeserialization(mutable.BitSet.empty)
+    assertEqualsAfterDeserialization(mutable.BitSet(1, 2, 3))
+  }
+
+  @Test
+  def treeSet(): Unit = {
+    assertEqualsAfterDeserialization(mutable.TreeSet.empty[Int])
+    assertEqualsAfterDeserialization(mutable.TreeSet(1, 2, 3))
+  }
+
+  private def assertEqualsAfterDeserialization[A](original: mutable.Iterable[A]): Unit = {
+    val after = serializeDeserialize(original)
+    assertEquals(original, after)
+  }
+
+  private def serializeDeserialize[T <: AnyRef](obj: T): T = {
+    import java.io._
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+}


### PR DESCRIPTION
This PR fixes #377. 

The reason for the `NotSerializableException`s is that the `HashTable`/`FlatHashTable` classes are not serializable nor the `table` fields in `HashMap`/`LinkedHashMap`/`HashSet`/`LinkedHashSet` classes are marked as transient. 

The easiest solution would be to make `HashTable`/`FlatHashTable` serializable. However, there are a few more issues here:

1. `out.defaultWriteObject` and `in.defaultReadObject` should be called from the `writeObject`/`readObject` methods of the class being serialized/deserialized (usually in the 1st line). Currently this is done from methods in `HashTable`/`FlatHashTable`, which is confusing and causes the issue below;
2. `table.init` is being called before `defaultReadObject`, which causes a NPE during deserialization (need to get past the `NotSerializableException` to see this one);
3. `HashMap`/`LinkedHashMap`/`LinkedHashSet` creates anonymous instances of `HashTable`. In Java (I assume the same applies to Scala) it is not recommended to serialize inner classes as these use compiler-generated synthetic fields to store references to enclosing instances and to store values of local variables from enclosing scopes (it is not a big deal now as the attributes in the enclosed classes are marked transient). Also, it's unspecified how these fields correspond to the class definition, as well as the names of anonymous and local classes.
4. `HashTable` and `FlatHashTable` are private classes in the `strawman.collection.mutable` package. If these classes are included in the serialized form of dependent classes, the former becomes part of the exported API of the latter. This decreases the flexibility to change them once they are released.

Issues 3 and 4 (name of anonymous and private classes leaking) are exemplified in the output below:

```
val obj = mutable.HashMap(1 -> "one", 2 -> "two", 3 -> "three")`:
val buffer = new ByteArrayOutputStream
val out = new ObjectOutputStream(buffer)
out.writeObject(obj)
println(new String(buffer.toByteArray)) 
```

```
��sr#strawman.collection.mutable.HashMapLtablet'Lstrawman/collection/mutable/HashTable;xpsr+strawman.collection.mutable.HashMap$$anon$1˜-���xr%strawman.collection.mutable.HashTab�srjava.lang.Integer⠤���8Ivaluexrjava.lang.Number���
                                                    ���xpttwosq~tonesq~tthreex
```

Below is the output for the same object after the changes in this PR were implemented:

```
�srjava.lang.Integer⠤���8Ivaluexrjava.lang.Number���
                                                    ���xpttwosq~tonesq~tthreex
```