### PR TITLE
First-class treatment of ClassTag-based factories

### DIFF
--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -6,7 +6,7 @@ import strawman.collection.immutable.NumericRange
 import scala.language.implicitConversions
 import strawman.collection.mutable.Builder
 
-import scala.{Any, Array, Char, Int, Integral, Nothing, Ordering, Some}
+import scala.{Any, Array, Char, Int, Integral, Nothing, Ordering, Some, `inline`}
 import scala.Predef.{implicitly, String}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
@@ -227,7 +227,6 @@ trait IterableFactoryLike[+CC[_]] {
     */
   def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
-
 }
 
 /** Base trait for companion objects of unconstrained collection types that can
@@ -388,59 +387,264 @@ object MapFactory {
   }
 }
 
-/** Base trait for companion objects of collections that require an implicit evidence
+/** Base trait for companion objects of collections that require an implicit evidence.
+  * @tparam CC Collection type constructor (e.g. `ImmutableArray`)
+  * @tparam Ev Unary type constructor for the implicit evidence required for an element type
+  *            (typically `Ordering` or `ClassTag`)
   *
   * @define factoryInfo
   *   This object provides a set of operations to create $Coll values.
-  *   @author Martin Odersky
-  *   @version 2.8
   *
   * @define coll collection
   * @define Coll `Iterable`
   */
-trait SortedIterableFactory[+CC[_]] {
+trait EvidenceIterableFactory[+CC[_], Ev[_]] {
 
-  def from[E : Ordering](it: IterableOnce[E]): CC[E]
+  def from[E : Ev](it: IterableOnce[E]): CC[E]
 
-  def empty[A : Ordering]: CC[A]
+  def empty[A : Ev]: CC[A]
 
-  def apply[A : Ordering](xs: A*): CC[A] = from(View.Elems(xs: _*))
+  def apply[A : Ev](xs: A*): CC[A] = from(View.Elems(xs: _*))
 
-  def fill[A : Ordering](n: Int)(elem: => A): CC[A] = from(View.Fill(n)(elem))
+  /** Produces a $coll containing the results of some element computation a number of times.
+    *  @param   n  the number of elements contained in the $coll.
+    *  @param   elem the element computation
+    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+    */
+  def fill[A : Ev](n: Int)(elem: => A): CC[A] = from(View.Fill(n)(elem))
 
-  def newBuilder[A : Ordering](): Builder[A, CC[A]]
+  /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+    *  @param  n   The number of elements in the $coll
+    *  @param  f   The function computing element values
+    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+    */
+  def tabulate[A : Ev](n: Int)(f: Int => A): CC[A] = from(new View.Tabulate(n)(f))
 
-  implicit def sortedIterableFactory[A : Ordering]: Factory[A, CC[A]] = SortedIterableFactory.toFactory(this)
+  def newBuilder[A : Ev](): Builder[A, CC[A]]
 
+  implicit def evidenceIterableFactory[A : Ev]: Factory[A, CC[A]] = EvidenceIterableFactory.toFactory(this)
 }
 
-object SortedIterableFactory {
+object EvidenceIterableFactory {
 
   /**
     * Fixes the element type of `factory` to `A`
     * @param factory The factory to fix the element type
     * @tparam A Type of elements
     * @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)
+    * @tparam Ev Type constructor of the evidence (usually `Ordering` or `ClassTag`)
     * @return A [[Factory]] that uses the given `factory` to build a collection of elements
     *         of type `A`
     */
-  implicit def toFactory[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): Factory[A, CC[A]] =
+  implicit def toFactory[Ev[_], A: Ev, CC[_]](factory: EvidenceIterableFactory[CC, Ev]): Factory[A, CC[A]] =
     new Factory[A, CC[A]] {
       def fromSpecific(it: IterableOnce[A]): CC[A] = factory.from[A](it)
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
 
-  implicit def toBuildFrom[A: Ordering, CC[_]](factory: SortedIterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
+  implicit def toBuildFrom[Ev[_], A: Ev, CC[_]](factory: EvidenceIterableFactory[CC, Ev]): BuildFrom[Any, A, CC[A]] =
     new BuildFrom[Any, A, CC[A]] {
       def fromSpecificIterable(from: Any)(it: Iterable[A]): CC[A] = factory.from[A](it)
       def newBuilder(from: Any): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
 
-  class Delegate[CC[_]](delegate: SortedIterableFactory[CC]) extends SortedIterableFactory[CC] {
-    def empty[A : Ordering]: CC[A] = delegate.empty
-    def from[E : Ordering](it: IterableOnce[E]): CC[E] = delegate.from(it)
-    def newBuilder[A : Ordering](): Builder[A, CC[A]] = delegate.newBuilder[A]()
+  class Delegate[CC[_], Ev[_]](delegate: EvidenceIterableFactory[CC, Ev]) extends EvidenceIterableFactory[CC, Ev] {
+    def empty[A : Ev]: CC[A] = delegate.empty
+    def from[E : Ev](it: IterableOnce[E]): CC[E] = delegate.from(it)
+    def newBuilder[A : Ev](): Builder[A, CC[A]] = delegate.newBuilder[A]()
   }
+}
+
+/** Base trait for companion objects of collections that require an implicit `Ordering`.
+  * @tparam CC Collection type constructor (e.g. `SortedSet`)
+  */
+trait SortedIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, Ordering]
+
+object SortedIterableFactory {
+  class Delegate[CC[_]](delegate: EvidenceIterableFactory[CC, Ordering])
+    extends EvidenceIterableFactory.Delegate[CC, Ordering](delegate) with SortedIterableFactory[CC]
+}
+
+/** Base trait for companion objects of collections that require an implicit `ClassTag`.
+  * @tparam CC Collection type constructor (e.g. `ImmutableArray`)
+  */
+trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassTag] {
+
+  @`inline` private[this] implicit def ccClassTag[X]: ClassTag[CC[X]] =
+    ClassTag.AnyRef.asInstanceOf[ClassTag[CC[X]]] // Good enough for boxed vs primitive arrays
+
+  /** Produces a $coll containing repeated applications of a function to a start value.
+    *
+    *  @param start the start value of the $coll
+    *  @param len   the number of elements contained in the $coll
+    *  @param f     the function that's repeatedly applied
+    *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
+    */
+  def iterate[A : ClassTag](start: A, len: Int)(f: A => A): CC[A] = from(new View.Iterate(start, len)(f))
+
+  /** Produces a $coll containing a sequence of increasing of integers.
+    *
+    *  @param start the first element of the $coll
+    *  @param end   the end value of the $coll (the first value NOT contained)
+    *  @return  a $coll with values `start, start + 1, ..., end - 1`
+    */
+  def range[A : Integral : ClassTag](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
+
+  /** Produces a $coll containing equally spaced values in some integer interval.
+    *  @param start the start value of the $coll
+    *  @param end   the end value of the $coll (the first value NOT contained)
+    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
+    *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
+    */
+  def range[A : Integral : ClassTag](start: A, end: A, step: A): CC[A] = from(NumericRange(start, end, step))
+
+  /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   elem the element computation
+    *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
+    */
+  def fill[A : ClassTag](n1: Int, n2: Int)(elem: => A): CC[CC[A] @uncheckedVariance] = fill(n1)(fill(n2)(elem))
+
+  /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   elem the element computation
+    *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
+    */
+  def fill[A : ClassTag](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]] @uncheckedVariance] = fill(n1)(fill(n2, n3)(elem))
+
+  /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   n4  the number of elements in the 4th dimension
+    *  @param   elem the element computation
+    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
+    */
+  def fill[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[CC[CC[CC[A]]] @uncheckedVariance] =
+    fill(n1)(fill(n2, n3, n4)(elem))
+
+  /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   n4  the number of elements in the 4th dimension
+    *  @param   n5  the number of elements in the 5th dimension
+    *  @param   elem the element computation
+    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
+    */
+  def fill[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
+    fill(n1)(fill(n2, n3, n4, n5)(elem))
+
+  /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   f   The function computing element values
+    *  @return A $coll consisting of elements `f(i1, i2)`
+    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+    */
+  def tabulate[A : ClassTag](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A] @uncheckedVariance] =
+    tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
+
+  /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   f   The function computing element values
+    *  @return A $coll consisting of elements `f(i1, i2, i3)`
+    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
+    */
+  def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[CC[CC[A]] @uncheckedVariance] =
+    tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
+
+  /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   n4  the number of elements in the 4th dimension
+    *  @param   f   The function computing element values
+    *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
+    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
+    */
+  def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[CC[CC[CC[A]]] @uncheckedVariance] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
+
+  /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+    *  @param   n1  the number of elements in the 1st dimension
+    *  @param   n2  the number of elements in the 2nd dimension
+    *  @param   n3  the number of elements in the 3nd dimension
+    *  @param   n4  the number of elements in the 4th dimension
+    *  @param   n5  the number of elements in the 5th dimension
+    *  @param   f   The function computing element values
+    *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
+    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
+    */
+  def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
+    tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
+}
+
+object ClassTagIterableFactory {
+  class Delegate[CC[_]](delegate: EvidenceIterableFactory[CC, ClassTag])
+    extends EvidenceIterableFactory.Delegate[CC, ClassTag](delegate) with ClassTagIterableFactory[CC]
+
+  /** An IterableFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
+    * sound depending on the use of the `ClassTag` by the collection implementation. */
+  class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
+    def empty[A]: CC[A] = delegate.empty(ClassTag.Any).asInstanceOf[CC[A]]
+    def from[A](it: IterableOnce[A]): CC[A] = delegate.from[Any](it)(ClassTag.Any).asInstanceOf[CC[A]]
+    def newBuilder[A](): Builder[A, CC[A]] = delegate.newBuilder()(ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
+    override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems: _*)(ClassTag.Any).asInstanceOf[CC[A]]
+    override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(ClassTag.Any).asInstanceOf[CC[A]]
+    override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(ClassTag.Any).asInstanceOf[CC[A]]
+  }
+}
+
+/**
+  * @tparam CC Collection type constructor (e.g. `WrappedArray`)
+  */
+trait ClassTagSeqFactory[+CC[_]] extends ClassTagIterableFactory[CC] {
+  def unapplySeq[A](x: CC[A] @uncheckedVariance): Some[CC[A]] = Some(x) //TODO is uncheckedVariance sound here?
+}
+
+object ClassTagSeqFactory {
+  class Delegate[CC[_]](delegate: ClassTagSeqFactory[CC])
+    extends ClassTagIterableFactory.Delegate[CC](delegate) with ClassTagSeqFactory[CC]
+
+  /** A SeqFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
+    * sound depending on the use of the `ClassTag` by the collection implementation. */
+  class AnySeqDelegate[CC[_]](delegate: ClassTagSeqFactory[CC])
+    extends ClassTagIterableFactory.AnyIterableDelegate[CC](delegate) with SeqFactory[CC]
+}
+
+trait StrictOptimizedClassTagSeqFactory[+CC[_]] extends ClassTagSeqFactory[CC] {
+
+  override def fill[A : ClassTag](n: Int)(elem: => A): CC[A] = {
+    val b = newBuilder[A]()
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += elem
+      i += 1
+    }
+    b.result()
+  }
+
+  override def tabulate[A : ClassTag](n: Int)(f: Int => A): CC[A] = {
+    val b = newBuilder[A]()
+    b.sizeHint(n)
+    var i = 0
+    while (i < n) {
+      b += f(i)
+      i += 1
+    }
+    b.result()
+  }
+
 }
 
 /**

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -260,7 +260,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       buf
     }
 
-    private def padding(x: Int) = immutable.ImmutableArray.fill(x)(pad.get())
+    private def padding(x: Int) = immutable.ImmutableArray.untagged.fill(x)(pad.get())
     private def gap = (step - size) max 0
 
     private def go(count: Int) = {
@@ -319,7 +319,7 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
       if (!filled)
         throw new NoSuchElementException("next on empty iterator")
       filled = false
-      immutable.ImmutableArray.fromArrayBuffer(buffer)
+      immutable.ImmutableArray.unsafeWrapArray(buffer.toArray[Any])
     }
   }
 

--- a/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
@@ -26,7 +26,7 @@ final class WrappedString(val self: String) extends AbstractSeq[Char] with Index
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[Char]): IndexedSeq[Char] =
     WrappedString.fromSpecific(coll)
   protected[this] def newSpecificBuilder(): Builder[Char, IndexedSeq[Char]] = WrappedString.newBuilder()
-  def iterableFactory: SeqFactory[IndexedSeq] = ImmutableArray
+  def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
 
   override def slice(from: Int, until: Int): WrappedString = {
     val start = if (from < 0) 0 else from

--- a/collections/src/main/scala/strawman/collection/package.scala
+++ b/collections/src/main/scala/strawman/collection/package.scala
@@ -2,7 +2,6 @@ package strawman
 
 import scala.{Any, AnyVal, Array, Boolean, Char, IllegalArgumentException, IndexOutOfBoundsException, Int, NoSuchElementException, Unit, UnsupportedOperationException, PartialFunction, Option, None, Some, deprecated}
 import scala.Predef.{String, ArrowAssoc}
-import scala.reflect.ClassTag
 
 package object collection extends LowPriority {
   @deprecated("Use Iterable instead of Traversable", "2.13.0")

--- a/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
@@ -79,7 +79,7 @@ class FactoriesTest {
         immutable.List,
         immutable.LazyList,
         immutable.Vector,
-        immutable.ImmutableArray,
+        immutable.ImmutableArray.untagged,
         mutable.ListBuffer: SeqFactory[mutable.ListBuffer], // type ascription needed by dotty
         mutable.ArrayBuffer: SeqFactory[mutable.ArrayBuffer] // type ascription needed by dotty
       )


### PR DESCRIPTION
This reinstates the factory part of the abstraction for arbitrary
evidence type constructors which we previously abandoned in favor of
SortedIterableFactory. Now we have a good reason for an
EvidenceIterableFactory with several Ordering-based and several
ClassTag-based factory instances.

ImmutableArray and WrappedArray now have a ClassTag-based factory in
their companion object so that building unboxed arrays with a proper
element type is always the default (and used automatically in calls like
`xs.to(ImmutableArray)` which would previously go through the regular
IterableFactory and build a boxed representation). IterableFactories are
still available as `{ImmutableArray/WrappedArray}.untagged`.

There are no new abstractions at the collection level. We could
consider reintroducing a ConstrainedIterable but at lower levels of
the hierarchy it doesn’t make sense because the Ordering- and
ClassTag-based collections are of very different types.

There are also some fixes for bad arraycopy calls (between boxed and
unboxed representations) and unnecessary boxing in combinators in
ImmutableArray.