### PR TITLE
[392] Fix bug in indexOfSlice/lastIndexOfSlice when Seq.size == slice.size

### DIFF
--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -855,7 +855,7 @@ object SeqOps {
     // Check for redundant case when both sequences are same size
     else if (m1-m0 == n1-n0) {
       // Accepting a little slowness for the uncommon case.
-      if (S.view.slice(m0, m1) == W.view.slice(n0, n1)) m0
+      if (S.iterator().slice(m0, m1).sameElements(W.iterator().slice(n0, n1))) m0
       else -1
     }
     // Now we know we actually need KMP search, so do it

--- a/test/junit/src/test/scala/strawman/collection/SeqTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/SeqTest.scala
@@ -45,4 +45,22 @@ class SeqTest {
 
     assertEquals(Seq("a", "aa", "aaa", "bbbb"), result)
   }
+
+  @Test
+  def hasCorrectIndexOfSlice(): Unit = {
+    assertEquals(0, Vector(0, 1).indexOfSlice(List(0, 1)))
+    assertEquals(0, Vector(0, 1).indexOfSlice(Vector(0, 1)))
+    assertEquals(1, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2)))
+    assertEquals(4, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2), from = 2))
+    assertEquals(-1, List(0, 1).indexOfSlice(List(1, 2)))
+  }
+
+  @Test
+  def hasCorrectLastIndexOfSlice(): Unit = {
+    assertEquals(0, Vector(0, 1).lastIndexOfSlice(List(0, 1)))
+    assertEquals(0, Vector(0, 1).lastIndexOfSlice(Vector(0, 1)))
+    assertEquals(4, Vector(0, 1, 2, 0, 1, 2).lastIndexOfSlice(Vector(1, 2)))
+    assertEquals(1, Vector(0, 1, 2, 0, 1, 2).lastIndexOfSlice(Vector(1, 2), end = 3))
+    assertEquals(-1, List(0, 1).lastIndexOfSlice(List(1, 2)))
+  }
 }


### PR DESCRIPTION
Fixes #392

Bug was in the equality comparison of views in `S.view.slice(m0, m1) == W.view.slice(n0, n1)`. Views don't override `equals` in strawman.