### PR TITLE
Bring back collection.convert.ImplicitConversions and fix StackOverflowError in Java wrappers' iterator()

### DIFF
--- a/collections/src/main/scala/strawman/collection/convert/ImplicitConversions.scala
+++ b/collections/src/main/scala/strawman/collection/convert/ImplicitConversions.scala
@@ -1,0 +1,172 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2016, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package strawman
+package collection
+package convert
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import scala.Predef.String
+import scala.language.implicitConversions
+
+import JavaConverters._
+
+/** Defines implicit converter methods from Java to Scala collections. */
+trait ToScalaImplicits {
+  /** Implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   *  @see [[AsScalaConverters.asScalaIterator]]
+   */
+  implicit def `iterator asScala`[A](it: ju.Iterator[A]): Iterator[A] = asScalaIterator(it)
+
+  /** Implicitly converts a Java `Enumeration` to a Scala `Iterator`.
+   *  @see [[AsScalaConverters.enumerationAsScalaIterator]]
+   */
+  implicit def `enumeration AsScalaIterator`[A](i: ju.Enumeration[A]): Iterator[A] = enumerationAsScalaIterator(i)
+
+  /** Implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   *  @see [[AsScalaConverters.iterableAsScalaIterable]]
+   */
+  implicit def `iterable AsScalaIterable`[A](i: jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable(i)
+
+  /** Implicitly converts a Java `Collection` to an Scala `Iterable`.
+   *  @see [[AsScalaConverters.collectionAsScalaIterable]]
+   */
+  implicit def `collection AsScalaIterable`[A](i: ju.Collection[A]): Iterable[A] = collectionAsScalaIterable(i)
+
+  /** Implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   *  @see [[AsScalaConverters.asScalaBuffer]]
+   */
+  implicit def `list asScalaBuffer`[A](l: ju.List[A]): mutable.Buffer[A] = asScalaBuffer(l)
+
+  /** Implicitly converts a Java `Set` to a Scala mutable `Set`.
+   *  @see [[AsScalaConverters.asScalaSet]]
+   */
+  implicit def `set asScala`[A](s: ju.Set[A]): mutable.Set[A] = asScalaSet(s)
+
+  /** Implicitly converts a Java `Map` to a Scala mutable `Map`.
+   *  @see [[AsScalaConverters.mapAsScalaMap]]
+   */
+  implicit def `map AsScala`[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap(m)
+
+  /** Implicitly converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
+   *  @see [[AsScalaConverters.mapAsScalaConcurrentMap]]
+   */
+  implicit def `map AsScalaConcurrentMap`[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = mapAsScalaConcurrentMap(m)
+
+  /** Implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
+   *  @see [[AsScalaConverters.dictionaryAsScalaMap]]
+   */
+  implicit def `dictionary AsScalaMap`[A, B](p: ju.Dictionary[A, B]): mutable.Map[A, B] = dictionaryAsScalaMap(p)
+
+  /** Implicitly converts a Java `Properties` to a Scala `mutable Map[String, String]`.
+   *  @see [[AsScalaConverters.propertiesAsScalaMap]]
+   */
+  implicit def `properties AsScalaMap`(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+/** Defines implicit conversions from Scala to Java collections. */
+trait ToJavaImplicits {
+  /** Implicitly converts a Scala `Iterator` to a Java `Iterator`.
+   *  @see [[AsJavaConverters.asJavaIterator]]
+   */
+  implicit def `iterator asJava`[A](it: Iterator[A]): ju.Iterator[A] = asJavaIterator(it)
+
+  /** Implicitly converts a Scala `Iterator` to a Java `Enumeration`.
+   *  @see [[AsJavaConverters.asJavaEnumeration]]
+   */
+  implicit def `enumeration asJava`[A](it: Iterator[A]): ju.Enumeration[A] = asJavaEnumeration(it)
+
+  /** Implicitly converts a Scala `Iterable` to a Java `Iterable`.
+   *  @see [[AsJavaConverters.asJavaIterable]]
+   */
+  implicit def `iterable asJava`[A](i: Iterable[A]): jl.Iterable[A] = asJavaIterable(i)
+
+  /** Implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
+   *  @see [[AsJavaConverters.asJavaCollection]]
+   */
+  implicit def `collection asJava`[A](it: Iterable[A]): ju.Collection[A] = asJavaCollection(it)
+
+  /** Implicitly converts a Scala mutable `Buffer` to a Java `List`.
+   *  @see [[AsJavaConverters.bufferAsJavaList]]
+   */
+  implicit def `buffer AsJavaList`[A](b: mutable.Buffer[A]): ju.List[A] = bufferAsJavaList(b)
+
+  /** Implicitly converts a Scala mutable `Seq` to a Java `List`.
+   *  @see [[AsJavaConverters.mutableSeqAsJavaList]]
+   */
+  implicit def `mutableSeq AsJavaList`[A](seq: mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList(seq)
+
+  /** Implicitly converts a Scala `Seq` to a Java `List`.
+   *  @see [[AsJavaConverters.seqAsJavaList]]
+   */
+  implicit def `seq AsJavaList`[A](seq: Seq[A]): ju.List[A] = seqAsJavaList(seq)
+
+  /** Implicitly converts a Scala mutable `Set` to a Java `Set`.
+   *  @see [[AsJavaConverters.mutableSetAsJavaSet]]
+   */
+  implicit def `mutableSet AsJavaSet`[A](s: mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet(s)
+
+  /** Implicitly converts a Scala `Set` to a Java `Set`.
+   *  @see [[AsJavaConverters.setAsJavaSet]]
+   */
+  implicit def `set AsJavaSet`[A](s: Set[A]): ju.Set[A] = setAsJavaSet(s)
+
+  /** Implicitly converts a Scala mutable `Map` to a Java `Map`.
+   *  @see [[AsJavaConverters.mutableMapAsJavaMap]]
+   */
+  implicit def `mutableMap AsJavaMap`[A, B](m: mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap(m)
+
+  /** Implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   *  @see [[AsJavaConverters.asJavaDictionary]]
+   */
+  implicit def `dictionary asJava`[A, B](m: mutable.Map[A, B]): ju.Dictionary[A, B] = asJavaDictionary(m)
+
+  /** Implicitly converts a Scala `Map` to a Java `Map`.
+   *  @see [[AsJavaConverters.mapAsJavaMap]]
+   */
+  implicit def `map AsJavaMap`[A, B](m: Map[A, B]): ju.Map[A, B] = mapAsJavaMap(m)
+
+  /** Implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
+   *  @see [[AsJavaConverters.mapAsJavaConcurrentMap]]
+   */
+  implicit def `map AsJavaConcurrentMap`[A, B](m: concurrent.Map[A, B]): juc.ConcurrentMap[A, B] = mapAsJavaConcurrentMap(m)
+}
+
+/**
+ * Convenience for miscellaneous implicit conversions from Scala to Java collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues, see [[ImplicitConversions]].
+ */
+object ImplicitConversionsToJava extends ToJavaImplicits
+
+/**
+ * Convenience for miscellaneous implicit conversions from Java to Scala collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues, see [[ImplicitConversions]].
+ */
+object ImplicitConversionsToScala extends ToScalaImplicits
+
+/**
+ * Convenience for miscellaneous implicit conversions between Java and Scala collections API.
+ *
+ * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
+ * Implicit conversions may cause unexpected issues. Example:
+ *
+ * {{{
+ *   import collection.convert.ImplicitConversions._
+ *   case class StringBox(s: String)
+ *   val m = Map(StringBox("one") -> "uno")
+ *   m.get("one")
+ * }}}
+ *
+ * The above example returns `null` instead of producing a type error at compile-time. The map is
+ * implicitly converted to a `java.util.Map` which provides a method `get(x: AnyRef)`.
+ */
+object ImplicitConversions extends ToScalaImplicits with ToJavaImplicits

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -53,14 +53,14 @@ private[collection] trait Wrappers {
   case class IterableWrapper[A](underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] { }
 
   case class JIterableWrapper[A](underlying: jl.Iterable[A]) extends AbstractIterable[A] with Iterable[A] {
-    def iterator() = underlying.asScala.iterator()
+    def iterator() = underlying.iterator().asScala
     protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
     def iterableFactory = mutable.ArrayBuffer
     protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
   }
 
   case class JCollectionWrapper[A](underlying: ju.Collection[A]) extends AbstractIterable[A] with Iterable[A] {
-    def iterator() = underlying.asScala.iterator()
+    def iterator() = underlying.iterator().asScala
     override def size = underlying.size
     override def isEmpty = underlying.isEmpty
     protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
@@ -91,7 +91,7 @@ private[collection] trait Wrappers {
   case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with SeqOps[A, mutable.Buffer, mutable.Buffer[A]] {
     def length = underlying.size
     override def isEmpty = underlying.isEmpty
-    override def iterator(): Iterator[A] = underlying.asScala.iterator()
+    override def iterator(): Iterator[A] = underlying.iterator().asScala
     def apply(i: Int) = underlying.get(i)
     def update(i: Int, elem: A) = underlying.set(i, elem)
     def prepend(elem: A) = { underlying.subList(0, 0) add elem; this }
@@ -184,7 +184,7 @@ private[collection] trait Wrappers {
 
     override def size = underlying.size
 
-    def iterator() = underlying.asScala.iterator()
+    def iterator() = underlying.iterator().asScala
 
     def contains(elem: A): Boolean = underlying.contains(elem)
 

--- a/test/junit/src/test/scala/strawman/collection/convert/JCollectionWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/JCollectionWrapperTest.scala
@@ -1,0 +1,23 @@
+package strawman.collection.convert
+
+import java.{util => ju}
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.Iterable
+import strawman.collection.JavaConverters._
+
+@RunWith(classOf[JUnit4])
+class JCollectionWrapperTest {
+
+  @Test
+  def testIteratorDoesNotCauseStackOverflow(): Unit = {
+    val jCol: ju.Collection[Int] = ju.Arrays.asList(1, 2, 3)
+    val sIterable: Iterable[Int] = jCol.asScala
+
+    assertTrue(sIterable.isInstanceOf[Wrappers.JCollectionWrapper[_]])
+    assertTrue(sIterable.iterator().sameElements(Iterable(1, 2, 3)))
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/JIterableWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/JIterableWrapperTest.scala
@@ -1,0 +1,23 @@
+package strawman.collection.convert
+
+import java.{lang => jl, util => ju}
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.Iterable
+import strawman.collection.JavaConverters._
+
+@RunWith(classOf[JUnit4])
+class JIterableWrapperTest {
+
+  @Test
+  def testIteratorDoesNotCauseStackOverflow(): Unit = {
+    val jIterable: jl.Iterable[Int] = ju.Arrays.asList(1, 2, 3)
+    val sIterable: Iterable[Int] = jIterable.asScala
+
+    assertTrue(sIterable.isInstanceOf[Wrappers.JIterableWrapper[_]])
+    assertTrue(sIterable.iterator().sameElements(Iterable(1, 2, 3)))
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/JListWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/JListWrapperTest.scala
@@ -1,0 +1,24 @@
+package strawman.collection.convert
+
+import java.{util => ju}
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.JavaConverters._
+import strawman.collection.immutable.List
+import strawman.collection.mutable.Buffer
+
+@RunWith(classOf[JUnit4])
+class JListWrapperTest {
+
+  @Test
+  def testIteratorDoesNotCauseStackOverflow(): Unit = {
+    val jList: ju.List[Int] = ju.Arrays.asList(1, 2, 3)
+    val sList: Buffer[Int] = jList.asScala
+
+    assertTrue(sList.isInstanceOf[Wrappers.JListWrapper[_]])
+    assertTrue(sList.iterator().sameElements(List(1, 2, 3)))
+  }
+}

--- a/test/junit/src/test/scala/strawman/collection/convert/JSetWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/JSetWrapperTest.scala
@@ -1,0 +1,23 @@
+package strawman.collection.convert
+
+import java.{util => ju}
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import strawman.collection.JavaConverters._
+import strawman.collection.Set
+
+@RunWith(classOf[JUnit4])
+class JSetWrapperTest {
+
+  @Test
+  def testIteratorDoesNotCauseStackOverflow(): Unit = {
+    val jSet: ju.Set[Int] = new ju.HashSet(ju.Arrays.asList(1, 2, 3))
+    val sSet: Set[Int] = jSet.asScala
+
+    assertTrue(sSet.isInstanceOf[Wrappers.JSetWrapper[_]])
+    assertTrue(sSet.iterator().sameElements(Set(1, 2, 3)))
+  }
+}


### PR DESCRIPTION
This PR addresses #372 and fixes `StackOverflowError`s found in Java wrappers' iterator() while testing.