### PR TITLE
Fix Vector.prependedAll

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -206,7 +206,8 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
       prefix.size match {
         case n if n <= TinyAppendFaster || n < (this.size >>> Log2ConcatFaster) =>
           var v: Vector[B] = this
-          for (b <- prefix) v = b +: v
+          val it = prefix.toIndexedSeq.reverseIterator()
+          while (it.hasNext) v = it.next() +: v
           v
         case n if this.size < (n >>> Log2ConcatFaster) && prefix.isInstanceOf[Vector[_]] =>
           var v = prefix.asInstanceOf[Vector[B]]

--- a/test/junit/src/test/scala/strawman/collection/immutable/VectorTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/VectorTest.scala
@@ -27,4 +27,16 @@ class VectorTest {
     assertEquals(v, v drop Int.MinValue)
     assertEquals(v, v dropRight Int.MinValue)
   }
+
+  @Test
+  def hasCorrectPrependedAll(): Unit = {
+    val els = Vector(1 to 1000: _*)
+
+    for (i <- 0 until els.size) {
+      val (prefix, suffix) = els.splitAt(i)
+
+      assertEquals(els, prefix ++: suffix)
+      assertEquals(els, prefix.toList ++: suffix)
+    }
+  }
 }


### PR DESCRIPTION
This PR aims to fix #399

`Vector` provides an optimized version of `prependedAll` (overrides the one inherited from `StrictOptimizedSeqOps`). In one of the cases, the `prefix` elements are incorrectly stacked in front of `this`, which messes up with the order of the resulting vector.

My solution to this was to relax the visibility of `Iterable.reversed` as it seemed to be the fastest alternative to have the elements prepended in the correct order.

I ran some [benchmarks](https://gist.github.com/marcelocenerine/0bac34b3c9def261cd5029a874b4d4ae) to compare the performance of:
- Scala's `Vector.++:`
- `prependedAll` inherited from `StrictOptimizedSeqOps`
- the buggy `prependedAll`
- the fixed `prependedAll`

It turns out that the optimization for `Vector` is ~5x faster than the one from `StrictOptimizedSeqOps`. Also, Scala's `Vector` does not override `++:` which makes its performance be similar to `StrictOptimizedSeqOps`'s.

`prependedAll` became slightly slower after my fix (<0.2x). Here are the [JMH logs](https://github.com/scala/collection-strawman/files/1693389/jmh-result.txt).

**Note:** the size parameter in the table/charts below correspond to the prefix size. The Vector size is calculated based on the prefix.size so that the lines of code we are interested in always execute. 

![image](https://user-images.githubusercontent.com/1107367/35783173-e8233a80-09fa-11e8-8cd9-7148340757b6.png)

![image](https://user-images.githubusercontent.com/1107367/35783181-035a83a8-09fb-11e8-95a6-75074cd60ccb.png)

I also tested a similar approach where the`prefix` iterable is transformed into an `IndexedSeq` and then the traversal is done via `reverseIterator()`. The advantage of this approach is that it would avoid the additional traversal to reverse the elements if `prefix` is already an `IndexedSeq`. However, for non-`IndexedSeq` collections the performance was slightly slower.

![image](https://user-images.githubusercontent.com/1107367/35784761-015bca90-0a13-11e8-9d30-a69e720b3862.png)



@julienrf / @Ichoran, please let me know if you have a better strategy.