### PR TITLE
Make LazyList.drop safe

### DIFF
--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -52,15 +52,15 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
 
   // Optimized version of `drop` that avoids copying
   override def drop(n: Int): C = {
-    def loop(n: Int, s: Iterable[A]): C =
-      if (n <= 0) s.asInstanceOf[C]
+    @tailrec def loop(n: Int, s: LinearSeq[A]): C =
+      if (n <= 0 || s.isEmpty) s.asInstanceOf[C]
       // implicit contract to guarantee success of asInstanceOf:
       //   (1) coll is of type C[A]
       //   (2) The tail of a LinearSeq is of the same type as the type of the sequence itself
       // it's surprisingly tricky/ugly to turn this into actual types, so we
       // leave this contract implicit.
       else loop(n - 1, s.tail)
-    loop(n, toIterable)
+    loop(n, coll)
   }
 
   // `apply` is defined in terms of `drop`, which is in turn defined in

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -156,16 +156,6 @@ sealed abstract class List[+A]
     h
   }
 
-  override def drop(n: Int): List[A] = {
-    var these = this
-    var count = n
-    while (!these.isEmpty && count > 0) {
-      these = these.tail
-      count -= 1
-    }
-    these
-  }
-
   /**
     *  @example {{{
     *  // Given a list

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -131,4 +131,12 @@ class LazyListTest {
     val s = LazyList.empty.#::(f).#::(f).#::(f)
     assertEquals(0, i)
   }
+
+  def hasCorrectDrop(): Unit = {
+    assertEquals(LazyList(), LazyList().drop(2))
+    assertEquals(LazyList(), LazyList(1).drop(2))
+    assertEquals(LazyList(), LazyList(1, 2).drop(2))
+    assertEquals(LazyList(3), LazyList(1, 2, 3).drop(2))
+    assertEquals(LazyList(3, 4), LazyList(1, 2, 3, 4).drop(2))
+  }
 }


### PR DESCRIPTION
Fixes #395

- Add extra condition in `LinearSeq.drop` to stop recursion when `tail` is empty (seemed pointless).
- Remove override in `List` as it basically duplicates what `LinearSeq.drop` does now