### PR TITLE
Bug fixes for Buffer/ArrayBuffer/ListBuffer

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -154,7 +154,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initLength: Int)
       Array.copy(array, idx + count, array, idx, end - (idx + count))
       reduceToSize(end - count)
     } else if (count < 0) {
-      throw new IllegalArgumentException("removing negative number of elements: " + count.toString)
+      throw new IllegalArgumentException("removing negative number of elements: " + count)
     }
 
   override def className = "ArrayBuffer"

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Int, `inline`, throws, IndexOutOfBoundsException, IllegalArgumentException, Unit, Boolean, Array, deprecated}
+import scala.{Int, `inline`, throws, IndexOutOfBoundsException, IllegalArgumentException, Unit, Boolean, Array, deprecated, math}
 import scala.Predef.intWrapper
 
 /** A `Buffer` is a growable and shrinkable `Seq`. */
@@ -85,7 +85,7 @@ trait Buffer[A]
 
   def dropInPlace(n: Int): this.type = { remove(0, n); this }
   def dropRightInPlace(n: Int): this.type = { remove(length - n, n); this }
-  def takeInPlace(n: Int): this.type = { remove(n, length); this }
+  def takeInPlace(n: Int): this.type = { remove(n, length - math.min(math.max(n, 0), length)); this }
   def takeRightInPlace(n: Int): this.type = { remove(0, length - n); this }
   def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
 

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -94,7 +94,7 @@ trait Buffer[A]
     remove(norm, length - norm)
     this
   }
-  def takeRightInPlace(n: Int): this.type = { remove(0, length - n); this }
+  def takeRightInPlace(n: Int): this.type = { remove(0, length - normalized(n)); this }
   def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
   private def normalized(n: Int): Int = math.min(math.max(n, 0), length)
 

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -83,11 +83,12 @@ trait Buffer[A]
   // def +=:(elem1: A, elem2: A, elems: A*): this.type = elem1 +=: elem2 +=: elems.toStrawman ++=: this
   // def ++=:(elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
 
-  def dropInPlace(n: Int): this.type = {
-    remove(0, normalized(n))
+  def dropInPlace(n: Int): this.type = { remove(0, normalized(n)); this }
+  def dropRightInPlace(n: Int): this.type = {
+    val norm = normalized(n)
+    remove(length - norm, norm)
     this
   }
-  def dropRightInPlace(n: Int): this.type = { remove(length - n, n); this }
   def takeInPlace(n: Int): this.type = {
     val norm = normalized(n)
     remove(norm, length - norm)

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -83,11 +83,19 @@ trait Buffer[A]
   // def +=:(elem1: A, elem2: A, elems: A*): this.type = elem1 +=: elem2 +=: elems.toStrawman ++=: this
   // def ++=:(elems: IterableOnce[A]): this.type = { insertAll(0, elems); this }
 
-  def dropInPlace(n: Int): this.type = { remove(0, n); this }
+  def dropInPlace(n: Int): this.type = {
+    remove(0, normalized(n))
+    this
+  }
   def dropRightInPlace(n: Int): this.type = { remove(length - n, n); this }
-  def takeInPlace(n: Int): this.type = { remove(n, length - math.min(math.max(n, 0), length)); this }
+  def takeInPlace(n: Int): this.type = {
+    val norm = normalized(n)
+    remove(norm, length - norm)
+    this
+  }
   def takeRightInPlace(n: Int): this.type = { remove(0, length - n); this }
   def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
+  private def normalized(n: Int): Int = math.min(math.max(n, 0), length)
 
   def dropWhileInPlace(p: A => Boolean): this.type = {
     val idx = indexWhere(!p(_))

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -72,7 +72,7 @@ trait Buffer[A]
     *  @param n  the number of elements to remove from the end
     *            of this buffer.
     */
-  def trimEnd(n: Int): Unit = remove(length - scala.math.max(n, 0), n)
+  def trimEnd(n: Int): Unit = remove(length - math.max(n, 0), n)
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type
 

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -65,14 +65,17 @@ trait Buffer[A]
     *  @param n  the number of elements to remove from the beginning
     *            of this buffer.
     */
-  def trimStart(n: Int): Unit = remove(0, n)
+  def trimStart(n: Int): Unit = remove(0, normalized(n))
 
   /** Removes the last ''n'' elements of this buffer.
     *
     *  @param n  the number of elements to remove from the end
     *            of this buffer.
     */
-  def trimEnd(n: Int): Unit = remove(length - math.max(n, 0), n)
+  def trimEnd(n: Int): Unit = {
+    val norm = normalized(n)
+    remove(length - norm, norm)
+  }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type
 

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -117,17 +117,18 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def filterInPlace(p: A => Boolean): this.type = {
-    var i = 0
-    while (i < size && p(apply(i))) i += 1
-    var j = 1
+    var i, j = 0
     while (i < size) {
       if (p(apply(i))) {
-        this(j) = this(i)
+        if (i != j) {
+          this(j) = this(i)
+        }
         j += 1
       }
       i += 1
     }
-    takeInPlace(j)
+
+    if (i == j) this else takeInPlace(j)
   }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -8,7 +8,7 @@ import scala.Int._
 import strawman.collection
 import strawman.collection.immutable.{List, Nil, ::}
 import scala.annotation.tailrec
-import java.lang.IndexOutOfBoundsException
+import java.lang.{IllegalArgumentException, IndexOutOfBoundsException}
 import scala.Predef.{assert, intWrapper}
 
 /** A `Buffer` implementation backed by a list. It provides constant time
@@ -214,11 +214,13 @@ class ListBuffer[A]
     nx.head
   }
 
-  def remove(idx: Int, n: Int): Unit =
-    if (n > 0) {
+  def remove(idx: Int, count: Int): Unit =
+    if (count > 0) {
       ensureUnaliased()
-      if (idx < 0 || idx + n > len) throw new IndexOutOfBoundsException
-      removeAfter(locate(idx), n)
+      if (idx < 0 || idx + count > len) throw new IndexOutOfBoundsException
+      removeAfter(locate(idx), count)
+    } else if (count < 0) {
+      throw new IllegalArgumentException("removing negative number of elements: " + count)
     }
 
   private def removeAfter(prev: Predecessor[A], n: Int) = {

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -260,8 +260,9 @@ class ListBuffer[A]
       if (!p(cur.head)) {
         setNext(prev, follow)
         len -= 1
+      } else {
+        prev = cur.asInstanceOf[Predecessor[A]]
       }
-      prev = cur.asInstanceOf[Predecessor[A]]
       cur = follow
     }
     this

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -207,10 +207,10 @@ class ListBuffer[A]
   def remove(idx: Int): A = {
     ensureUnaliased()
     if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException
-    len -= 1
     val p = locate(idx)
     val nx = getNext(p)
     setNext(p, nx.tail)
+    len -= 1
     nx.head
   }
 

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -77,8 +77,17 @@ class ArrayBufferTest {
   @Test
   def testTakeInPlace: Unit = {
     assertEquals(ArrayBuffer(), ArrayBuffer().takeInPlace(10))
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).takeInPlace(-1))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).takeInPlace(10))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 100).takeInPlace(10))
+  }
+
+  @Test
+  def testDropInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer().dropInPlace(10))
+    assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).dropInPlace(-1))
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).dropInPlace(10))
+    assertEquals(ArrayBuffer.range(10, 100), ArrayBuffer.range(0, 100).dropInPlace(10))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -83,6 +83,14 @@ class ArrayBufferTest {
   }
 
   @Test
+  def testTakeRightInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer().takeRightInPlace(10))
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).takeRightInPlace(-1))
+    assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).takeRightInPlace(10))
+    assertEquals(ArrayBuffer.range(90, 100), ArrayBuffer.range(0, 100).takeRightInPlace(10))
+  }
+
+  @Test
   def testDropInPlace: Unit = {
     assertEquals(ArrayBuffer(), ArrayBuffer().dropInPlace(10))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).dropInPlace(-1))

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -67,6 +67,14 @@ class ArrayBufferTest {
   }
 
   @Test
+  def testFilterInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 100).filterInPlace(_ => false))
+    assertEquals(ArrayBuffer.range(0, 100), ArrayBuffer.range(0, 100).filterInPlace(_ => true))
+    assertEquals(ArrayBuffer.range(start = 0, end = 100, step = 2), ArrayBuffer.range(0, 100).filterInPlace(_ % 2 == 0))
+    assertEquals(ArrayBuffer.range(start = 1, end = 100, step = 2), ArrayBuffer.range(0, 100).filterInPlace(_ % 2 != 0))
+  }
+
+  @Test
   def testTakeInPlace: Unit = {
     assertEquals(ArrayBuffer(), ArrayBuffer().takeInPlace(10))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).takeInPlace(10))

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -82,6 +82,31 @@ class ArrayBufferTest {
   }
 
   @Test
+  def testRemove: Unit = {
+    val b1 = ArrayBuffer(0, 1, 2)
+    assertEquals(0, b1.remove(0))
+    assertEquals(ArrayBuffer(1, 2), b1)
+
+    val b2 = ArrayBuffer(0, 1, 2)
+    assertEquals(1, b2.remove(1))
+    assertEquals(ArrayBuffer(0, 2), b2)
+
+    val b3 = ArrayBuffer(0, 1, 2)
+    assertEquals(2, b3.remove(2))
+    assertEquals(ArrayBuffer(0, 1), b3)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testRemoveWithNegativeIndex: Unit = {
+    ArrayBuffer(0, 1, 2).remove(-1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testRemoveWithTooLargeIndex: Unit = {
+    ArrayBuffer(0).remove(1)
+  }
+
+  @Test
   def testRemoveMany: Unit = {
     def testRemoveMany(idx: Int, count: Int, expectation: ArrayBuffer[Int]): Unit = {
       val buffer = ArrayBuffer(0, 1, 2)
@@ -99,22 +124,22 @@ class ArrayBufferTest {
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithNegativeIndex: Unit = {
+  def testRemoveManyWithNegativeIndex: Unit = {
     ArrayBuffer(0, 1, 2).remove(idx = -1, count = 1)
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithTooLargeIndex: Unit = {
+  def testRemoveManyWithTooLargeIndex: Unit = {
     ArrayBuffer(0).remove(idx = 1, count = 1)
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def removeManyWithNegativeCount: Unit = {
+  def testRemoveManyWithNegativeCount: Unit = {
     ArrayBuffer(0).remove(idx = 0, count = -1)
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithTooLargeCount: Unit = {
+  def testRemoveManyWithTooLargeCount: Unit = {
     ArrayBuffer(0).remove(idx = 0, count = 100)
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -65,4 +65,11 @@ class ArrayBufferTest {
 
     assertEquals(ArrayBuffer(els.reverse: _*), buffer)
   }
+
+  @Test
+  def testTakeInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer().takeInPlace(10))
+    assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).takeInPlace(10))
+    assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 100).takeInPlace(10))
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -80,4 +80,41 @@ class ArrayBufferTest {
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).takeInPlace(10))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 100).takeInPlace(10))
   }
+
+  @Test
+  def testRemoveMany: Unit = {
+    def testRemoveMany(idx: Int, count: Int, expectation: ArrayBuffer[Int]): Unit = {
+      val buffer = ArrayBuffer(0, 1, 2)
+      buffer.remove(idx, count)
+      assertEquals(expectation, buffer)
+    }
+
+    testRemoveMany(idx = 0, count = 0, expectation = ArrayBuffer(0, 1, 2))
+    testRemoveMany(idx = 0, count = 1, expectation = ArrayBuffer(1, 2))
+    testRemoveMany(idx = 0, count = 2, expectation = ArrayBuffer(2))
+    testRemoveMany(idx = 0, count = 3, expectation = ArrayBuffer())
+    testRemoveMany(idx = 1, count = 1, expectation = ArrayBuffer(0, 2))
+    testRemoveMany(idx = 1, count = 2, expectation = ArrayBuffer(0))
+    testRemoveMany(idx = 2, count = 1, expectation = ArrayBuffer(0, 1))
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithNegativeIndex: Unit = {
+    ArrayBuffer(0, 1, 2).remove(idx = -1, count = 1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithTooLargeIndex: Unit = {
+    ArrayBuffer(0).remove(idx = 1, count = 1)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def removeManyWithNegativeCount: Unit = {
+    ArrayBuffer(0).remove(idx = 0, count = -1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithTooLargeCount: Unit = {
+    ArrayBuffer(0).remove(idx = 0, count = 100)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -167,4 +167,42 @@ class ArrayBufferTest {
   def testRemoveManyWithTooLargeCount: Unit = {
     ArrayBuffer(0).remove(idx = 0, count = 100)
   }
+
+  @Test
+  def testTrimStart: Unit = {
+    val b1 = ArrayBuffer()
+    b1.trimStart(10)
+    assertEquals(ArrayBuffer(), b1)
+
+    val b2 = ArrayBuffer.range(0, 10)
+    b2.trimStart(-1)
+    assertEquals(ArrayBuffer.range(0, 10), b2)
+
+    val b3 = ArrayBuffer.range(0, 10)
+    b3.trimStart(10)
+    assertEquals(ArrayBuffer(), b3)
+
+    val b4 = ArrayBuffer.range(0, 100)
+    b4.trimStart(10)
+    assertEquals(ArrayBuffer.range(10, 100), b4)
+  }
+
+  @Test
+  def testTrimEnd: Unit = {
+    val b1 = ArrayBuffer()
+    b1.trimEnd(10)
+    assertEquals(ArrayBuffer(), b1)
+
+    val b2 = ArrayBuffer.range(0, 10)
+    b2.trimEnd(-1)
+    assertEquals(ArrayBuffer.range(0, 10), b2)
+
+    val b3 = ArrayBuffer.range(0, 10)
+    b3.trimEnd(10)
+    assertEquals(ArrayBuffer(), b3)
+
+    val b4 = ArrayBuffer.range(0, 100)
+    b4.trimEnd(10)
+    assertEquals(ArrayBuffer.range(0, 90), b4)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -91,6 +91,14 @@ class ArrayBufferTest {
   }
 
   @Test
+  def testDropRightInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer().dropRightInPlace(10))
+    assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).dropRightInPlace(-1))
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).dropRightInPlace(10))
+    assertEquals(ArrayBuffer.range(0, 90), ArrayBuffer.range(0, 100).dropRightInPlace(10))
+  }
+
+  @Test
   def testRemove: Unit = {
     val b1 = ArrayBuffer(0, 1, 2)
     assertEquals(0, b1.remove(0))

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -91,6 +91,13 @@ class ArrayBufferTest {
   }
 
   @Test
+  def testTakeWhileInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ListBuffer[Int]().takeWhileInPlace(_ < 50))
+    assertEquals(ArrayBuffer.range(0, 10), ListBuffer.range(0, 10).takeWhileInPlace(_ < 50))
+    assertEquals(ArrayBuffer.range(0, 50), ListBuffer.range(0, 100).takeWhileInPlace(_ < 50))
+  }
+
+  @Test
   def testDropInPlace: Unit = {
     assertEquals(ArrayBuffer(), ArrayBuffer().dropInPlace(10))
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).dropInPlace(-1))
@@ -104,6 +111,13 @@ class ArrayBufferTest {
     assertEquals(ArrayBuffer.range(0, 10), ArrayBuffer.range(0, 10).dropRightInPlace(-1))
     assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).dropRightInPlace(10))
     assertEquals(ArrayBuffer.range(0, 90), ArrayBuffer.range(0, 100).dropRightInPlace(10))
+  }
+
+  @Test
+  def testDropWhileInPlace: Unit = {
+    assertEquals(ArrayBuffer(), ArrayBuffer[Int]().dropWhileInPlace(_ < 50))
+    assertEquals(ArrayBuffer(), ArrayBuffer.range(0, 10).dropWhileInPlace(_ < 50))
+    assertEquals(ArrayBuffer.range(50, 100), ArrayBuffer.range(0, 100).dropWhileInPlace(_ < 50))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -1,8 +1,8 @@
 package strawman.collection.mutable
 
+import org.junit.Assert.{assertEquals, assertTrue}
 import strawman.collection.immutable.Nil
-
-import org.junit.{Assert, Test}
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -13,18 +13,25 @@ class ListBufferTest {
   def hasCorrectClear(): Unit = {
     val b = ListBuffer.empty[String]
     b += "a"
-    Assert.assertTrue(b.sameElements("a" :: Nil))
+    assertTrue(b.sameElements("a" :: Nil))
     b.clear()
-    Assert.assertEquals(ListBuffer.empty[String], b)
+    assertEquals(ListBuffer.empty[String], b)
     b += "b"
-    Assert.assertTrue(b.sameElements("b" :: Nil))
+    assertTrue(b.sameElements("b" :: Nil))
 
     val b2 = ListBuffer.empty[String]
     b2 += "a"
     val _ = b2.toList
     b2.clear()
     b2 += "b"
-    Assert.assertTrue(b2.sameElements("b" :: Nil))
+    assertTrue(b2.sameElements("b" :: Nil))
   }
 
+  @Test
+  def testFilterInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer.range(0, 100).filterInPlace(_ => false))
+    assertEquals(ListBuffer.range(0, 100), ListBuffer.range(0, 100).filterInPlace(_ => true))
+    assertEquals(ListBuffer.range(start = 0, end = 100, step = 2), ListBuffer.range(0, 100).filterInPlace(_ % 2 == 0))
+    assertEquals(ListBuffer.range(start = 1, end = 100, step = 2), ListBuffer.range(0, 100).filterInPlace(_ % 2 != 0))
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -52,6 +52,13 @@ class ListBufferTest {
   }
 
   @Test
+  def testTakeWhileInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer[Int]().takeWhileInPlace(_ < 50))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeWhileInPlace(_ < 50))
+    assertEquals(ListBuffer.range(0, 50), ListBuffer.range(0, 100).takeWhileInPlace(_ < 50))
+  }
+
+  @Test
   def testDropInPlace: Unit = {
     assertEquals(ListBuffer(), ListBuffer().dropInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropInPlace(-1))
@@ -65,6 +72,13 @@ class ListBufferTest {
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropRightInPlace(-1))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropRightInPlace(10))
     assertEquals(ListBuffer.range(0, 90), ListBuffer.range(0, 100).dropRightInPlace(10))
+  }
+
+  @Test
+  def testDropWhileInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer[Int]().dropWhileInPlace(_ < 50))
+    assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropWhileInPlace(_ < 50))
+    assertEquals(ListBuffer.range(50, 100), ListBuffer.range(0, 100).dropWhileInPlace(_ < 50))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -10,7 +10,7 @@ import org.junit.runners.JUnit4
 class ListBufferTest {
 
   @Test
-  def hasCorrectClear(): Unit = {
+  def testClear(): Unit = {
     val b = ListBuffer.empty[String]
     b += "a"
     assertTrue(b.sameElements("a" :: Nil))
@@ -40,5 +40,42 @@ class ListBufferTest {
     assertEquals(ListBuffer(), ListBuffer().takeInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 100).takeInPlace(10))
+  }
+
+  @Test
+  def testRemoveMany: Unit = {
+    def testRemoveMany(idx: Int, count: Int, expectation: ListBuffer[Int]): Unit = {
+      val buffer = ListBuffer(0, 1, 2)
+      buffer.remove(idx, count)
+      assertEquals(expectation, buffer)
+    }
+
+    testRemoveMany(idx = 0, count = 0, expectation = ListBuffer(0, 1, 2))
+    testRemoveMany(idx = 0, count = 1, expectation = ListBuffer(1, 2))
+    testRemoveMany(idx = 0, count = 2, expectation = ListBuffer(2))
+    testRemoveMany(idx = 0, count = 3, expectation = ListBuffer())
+    testRemoveMany(idx = 1, count = 1, expectation = ListBuffer(0, 2))
+    testRemoveMany(idx = 1, count = 2, expectation = ListBuffer(0))
+    testRemoveMany(idx = 2, count = 1, expectation = ListBuffer(0, 1))
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithNegativeIndex: Unit = {
+    ListBuffer(0, 1, 2).remove(idx = -1, count = 1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithTooLargeIndex: Unit = {
+    ListBuffer(0).remove(idx = 1, count = 1)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def removeManyWithNegativeCount: Unit = {
+    ListBuffer(0).remove(idx = 0, count = -1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeManyWithTooLargeCount: Unit = {
+    ListBuffer(0).remove(idx = 0, count = 100)
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -44,6 +44,14 @@ class ListBufferTest {
   }
 
   @Test
+  def testTakeRightInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer().takeRightInPlace(10))
+    assertEquals(ListBuffer(), ListBuffer.range(0, 10).takeRightInPlace(-1))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeRightInPlace(10))
+    assertEquals(ListBuffer.range(90, 100), ListBuffer.range(0, 100).takeRightInPlace(10))
+  }
+
+  @Test
   def testDropInPlace: Unit = {
     assertEquals(ListBuffer(), ListBuffer().dropInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropInPlace(-1))

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -52,6 +52,14 @@ class ListBufferTest {
   }
 
   @Test
+  def testDropRightInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer().dropRightInPlace(10))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropRightInPlace(-1))
+    assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropRightInPlace(10))
+    assertEquals(ListBuffer.range(0, 90), ListBuffer.range(0, 100).dropRightInPlace(10))
+  }
+
+  @Test
   def testRemove: Unit = {
     val b1 = ListBuffer(0, 1, 2)
     assertEquals(0, b1.remove(0))

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -34,4 +34,11 @@ class ListBufferTest {
     assertEquals(ListBuffer.range(start = 0, end = 100, step = 2), ListBuffer.range(0, 100).filterInPlace(_ % 2 == 0))
     assertEquals(ListBuffer.range(start = 1, end = 100, step = 2), ListBuffer.range(0, 100).filterInPlace(_ % 2 != 0))
   }
+
+  @Test
+  def testTakeInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer().takeInPlace(10))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeInPlace(10))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 100).takeInPlace(10))
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -38,8 +38,17 @@ class ListBufferTest {
   @Test
   def testTakeInPlace: Unit = {
     assertEquals(ListBuffer(), ListBuffer().takeInPlace(10))
+    assertEquals(ListBuffer(), ListBuffer.range(0, 10).takeInPlace(-1))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 100).takeInPlace(10))
+  }
+
+  @Test
+  def testDropInPlace: Unit = {
+    assertEquals(ListBuffer(), ListBuffer().dropInPlace(10))
+    assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropInPlace(-1))
+    assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropInPlace(10))
+    assertEquals(ListBuffer.range(10, 100), ListBuffer.range(0, 100).dropInPlace(10))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -43,6 +43,31 @@ class ListBufferTest {
   }
 
   @Test
+  def testRemove: Unit = {
+    val b1 = ListBuffer(0, 1, 2)
+    assertEquals(0, b1.remove(0))
+    assertEquals(ListBuffer(1, 2), b1)
+
+    val b2 = ListBuffer(0, 1, 2)
+    assertEquals(1, b2.remove(1))
+    assertEquals(ListBuffer(0, 2), b2)
+
+    val b3 = ListBuffer(0, 1, 2)
+    assertEquals(2, b3.remove(2))
+    assertEquals(ListBuffer(0, 1), b3)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeWithNegativeIndex: Unit = {
+    ListBuffer(0, 1, 2).remove(-1)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def removeWithTooLargeIndex: Unit = {
+    ListBuffer(0).remove(1)
+  }
+
+  @Test
   def testRemoveMany: Unit = {
     def testRemoveMany(idx: Int, count: Int, expectation: ListBuffer[Int]): Unit = {
       val buffer = ListBuffer(0, 1, 2)

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -128,4 +128,42 @@ class ListBufferTest {
   def removeManyWithTooLargeCount: Unit = {
     ListBuffer(0).remove(idx = 0, count = 100)
   }
+
+  @Test
+  def testTrimStart: Unit = {
+    val b1 = ListBuffer()
+    b1.trimStart(10)
+    assertEquals(ListBuffer(), b1)
+
+    val b2 = ListBuffer.range(0, 10)
+    b2.trimStart(-1)
+    assertEquals(ListBuffer.range(0, 10), b2)
+
+    val b3 = ListBuffer.range(0, 10)
+    b3.trimStart(10)
+    assertEquals(ListBuffer(), b3)
+
+    val b4 = ListBuffer.range(0, 100)
+    b4.trimStart(10)
+    assertEquals(ListBuffer.range(10, 100), b4)
+  }
+
+  @Test
+  def testTrimEnd: Unit = {
+    val b1 = ListBuffer()
+    b1.trimEnd(10)
+    assertEquals(ListBuffer(), b1)
+
+    val b2 = ListBuffer.range(0, 10)
+    b2.trimEnd(-1)
+    assertEquals(ListBuffer.range(0, 10), b2)
+
+    val b3 = ListBuffer.range(0, 10)
+    b3.trimEnd(10)
+    assertEquals(ListBuffer(), b3)
+
+    val b4 = ListBuffer.range(0, 100)
+    b4.trimEnd(10)
+    assertEquals(ListBuffer.range(0, 90), b4)
+  }
 }


### PR DESCRIPTION
This PR fixes #413, #409, #410, #406

My original goal was to fix #413 only. It turns out that I had to fix other bugs along the way to allow the original one to be fixed or was somehow related. Some of these bugs have issues and others don't (e.g. `ListBuffer.remove(idx)`, `Buffer.trimStart/trimEnd`, ...). Each fix is in a separate commit to ease the code review

There are still some bugs in those classes which are covered by other issues that @Ichoran has already filed