### PR TITLE
Memoize IterableOnce source on first View traversal

### DIFF
--- a/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiDict.scala
@@ -17,7 +17,7 @@ class SortedMultiDict[K, V] private (elems: SortedMap[K, Set[V]])(implicit val o
 
   def sets: collection.SortedMap[K, collection.Set[V]] = elems
 
-  def iterableFactory: IterableFactoryLike[collection.Iterable] = collection.Iterable
+  def iterableFactory: IterableFactory[collection.Iterable] = collection.Iterable
   def sortedMultiMapFactory: SortedMapFactory[SortedMultiDict] = SortedMultiDict
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): SortedMultiDict[K, V] = sortedMultiMapFactory.from(coll)

--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -72,10 +72,7 @@ object Factory {
   * @define coll collection
   * @define Coll `Iterable`
   */
-trait IterableFactoryLike[+CC[_]] {
-
-  /** Type of a source collection to build from */
-  type Source[A] >: Iterable[A]
+trait IterableFactory[+CC[_]] {
 
   /** Creates a target $coll from an existing source collection
     *
@@ -83,7 +80,7 @@ trait IterableFactoryLike[+CC[_]] {
     * @tparam A the type of the collection’s elements
     * @return a new $coll with the elements of `source`
     */
-  def from[A](source: Source[A]): CC[A]
+  def from[A](source: IterableOnce[A]): CC[A]
 
   /** An empty collection
     * @tparam A      the type of the ${coll}'s elements
@@ -227,20 +224,6 @@ trait IterableFactoryLike[+CC[_]] {
     */
   def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
-}
-
-/** Base trait for companion objects of unconstrained collection types that can
-  * build a target collection `CC` from a source collection with a single traversal
-  * of the source.
-  *
-  * @tparam CC Collection type constructor (e.g. `List`)
-  */
-trait IterableFactory[+CC[_]] extends IterableFactoryLike[CC] {
-
-  // Since most collection factories can build a target collection instance by performing only one
-  // traversal of a source collection, the type of this source collection can be refined to be
-  // just `IterableOnce`
-  type Source[A] = IterableOnce[A]
 
   implicit def iterableFactory[A]: Factory[A, CC[A]] = IterableFactory.toFactory(this)
 

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -91,7 +91,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   /**
     * @return The companion object of this ${coll}, providing various factory methods.
     */
-  def iterableFactory: IterableFactoryLike[CC]
+  def iterableFactory: IterableFactory[CC]
 
   /**
     * @return a strict builder for the same collection type.

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -168,7 +168,7 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
     b.addAll(coll)
     b.result()
   }
-  def iterableFactory: IterableFactoryLike[Iterable] = Iterable
+  def iterableFactory: IterableFactory[Iterable] = Iterable
   protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
       def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }

--- a/collections/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Map.scala
@@ -138,7 +138,7 @@ object Map extends MapFactory[Map] {
 
     override def default(key: K): V = defaultValue(key)
 
-    def iterableFactory: IterableFactoryLike[Iterable] = underlying.iterableFactory
+    def iterableFactory: IterableFactory[Iterable] = underlying.iterableFactory
 
     def iterator(): Iterator[(K, V)] = underlying.iterator()
 


### PR DESCRIPTION
This allows us to get rid of `IterableFactoryLike` and still define
`View.from` in a reasonable way.

I pushed this branch last week but most have forgotten to open a PR...