### PR TITLE
Add possibility to check if string is a valid int/long/boolean/etc

### DIFF
--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -405,6 +405,22 @@ final class StringOps(val s: String)
    */
   def toDouble: Double   = java.lang.Double.parseDouble(toString)
 
+  def isBoolean: Boolean = check(toBoolean)
+
+  def isByte: Boolean    = check(toByte)
+
+  def isShort: Boolean   = check(toShort)
+
+  def isInt: Boolean     = check(toInt)
+
+  def isLong: Boolean    = check(toLong)
+
+  def isFloat: Boolean   = check(toFloat)
+
+  def isDouble: Boolean  = check(toDouble)
+
+  private def check[T](f : => T): Boolean = try { f; true } catch { case e: java.lang.Throwable => false }
+
   private def parseBoolean(s: String): Boolean =
     if (s != null) s.toLowerCase match {
       case "true" => true


### PR DESCRIPTION
I thought it may be worth considering to add several methods that verify if the given string is a valid `int`/`long`/etc. On multiple occasions, I wrote something like this: `Try(s.toInt).isSuccess` which is more than inconvenient and suboptimal.

- I don't know if its really worth to add it
- I can add docs and tests once general idea is accepted
- I didn't know if this should go to `collections` or `collections-contrib`

In general, I will be happy to apply any changes needed, just let me know.