### PR TITLE
Bunch of bug fixes for `ArrayBuffer` & `ListBuffer`

### DIFF
--- a/collections/src/main/scala/strawman/collection/View.scala
+++ b/collections/src/main/scala/strawman/collection/View.scala
@@ -264,7 +264,6 @@ object View extends IterableFactoryLike[View] {
   }
 
   private[collection] class Patched[A](underlying: Iterable[A], from: Int, other: IterableOnce[A], replaced: Int) extends View[A] {
-    if (from < 0 || (knownSize > -1 && from > knownSize)) throw new IndexOutOfBoundsException(from.toString)
     def iterator(): Iterator[A] = underlying.iterator().patch(from, other.iterator(), replaced)
   }
 

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -80,8 +80,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
 
   protected[this] def newSpecificBuilder(): Builder[A, ArrayBuffer[A]] = ArrayBuffer.newBuilder()
 
-  def clear(): Unit =
-    size0 = 0
+  def clear(): Unit = reduceToSize(0)
 
   def addOne(elem: A): this.type = {
     val i = size0

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -145,16 +145,16 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
-    val _replaced = math.min(math.max(replaced, 0), size)
-    val _from = math.min(math.max(from, 0), size)
-    val n = math.min(patch.size, _replaced)
-    var i = 0
-    while (i < n && _from + i < size) {
-      update(_from + i, patch(i))
-      i += 1
+    val replaced0 = math.min(math.max(replaced, 0), size)
+    val i = math.min(math.max(from, 0), size)
+    var j = 0
+    val n = math.min(patch.size, replaced0)
+    while (j < n && i + j < size) {
+      update(i + j, patch(j))
+      j += 1
     }
-    if (i < patch.size) insertAll(_from + i, patch.iterator().drop(i))
-    else if (i < _replaced) remove(_from + i, _replaced - i)
+    if (j < patch.size) insertAll(i + j, patch.iterator().drop(j))
+    else if (j < replaced0) remove(i + j, replaced0 - j)
     this
   }
 }

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -145,11 +145,16 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
-    val n = patch.size min replaced
+    val _replaced = math.min(math.max(replaced, 0), size)
+    val _from = math.min(math.max(from, 0), size)
+    val n = math.min(patch.size, _replaced)
     var i = 0
-    while (i < n) { update(from + i, patch(i)); i += 1 }
-    if (i < patch.size) insertAll(from + i, patch.iterator().drop(i))
-    else if (i < replaced) remove(from + i, replaced - i)
+    while (i < n && _from + i < size) {
+      update(_from + i, patch(i))
+      i += 1
+    }
+    if (i < patch.size) insertAll(_from + i, patch.iterator().drop(i))
+    else if (i < _replaced) remove(_from + i, _replaced - i)
     this
   }
 }

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -3,7 +3,7 @@ package mutable
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
-import scala.{Any, Boolean, Int, Unit, throws, Serializable, SerialVersionUID}
+import scala.{Any, Boolean, Int, math, Unit, throws, Serializable, SerialVersionUID}
 import scala.Int._
 import strawman.collection
 import strawman.collection.immutable.{List, Nil, ::}
@@ -272,9 +272,11 @@ class ListBuffer[A]
   }
 
   def patchInPlace(from: Int, patch: collection.Seq[A], replaced: Int): this.type = {
+    val i = math.min(math.max(from, 0), length)
+    val n = math.min(math.max(replaced, 0), length)
     ensureUnaliased()
-    val p = locate(from)
-    removeAfter(p, replaced `min` (len - from))
+    val p = locate(i)
+    removeAfter(p, math.min(n, len - i))
     insertAfter(p, patch.iterator())
     this
   }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -282,4 +282,12 @@ class ArrayBufferTest {
 
     buffer.update(0, 100)
   }
+
+  @Test
+  def testClear: Unit = {
+    val buffer = ArrayBuffer(1, 2, 3)
+    buffer.clear()
+
+    assertEquals(0, buffer.size)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -256,4 +256,30 @@ class ArrayBufferTest {
     testPatchInPlace(from = 10, replaced = 10, expectation = ArrayBuffer(0, 1, 2, -3, -2, -1))
     testPatchInPlace(from = 0, replaced = 100, expectation = ArrayBuffer(-3, -2, -1))
   }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testApplyWhenEmpty: Unit = {
+    new ArrayBuffer().apply(0)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testApplyAfterClearing: Unit = {
+    val buffer = ArrayBuffer(1, 2, 3)
+    buffer.clear()
+
+    buffer(0)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testUpdateWhenEmpty: Unit = {
+    new ArrayBuffer().update(0, 100)
+  }
+
+  @Test(expected = classOf[IndexOutOfBoundsException])
+  def testUpdateAfterClearing: Unit = {
+    val buffer = ArrayBuffer(1, 2, 3)
+    buffer.clear()
+
+    buffer.update(0, 100)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -229,4 +229,17 @@ class ArrayBufferTest {
     b4.trimEnd(10)
     assertEquals(ArrayBuffer.range(0, 90), b4)
   }
+
+  @Test
+  def testPatch: Unit = {
+    val buffer = ArrayBuffer(0, 1, 2, 3)
+    val patch = List(-3, -2, -1)
+    assertEquals(ArrayBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = -1, patch, replaced = -1))
+    assertEquals(ArrayBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = 0, patch, replaced = 0))
+    assertEquals(ArrayBuffer(0, -3, -2, -1, 2, 3), buffer.patch(from = 1, patch, replaced = 1))
+    assertEquals(ArrayBuffer(0, 1, -3, -2, -1), buffer.patch(from = 2, patch, replaced = 2))
+    assertEquals(ArrayBuffer(0, 1, 2, 3, -3, -2, -1), buffer.patch(from = 10, patch, replaced = 10))
+    assertEquals(ArrayBuffer(-3, -2, -1), buffer.patch(from = 0, patch, replaced = 100))
+  }
+
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayBufferTest.scala
@@ -237,9 +237,23 @@ class ArrayBufferTest {
     assertEquals(ArrayBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = -1, patch, replaced = -1))
     assertEquals(ArrayBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = 0, patch, replaced = 0))
     assertEquals(ArrayBuffer(0, -3, -2, -1, 2, 3), buffer.patch(from = 1, patch, replaced = 1))
+    assertEquals(ArrayBuffer(0, -3, -2, -1), buffer.patch(from = 1, patch, replaced = 3))
     assertEquals(ArrayBuffer(0, 1, -3, -2, -1), buffer.patch(from = 2, patch, replaced = 2))
     assertEquals(ArrayBuffer(0, 1, 2, 3, -3, -2, -1), buffer.patch(from = 10, patch, replaced = 10))
     assertEquals(ArrayBuffer(-3, -2, -1), buffer.patch(from = 0, patch, replaced = 100))
   }
 
+  @Test
+  def testPatchInPlace: Unit = {
+    def testPatchInPlace(from: Int, replaced: Int, expectation: ArrayBuffer[Int]) =
+      assertEquals(expectation, ArrayBuffer(0, 1, 2).patchInPlace(from, patch = List(-3, -2, -1), replaced))
+
+    testPatchInPlace(from = -1, replaced = -1, expectation = ArrayBuffer(-3, -2, -1, 0, 1, 2))
+    testPatchInPlace(from = 0, replaced = 0, expectation = ArrayBuffer(-3, -2, -1, 0, 1, 2))
+    testPatchInPlace(from = 1, replaced = 1, expectation = ArrayBuffer(0, -3, -2, -1, 2))
+    testPatchInPlace(from = 1, replaced = 2, expectation = ArrayBuffer(0, -3, -2, -1))
+    testPatchInPlace(from = 2, replaced = 1, expectation = ArrayBuffer(0, 1, -3, -2, -1))
+    testPatchInPlace(from = 10, replaced = 10, expectation = ArrayBuffer(0, 1, 2, -3, -2, -1))
+    testPatchInPlace(from = 0, replaced = 100, expectation = ArrayBuffer(-3, -2, -1))
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -199,8 +199,23 @@ class ListBufferTest {
     assertEquals(ListBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = -1, patch, replaced = -1))
     assertEquals(ListBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = 0, patch, replaced = 0))
     assertEquals(ListBuffer(0, -3, -2, -1, 2, 3), buffer.patch(from = 1, patch, replaced = 1))
+    assertEquals(ListBuffer(0, -3, -2, -1), buffer.patch(from = 1, patch, replaced = 3))
     assertEquals(ListBuffer(0, 1, -3, -2, -1), buffer.patch(from = 2, patch, replaced = 2))
     assertEquals(ListBuffer(0, 1, 2, 3, -3, -2, -1), buffer.patch(from = 10, patch, replaced = 10))
     assertEquals(ListBuffer(-3, -2, -1), buffer.patch(from = 0, patch, replaced = 100))
+  }
+
+  @Test
+  def testPatchInPlace: Unit = {
+    def testPatchInPlace(from: Int, replaced: Int, expectation: ListBuffer[Int]) =
+      assertEquals(expectation, ListBuffer(0, 1, 2).patchInPlace(from, patch = List(-3, -2, -1), replaced))
+
+    testPatchInPlace(from = -1, replaced = -1, expectation = ListBuffer(-3, -2, -1, 0, 1, 2))
+    testPatchInPlace(from = 0, replaced = 0, expectation = ListBuffer(-3, -2, -1, 0, 1, 2))
+    testPatchInPlace(from = 1, replaced = 1, expectation = ListBuffer(0, -3, -2, -1, 2))
+    testPatchInPlace(from = 1, replaced = 2, expectation = ListBuffer(0, -3, -2, -1))
+    testPatchInPlace(from = 2, replaced = 1, expectation = ListBuffer(0, 1, -3, -2, -1))
+    testPatchInPlace(from = 10, replaced = 10, expectation = ListBuffer(0, 1, 2, -3, -2, -1))
+    testPatchInPlace(from = 0, replaced = 100, expectation = ListBuffer(-3, -2, -1))
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ListBufferTest.scala
@@ -191,4 +191,16 @@ class ListBufferTest {
     b4.trimEnd(10)
     assertEquals(ListBuffer.range(0, 90), b4)
   }
+
+  @Test
+  def testPatch: Unit = {
+    val buffer = ListBuffer(0, 1, 2, 3)
+    val patch = List(-3, -2, -1)
+    assertEquals(ListBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = -1, patch, replaced = -1))
+    assertEquals(ListBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = 0, patch, replaced = 0))
+    assertEquals(ListBuffer(0, -3, -2, -1, 2, 3), buffer.patch(from = 1, patch, replaced = 1))
+    assertEquals(ListBuffer(0, 1, -3, -2, -1), buffer.patch(from = 2, patch, replaced = 2))
+    assertEquals(ListBuffer(0, 1, 2, 3, -3, -2, -1), buffer.patch(from = 10, patch, replaced = 10))
+    assertEquals(ListBuffer(-3, -2, -1), buffer.patch(from = 0, patch, replaced = 100))
+  }
 }


### PR DESCRIPTION
- fix #398 (`Buffer.patch` throws out of bound index exception) by dropping validation in `View.Patched`
- fix #407 (`ListBuffer.patchInPlace` throws class cast exception) by clipping index/count to safe values
- fix various issues in `ArrayBuffer.patchInPlace` causing out of bound index exceptions
- fix #385 (`ArrayBuffer.clear` not dereferencing cleared elements)
- Ensure that index passed into `ArrayBuffer`'s `apply` and `update` is within bounds. This fix uncovered other issues in `addOne` and `insert`

Note: each fix is in a separate commit