### PR TITLE
Revert length / size changes

### DIFF
--- a/collections/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/collections/src/main/scala/strawman/collection/ArrayOps.scala
@@ -33,7 +33,7 @@ class ArrayOps[A](val xs: Array[A]) extends AnyVal
   protected[this] def coll: Array[A] = xs
   override def toSeq: immutable.Seq[A] = fromIterable(toIterable)
 
-  protected def finiteSize = xs.length
+  def length = xs.length
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int) = xs.apply(i)
 

--- a/collections/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/collections/src/main/scala/strawman/collection/ArrayOps.scala
@@ -22,8 +22,7 @@ object ArrayOps {
 class ArrayOps[A](val xs: Array[A]) extends AnyVal
   with IterableOnce[A]
   with IndexedSeqOps[A, immutable.IndexedSeq, Array[A]]
-  with StrictOptimizedSeqOps[A, Seq, Array[A]]
-  with ArrayLike[A] {
+  with StrictOptimizedSeqOps[A, Seq, Array[A]] {
 
   protected def fromTaggedIterable[B: ClassTag](coll: Iterable[B]): Array[B] = coll.toArray[B]
 

--- a/collections/src/main/scala/strawman/collection/IndexedSeq.scala
+++ b/collections/src/main/scala/strawman/collection/IndexedSeq.scala
@@ -13,16 +13,12 @@ trait IndexedSeq[+A] extends Seq[A] with IndexedSeqOps[A, IndexedSeq, IndexedSeq
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
 /** Base trait for indexed Seq operations */
-trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, CC, C] with ArrayLike[A] { self =>
+trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   def iterator(): Iterator[A] = view.iterator()
 
-  final override def size: Int = finiteSize
-
-  final override def knownSize: Int = finiteSize
-
   override def reverseIterator(): Iterator[A] = new AbstractIterator[A] {
-    private var i = self.size
+    private var i = self.length
     def hasNext: Boolean = 0 < i
     def next(): A =
       if (0 < i) {
@@ -32,7 +28,7 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
   }
 
   override def view: IndexedView[A] = new IndexedView[A] {
-    protected def finiteSize: Int = self.size
+    def length: Int = self.length
     def apply(i: Int): A = self(i)
   }
 
@@ -45,7 +41,9 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends Any with SeqOps[A, 
     * linear, immutable collections this should avoid making a copy. */
   override def dropRight(n: Int): C = fromSpecificIterable(view.dropRight(n))
 
-  override def lengthCompare(len: Int): Int = size - len
+  override def lengthCompare(len: Int): Int = length - len
+
+  final override def knownSize: Int = length
 
   override def search[B >: A](elem: B)(implicit ord: Ordering[B]): SearchResult =
     binarySearch(elem, 0, length)(ord)

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -272,10 +272,10 @@ trait Iterator[+A] extends IterableOnce[A] { self =>
         val res = takeDestructively(count)
         // was: extra checks so we don't calculate length unless there's reason
         // but since we took the group eagerly, just use the fast length
-        val shortBy = count - res.size
+        val shortBy = count - res.length
         if (shortBy > 0 && pad.isDefined) res ++ padding(shortBy) else res
       }
-      lazy val len = xs.size
+      lazy val len = xs.length
       lazy val incomplete = len < count
 
       // if 0 elements are requested, or if the number of newly obtained
@@ -1147,7 +1147,7 @@ object Iterator {
   }
 
   def apply[A](xs: A*): Iterator[A] = new IndexedView[A] {
-    protected def finiteSize = xs.size
+    val length = xs.length
     def apply(n: Int) = xs(n)
   }.iterator()
 

--- a/collections/src/main/scala/strawman/collection/LinearSeq.scala
+++ b/collections/src/main/scala/strawman/collection/LinearSeq.scala
@@ -25,7 +25,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A]] extends Any w
     def next() = { val r = current.head; current = current.tail; r }
   }
 
-  override def size: Int = {
+  def length: Int = {
     var these = toIterable
     var len = 0
     while (!these.isEmpty) {

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -82,8 +82,15 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
   * @define Coll `Seq`
   */
 trait SeqOps[+A, +CC[_], +C] extends Any
-  with IterableOps[A, CC, C]
-  with ArrayLike[A] {
+  with IterableOps[A, CC, C] {
+
+  /** Get the element at the specified index. This operation is provided for convenience in `Seq`. It should
+    * not be assumed to be efficient unless you have an `IndexedSeq`. */
+  @throws[IndexOutOfBoundsException]
+  def apply(i: Int): A
+
+  /** The length (number of elements) of the $coll. `size` is an alias for `length` in `Seq` collections. */
+  def length: Int
 
   /**
     * @return This collection as a `Seq[A]`. This is equivalent to `to(Seq)` but might be faster.

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -25,7 +25,6 @@ final class StringOps(val s: String)
     with IterableOnce[Char]
     with collection.IndexedSeqOps[Char, immutable.IndexedSeq, String]
     with collection.StrictOptimizedIterableOps[Char, immutable.IndexedSeq, String]
-    with collection.ArrayLike[Char]
     with Ordered[String] {
 
   def toIterable = StringView(s)

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -43,7 +43,7 @@ final class StringOps(val s: String)
 
   protected[this] def newSpecificBuilder() = new StringBuilder
 
-  protected def finiteSize = s.length
+  def length = s.length
 
   @throws[StringIndexOutOfBoundsException]
   def apply(i: Int) = s.charAt(i)
@@ -153,7 +153,7 @@ final class StringOps(val s: String)
 
   override def slice(from: Int, until: Int): String = {
     val start = from max 0
-    val end   = until min finiteSize
+    val end   = until min length
 
     if (start >= end) newSpecificBuilder().result()
     else (newSpecificBuilder() ++= toString.substring(start, end)).result()
@@ -456,7 +456,7 @@ final class StringOps(val s: String)
 }
 
 case class StringView(s: String) extends IndexedView[Char] {
-  protected def finiteSize = s.length
+  def length = s.length
   @throws[StringIndexOutOfBoundsException]
   def apply(n: Int) = s.charAt(n)
   override def className = "StringView"

--- a/collections/src/main/scala/strawman/collection/View.scala
+++ b/collections/src/main/scala/strawman/collection/View.scala
@@ -300,15 +300,8 @@ object View extends IterableFactory[View] {
   }
 }
 
-/** A trait representing indexable collections with finite length */
-trait ArrayLike[+A] extends Any { self =>
-  def length: Int
-  @throws[IndexOutOfBoundsException]
-  def apply(i: Int): A
-}
-
 /** View defined in terms of indexing a range */
-trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, View[A]] { self =>
+trait IndexedView[+A] extends View[A] with SeqOps[A, View, View[A]] { self =>
 
   def iterator(): Iterator[A] = new AbstractIterator[A] {
     private var current = 0
@@ -321,7 +314,7 @@ trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, Vie
     }
   }
 
-  override def knownSize: Int = length
+  final override def knownSize: Int = length
 
   override def take(n: Int): IndexedView[A] = new IndexedView.Take(this, n)
   override def takeRight(n: Int): IndexedView[A] = new IndexedView.TakeRight(this, n)

--- a/collections/src/main/scala/strawman/collection/View.scala
+++ b/collections/src/main/scala/strawman/collection/View.scala
@@ -301,9 +301,8 @@ object View extends IterableFactory[View] {
 }
 
 /** A trait representing indexable collections with finite length */
-trait ArrayLike[+A] extends Any {
-  /** The finite size of the collection. */
-  protected def finiteSize: Int
+trait ArrayLike[+A] extends Any { self =>
+  def length: Int
   @throws[IndexOutOfBoundsException]
   def apply(i: Int): A
 }
@@ -313,8 +312,8 @@ trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, Vie
 
   def iterator(): Iterator[A] = new AbstractIterator[A] {
     private var current = 0
-    override def knownSize: Int = self.size - current
-    def hasNext = current < self.size
+    override def knownSize: Int = self.length - current
+    def hasNext = current < self.length
     def next(): A = {
       val r = self.apply(current)
       current += 1
@@ -322,7 +321,7 @@ trait IndexedView[+A] extends View[A] with ArrayLike[A] with SeqOps[A, View, Vie
     }
   }
 
-  final override def knownSize: Int = finiteSize
+  override def knownSize: Int = length
 
   override def take(n: Int): IndexedView[A] = new IndexedView.Take(this, n)
   override def takeRight(n: Int): IndexedView[A] = new IndexedView.TakeRight(this, n)
@@ -336,41 +335,41 @@ object IndexedView {
 
   class Take[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
     private[this] val normN = n max 0
-    protected def finiteSize = underlying.size min normN
+    def length = underlying.length min normN
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i)
   }
 
   class TakeRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
-    private[this] val delta = (underlying.size - (n max 0)) max 0
-    protected def finiteSize = underlying.size - delta
+    private[this] val delta = (underlying.length - (n max 0)) max 0
+    def length = underlying.length - delta
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + delta)
   }
 
   class Drop[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
     protected val normN = n max 0
-    protected def finiteSize = (underlying.size - normN) max 0
+    def length = (underlying.length - normN) max 0
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i + normN)
   }
 
   class DropRight[A](underlying: IndexedView[A], n: Int) extends IndexedView[A] {
-    private[this] val len = (underlying.size - (n max 0)) max 0
-    protected def finiteSize = len
+    private[this] val len = (underlying.length - (n max 0)) max 0
+    def length = len
     @throws[IndexOutOfBoundsException]
     def apply(i: Int) = underlying.apply(i)
   }
 
   class Map[A, B](underlying: IndexedView[A], f: A => B) extends IndexedView[B] {
-    protected def finiteSize = underlying.size
+    def length = underlying.length
     @throws[IndexOutOfBoundsException]
     def apply(n: Int) = f(underlying.apply(n))
   }
 
   case class Reverse[A](underlying: IndexedView[A]) extends IndexedView[A] {
-    protected def finiteSize = underlying.size
+    def length = underlying.length
     @throws[IndexOutOfBoundsException]
-    def apply(i: Int) = underlying.apply(size - 1 - i)
+    def apply(i: Int) = underlying.apply(length - 1 - i)
   }
 }

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -89,7 +89,7 @@ private[collection] trait Wrappers {
   }
 
   case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with SeqOps[A, mutable.Buffer, mutable.Buffer[A]] {
-    override def size = underlying.size
+    def length = underlying.size
     override def isEmpty = underlying.isEmpty
     override def iterator(): Iterator[A] = underlying.iterator().asScala
     def apply(i: Int) = underlying.get(i)

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -91,7 +91,7 @@ sealed abstract class ImmutableArray[+A]
   override def zip[B](that: collection.Iterable[B]): ImmutableArray[(A, B)] =
     that match {
       case bs: ImmutableArray[B] =>
-        ImmutableArray.tabulate(finiteSize min bs.finiteSize) { i =>
+        ImmutableArray.tabulate(length min bs.length) { i =>
           (apply(i), bs(i))
         }
       case _ =>
@@ -181,7 +181,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ImmutableArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](unsafeArray.getClass.getComponentType)
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): T = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -193,7 +193,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofByte(val unsafeArray: Array[Byte]) extends ImmutableArray[Byte] with Serializable {
     protected[this] def elemTag = ClassTag.Byte
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Byte = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -205,7 +205,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofShort(val unsafeArray: Array[Short]) extends ImmutableArray[Short] with Serializable {
     protected[this] def elemTag = ClassTag.Short
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Short = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -217,7 +217,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofChar(val unsafeArray: Array[Char]) extends ImmutableArray[Char] with Serializable {
     protected[this] def elemTag = ClassTag.Char
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Char = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -229,7 +229,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofInt(val unsafeArray: Array[Int]) extends ImmutableArray[Int] with Serializable {
     protected[this] def elemTag = ClassTag.Int
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Int = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -241,7 +241,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofLong(val unsafeArray: Array[Long]) extends ImmutableArray[Long] with Serializable {
     protected[this] def elemTag = ClassTag.Long
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Long = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -253,7 +253,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofFloat(val unsafeArray: Array[Float]) extends ImmutableArray[Float] with Serializable {
     protected[this] def elemTag = ClassTag.Float
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Float = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -265,7 +265,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofDouble(val unsafeArray: Array[Double]) extends ImmutableArray[Double] with Serializable {
     protected[this] def elemTag = ClassTag.Double
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Double = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -277,7 +277,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ImmutableArray[Boolean] with Serializable {
     protected[this] def elemTag = ClassTag.Boolean
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Boolean = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)
@@ -289,7 +289,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
 
   final class ofUnit(val unsafeArray: Array[Unit]) extends ImmutableArray[Unit] with Serializable {
     protected[this] def elemTag = ClassTag.Unit
-    protected def finiteSize: Int = unsafeArray.length
+    def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Unit = unsafeArray(i)
     override def hashCode = MurmurHash3.arrayHash(unsafeArray)

--- a/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -72,11 +72,11 @@ sealed class NumericRange[T](
   import num._
 
   // See comment in Range for why this must be lazy.
-  override protected lazy val finiteSize: Int = NumericRange.count(start, end, step, isInclusive)
-  override def isEmpty = finiteSize == 0
+  override lazy val length: Int = NumericRange.count(start, end, step, isInclusive)
+  override def isEmpty = length == 0
   override def last: T =
-    if (finiteSize == 0) Nil.head
-    else locationAfterN(finiteSize - 1)
+    if (length == 0) Nil.head
+    else locationAfterN(length - 1)
   override def init: NumericRange[T] =
     if (isEmpty) Nil.init
     else new NumericRange(start, end - step, step, isInclusive)
@@ -100,14 +100,14 @@ sealed class NumericRange[T](
 
   @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
-    if (idx < 0 || idx >= finiteSize) throw new IndexOutOfBoundsException(idx.toString)
+    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
     else locationAfterN(idx)
   }
 
   override def foreach[@specialized(Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
-    while (count < finiteSize) {
+    while (count < length) {
       f(current)
       current += step
       count += 1
@@ -135,14 +135,14 @@ sealed class NumericRange[T](
   private def newEmptyRange(value: T) = NumericRange(value, value, step)
 
   override def take(n: Int): NumericRange[T] = {
-    if (n <= 0 || finiteSize == 0) newEmptyRange(start)
-    else if (n >= finiteSize) this
+    if (n <= 0 || length == 0) newEmptyRange(start)
+    else if (n >= length) this
     else new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
   }
 
   override def drop(n: Int): NumericRange[T] = {
-    if (n <= 0 || finiteSize == 0) this
-    else if (n >= finiteSize) newEmptyRange(end)
+    if (n <= 0 || length == 0) this
+    else if (n >= length) newEmptyRange(end)
     else copy(locationAfterN(n), end, step)
   }
 
@@ -276,7 +276,7 @@ sealed class NumericRange[T](
           var acc = num.zero
           var i = head
           var idx = 0
-          while(idx < finiteSize) {
+          while(idx < length) {
             acc = num.plus(acc, i)
             i = i + step
             idx = idx + 1
@@ -290,8 +290,8 @@ sealed class NumericRange[T](
   override lazy val hashCode: Int = super.hashCode()
   override def equals(other: Any): Boolean = other match {
     case x: NumericRange[_] =>
-      (x canEqual this) && (finiteSize == x.finiteSize) && (
-        (finiteSize == 0) ||                      // all empty sequences are equal
+      (x canEqual this) && (length == x.length) && (
+        (length == 0) ||                      // all empty sequences are equal
           (start == x.start && last == x.last)  // same length and same endpoints implies equality
         )
     case _ =>
@@ -340,8 +340,8 @@ object NumericRange {
           val stepint = num.toInt(step)
           if (step == num.fromInt(stepint)) {
             return {
-              if (isInclusive) Range.inclusive(startint, endint, stepint).size
-              else             Range          (startint, endint, stepint).size
+              if (isInclusive) Range.inclusive(startint, endint, stepint).length
+              else             Range          (startint, endint, stepint).length
             }
           }
         }

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -89,7 +89,7 @@ sealed abstract class Range(
     }
   }
 
-  protected def finiteSize: Int = if (numRangeElements < 0) fail() else numRangeElements
+  def length = if (numRangeElements < 0) fail() else numRangeElements
 
   // This field has a sensible value only for non-empty ranges
   private val lastElement = step match {

--- a/collections/src/main/scala/strawman/collection/immutable/TrieIterator.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TrieIterator.scala
@@ -170,7 +170,7 @@ private[collection] abstract class TrieIterator[+T](elems: Array[Iterable[T]]) e
     if (subIter ne null) {
       val buff = ArrayBuffer.empty.++=(subIter)
       subIter = null
-      ((buff.iterator(), buff.size), this)
+      ((buff.iterator(), buff.length), this)
     }
     else {
       // otherwise find the topmost array stack element

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -78,9 +78,9 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 
   private[immutable] var dirty = false
 
-  protected def finiteSize: Int = endIndex - startIndex
+  def length: Int = endIndex - startIndex
 
-  override def lengthCompare(len: Int): Int = finiteSize - len
+  override def lengthCompare(len: Int): Int = length - len
 
   private[collection] def initIterator[B >: A](s: VectorIterator[B]): Unit = {
     s.initFrom(this)
@@ -163,7 +163,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
 
   override def last: A = {
     if (isEmpty) throw new UnsupportedOperationException("empty.last")
-    apply(finiteSize - 1)
+    apply(length - 1)
   }
 
   override def init: Vector[A] = {

--- a/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
@@ -36,7 +36,7 @@ final class WrappedString(val self: String) extends AbstractSeq[Char] with Index
     val end = if (until > length) length else until
     new WrappedString(self.substring(start, end))
   }
-  def finiteSize = self.length
+  override def length = self.length
   override def toString = self
   override def view: StringView = new StringView(self)
 }

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -73,7 +73,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
     array(n) = elem.asInstanceOf[AnyRef]
   }
 
-  protected def finiteSize = size0
+  def length = size0
 
   override def view: ArrayBufferView[A] = new ArrayBufferView(array, size0)
 
@@ -103,9 +103,9 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
   override def addAll(elems: IterableOnce[A]): this.type = {
     elems match {
       case elems: ArrayBuffer[_] =>
-        ensureSize(size + elems.size)
-        Array.copy(elems.array, 0, array, size, elems.size)
-        size0 = size + elems.size
+        ensureSize(length + elems.length)
+        Array.copy(elems.array, 0, array, length, elems.length)
+        size0 = length + elems.length
       case _ => super.addAll(elems)
     }
     this
@@ -129,7 +129,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
     elems match {
       case elems: collection.Iterable[A] =>
         val elemsLength = elems.size
-        ensureSize(size + elemsLength)
+        ensureSize(length + elemsLength)
         Array.copy(array, idx, array, idx + elemsLength, size0 - idx)
         size0 = size0 + elemsLength
         elems match {
@@ -197,7 +197,7 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 }
 
-class ArrayBufferView[A](val array: Array[AnyRef], protected val finiteSize: Int) extends IndexedView[A] {
+class ArrayBufferView[A](val array: Array[AnyRef], val length: Int) extends IndexedView[A] {
   @throws[ArrayIndexOutOfBoundsException]
   def apply(n: Int) = array(n).asInstanceOf[A]
   override def className = "ArrayBufferView"

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
@@ -89,9 +89,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[T]): this.type = (xs.asInstanceOf[AnyRef]) match {
       case xs: ImmutableArray.ofRef[_] =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -138,9 +138,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Byte]): this.type = xs match {
       case xs: ImmutableArray.ofByte =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -187,9 +187,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Short]): this.type = xs match {
       case xs: ImmutableArray.ofShort =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -236,9 +236,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Char]): this.type = xs match {
       case xs: ImmutableArray.ofChar =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -285,9 +285,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Int]): this.type = xs match {
       case xs: ImmutableArray.ofInt =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -334,9 +334,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Long]): this.type = xs match {
       case xs: ImmutableArray.ofLong =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -383,9 +383,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Float]): this.type = xs match {
       case xs: ImmutableArray.ofFloat =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -432,9 +432,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Double]): this.type = xs match {
       case xs: ImmutableArray.ofDouble =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)
@@ -481,9 +481,9 @@ object ArrayBuilder {
 
     override def addAll(xs: IterableOnce[Boolean]): this.type = xs match {
       case xs: ImmutableArray.ofBoolean =>
-        ensureSize(this.size + xs.size)
-        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.size)
-        size += xs.size
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.unsafeArray, 0, elems, this.size, xs.length)
+        size += xs.length
         this
       case _ =>
         super.addAll(xs)

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -110,7 +110,7 @@ trait Buffer[A]
     if (idx < 0) this else takeInPlace(idx)
   }
   def padToInPlace(len: Int, elem: A): this.type = {
-    while (size < len) +=(elem)
+    while (length < len) +=(elem)
     this
   }
 }
@@ -145,15 +145,15 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
   }
 
   def patchInPlace(from: Int, patch: strawman.collection.Seq[A], replaced: Int): this.type = {
-    val replaced0 = math.min(math.max(replaced, 0), size)
-    val i = math.min(math.max(from, 0), size)
+    val replaced0 = math.min(math.max(replaced, 0), length)
+    val i = math.min(math.max(from, 0), length)
     var j = 0
-    val n = math.min(patch.size, replaced0)
-    while (j < n && i + j < size) {
+    val n = math.min(patch.length, replaced0)
+    while (j < n && i + j < length) {
       update(i + j, patch(j))
       j += 1
     }
-    if (j < patch.size) insertAll(i + j, patch.iterator().drop(j))
+    if (j < patch.length) insertAll(i + j, patch.iterator().drop(j))
     else if (j < replaced0) remove(i + j, replaced0 - j)
     this
   }

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -92,7 +92,8 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Cha
   protected[this] def newSpecificBuilder(): strawman.collection.mutable.Builder[Char, IndexedSeq[Char]] =
     iterableFactory.newBuilder()
 
-  protected def finiteSize: Int = sb.length()
+  //TODO In the old collections, StringBuilder extends Seq -- should it do the same here to get this method?
+  def length: Int = sb.length()
 
   def addOne(x: Char) = { sb.append(x); this }
 

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
@@ -130,7 +130,7 @@ private[mutable] final class LinkedList[A]() extends AbstractSeq[A]
   /** Determines the length of this $coll by traversing and counting every
     * node.
     */
-  override def size: Int = size0(this, 0)
+  override def length: Int = size0(this, 0)
 
   @tailrec private def size0(elem: LinkedList[A], acc: Int): Int =
     if (elem.isEmpty) acc else size0(elem.next, acc + 1)

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -54,7 +54,7 @@ class ListBuffer[A]
   @throws[IndexOutOfBoundsException]
   def apply(i: Int) = first.apply(i)
 
-  override def size = len
+  def length = len
   override def knownSize = len
 
   override def isEmpty: Boolean = len == 0

--- a/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
@@ -159,7 +159,7 @@ private[mutable] class MutableList[A]
 
   /** Returns the length of this list.
     */
-  override def size: Int = len
+  override def length: Int = len
 
   /** Returns the `n`-th element of this list.
     *  @throws IndexOutOfBoundsException if index does not exist.

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -150,7 +150,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 
   def result() = this
 
-  override def size: Int = sz
+  def length = sz
 
   def apply(idx: Int) =
     if (idx >= 0 && idx < sz) headptr(idx)

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -29,7 +29,6 @@ abstract class WrappedArray[T]
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, WrappedArray, WrappedArray[T]]
-    with ArrayLike[T]
     with IndexedOptimizedSeq[T]
     with StrictOptimizedSeqOps[T, WrappedArray, WrappedArray[T]]
     with Serializable {

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -114,7 +114,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](array.getClass.getComponentType)
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): T = array(index).asInstanceOf[T]
     def update(index: Int, elem: T): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -126,7 +126,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {
     def elemTag = ClassTag.Byte
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Byte = array(index)
     def update(index: Int, elem: Byte): Unit = { array(index) = elem }
     override def hashCode = wrappedBytesHash(array)
@@ -138,7 +138,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofShort(val array: Array[Short]) extends WrappedArray[Short] with Serializable {
     def elemTag = ClassTag.Short
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Short = array(index)
     def update(index: Int, elem: Short): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -150,7 +150,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofChar(val array: Array[Char]) extends WrappedArray[Char] with Serializable {
     def elemTag = ClassTag.Char
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Char = array(index)
     def update(index: Int, elem: Char): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -162,7 +162,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofInt(val array: Array[Int]) extends WrappedArray[Int] with Serializable {
     def elemTag = ClassTag.Int
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Int = array(index)
     def update(index: Int, elem: Int): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -174,7 +174,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofLong(val array: Array[Long]) extends WrappedArray[Long] with Serializable {
     def elemTag = ClassTag.Long
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Long = array(index)
     def update(index: Int, elem: Long): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -186,7 +186,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofFloat(val array: Array[Float]) extends WrappedArray[Float] with Serializable {
     def elemTag = ClassTag.Float
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Float = array(index)
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -198,7 +198,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofDouble(val array: Array[Double]) extends WrappedArray[Double] with Serializable {
     def elemTag = ClassTag.Double
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Double = array(index)
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -210,7 +210,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofBoolean(val array: Array[Boolean]) extends WrappedArray[Boolean] with Serializable {
     def elemTag = ClassTag.Boolean
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Boolean = array(index)
     def update(index: Int, elem: Boolean): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)
@@ -222,7 +222,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
 
   final class ofUnit(val array: Array[Unit]) extends WrappedArray[Unit] with Serializable {
     def elemTag = ClassTag.Unit
-    protected def finiteSize: Int = array.length
+    def length: Int = array.length
     def apply(index: Int): Unit = array(index)
     def update(index: Int, elem: Unit): Unit = { array(index) = elem }
     override def hashCode = wrappedArrayHash(array)

--- a/collections/src/main/scala/strawman/collection/package.scala
+++ b/collections/src/main/scala/strawman/collection/package.scala
@@ -8,6 +8,8 @@ package object collection extends LowPriority {
   val Traversable = Iterable
   @deprecated("Use SeqOps instead of SeqLike", "2.13.0")
   type SeqLike[A, T] = SeqOps[A, Seq, T]
+  @deprecated("Use SeqOps (for the methods) or IndexedSeqOps (for fast indexed access) instead of ArrayLike", "2.13.0")
+  type ArrayLike[A] = SeqOps[A, Seq, Seq[A]]
 
   @deprecated("Gen* collection types have been removed", "2.13.0")
   type GenTraversableOnce[+X] = IterableOnce[X]


### PR DESCRIPTION
This reverts https://github.com/scala/collection-strawman/pull/356 which causes compatibility issues requiring unnecessary changes in every Seq implementation for no obvious benefit.