### PR TITLE
Harmonize use of @SerialVersionUID

### DIFF
--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -3,7 +3,7 @@ package collection
 
 import collection.mutable.Builder
 
-import scala.{Any, Boolean, ClassCastException, Equals, Int, NoSuchElementException, None, Nothing, Option, Ordering, PartialFunction, Serializable, Some, StringContext, `inline`, throws}
+import scala.{Any, Boolean, ClassCastException, Equals, Int, NoSuchElementException, None, Nothing, Option, Ordering, PartialFunction, Serializable, SerialVersionUID, Some, StringContext, `inline`, throws}
 import scala.Predef.String
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.implicitConversions
@@ -105,6 +105,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
 
   /** The implementation class of the set returned by `keySet`.
     */
+  @SerialVersionUID(3L)
   protected class KeySet extends Set[K] with GenKeySet {
     def iterableFactory: IterableFactory[Set] = Set
     protected[this] def fromSpecificIterable(coll: Iterable[K]): Set[K] = fromIterable(coll)

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -778,8 +778,8 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): CC[B] =
     fromIterable(new View.Patched(toIterable, from, other, replaced))
 
-  private[this] def occCounts[B](sq: Seq[B]): mutable.HashMap[B, Int] = {
-    val occ = new mutable.HashMap[B, Int] { override def default(k: B) = 0 }
+  private[this] def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
+    val occ = mutable.Map.empty[B, Int].withDefaultValue(0)
     for (y <- sq) occ(y) += 1
     occ
   }

--- a/collections/src/main/scala/strawman/collection/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/SortedMap.scala
@@ -5,7 +5,7 @@ import strawman.collection.immutable.TreeMap
 import strawman.collection.mutable.Builder
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.{Boolean, Int, Option, Ordering, PartialFunction, Serializable, `inline`}
+import scala.{Boolean, Int, Option, Ordering, PartialFunction, Serializable, SerialVersionUID, `inline`}
 
 /** Base type of sorted sets */
 trait SortedMap[K, +V]
@@ -89,6 +89,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   override def keySet: SortedSet[K] = new KeySortedSet
 
   /** The implementation class of the set returned by `keySet` */
+  @SerialVersionUID(3L)
   protected class KeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
     def iterableFactory: IterableFactory[Set] = Set
     def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet

--- a/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
+++ b/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
@@ -642,7 +642,7 @@ private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expected
   *  @author Aleksandar Prokopec
   *  @since 2.10
   */
-@SerialVersionUID(0L - 6402774413839597105L)
+@SerialVersionUID(3L)
 final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef], hashf: Hashing[K], ef: Equiv[K])
   extends strawman.collection.concurrent.Map[K, V]
     with strawman.collection.mutable.MapOps[K, V, TrieMap, TrieMap[K, V]]
@@ -1133,7 +1133,7 @@ private[concurrent] object RestartException extends ControlThrowable
 
 
 /** Only used for ctrie serialization. */
-@SerialVersionUID(0L - 7237891413820527142L)
+@SerialVersionUID(3L)
 private[concurrent] case object TrieMapSerializationEnd
 
 

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -28,6 +28,7 @@ private[collection] trait Wrappers {
     override def isEmpty = underlying.isEmpty
   }
 
+  @SerialVersionUID(3L)
   case class IteratorWrapper[A](underlying: Iterator[A]) extends ju.Iterator[A] with ju.Enumeration[A] {
     def hasNext = underlying.hasNext
     def next() = underlying.next()
@@ -40,18 +41,22 @@ private[collection] trait Wrappers {
     def asJava = new IteratorWrapper(underlying)
   }
 
+  @SerialVersionUID(3L)
   case class JIteratorWrapper[A](underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] {
     def hasNext = underlying.hasNext
     def next() = underlying.next
   }
 
+  @SerialVersionUID(3L)
   case class JEnumerationWrapper[A](underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] {
     def hasNext = underlying.hasMoreElements
     def next() = underlying.nextElement
   }
 
+  @SerialVersionUID(3L)
   case class IterableWrapper[A](underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] { }
 
+  @SerialVersionUID(3L)
   case class JIterableWrapper[A](underlying: jl.Iterable[A]) extends AbstractIterable[A] with Iterable[A] {
     def iterator() = underlying.iterator().asScala
     protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
@@ -59,6 +64,7 @@ private[collection] trait Wrappers {
     protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
   }
 
+  @SerialVersionUID(3L)
   case class JCollectionWrapper[A](underlying: ju.Collection[A]) extends AbstractIterable[A] with Iterable[A] {
     def iterator() = underlying.iterator().asScala
     override def size = underlying.size
@@ -68,10 +74,12 @@ private[collection] trait Wrappers {
     protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
   }
 
+  @SerialVersionUID(3L)
   case class SeqWrapper[A](underlying: Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
   }
 
+  @SerialVersionUID(3L)
   case class MutableSeqWrapper[A](underlying: mutable.Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = {
@@ -81,6 +89,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(3L)
   case class MutableBufferWrapper[A](underlying: mutable.Buffer[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = { val p = underlying(i); underlying(i) = elem; p }
@@ -88,6 +97,7 @@ private[collection] trait Wrappers {
     override def remove(i: Int) = underlying remove i
   }
 
+  @SerialVersionUID(3L)
   case class JListWrapper[A](underlying: ju.List[A]) extends mutable.AbstractBuffer[A] with SeqOps[A, mutable.Buffer, mutable.Buffer[A]] {
     override def size = underlying.size
     override def isEmpty = underlying.isEmpty
@@ -168,6 +178,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(3L)
   case class MutableSetWrapper[A](underlying: mutable.Set[A]) extends SetWrapper[A](underlying) {
     override def add(elem: A) = {
       val sz = underlying.size
@@ -180,6 +191,7 @@ private[collection] trait Wrappers {
     override def clear() = underlying.clear()
   }
 
+  @SerialVersionUID(3L)
   case class JSetWrapper[A](underlying: ju.Set[A]) extends mutable.AbstractSet[A] with mutable.Set[A] with mutable.SetOps[A, mutable.Set, mutable.Set[A]] {
 
     override def size = underlying.size
@@ -274,6 +286,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(3L)
   case class MutableMapWrapper[A, B](underlying: mutable.Map[A, B]) extends MapWrapper[A, B](underlying) {
     override def put(k: A, v: B) = underlying.put(k, v) match {
       case Some(v1) => v1
@@ -339,10 +352,12 @@ private[collection] trait Wrappers {
     * This includes `get`, as `java.util.Map`'s API does not allow for an
     * atomic `get` when `null` values may be present.
     */
+  @SerialVersionUID(3L)
   case class JMapWrapper[A, B](underlying : ju.Map[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JMapWrapper[A, B]] {
     override def empty = JMapWrapper(new ju.HashMap[A, B])
   }
 
+  @SerialVersionUID(3L)
   class ConcurrentMapWrapper[A, B](override val underlying: concurrent.Map[A, B]) extends MutableMapWrapper[A, B](underlying) with juc.ConcurrentMap[A, B] {
 
     override def putIfAbsent(k: A, v: B) = underlying.putIfAbsent(k, v) match {
@@ -369,6 +384,7 @@ private[collection] trait Wrappers {
     * access is supported; multi-element operations such as maps and filters
     * are not guaranteed to be atomic.
     */
+  @SerialVersionUID(3L)
   case class JConcurrentMapWrapper[A, B](underlying: juc.ConcurrentMap[A, B]) extends mutable.AbstractMap[A, B] with JMapWrapperLike[A, B, JConcurrentMapWrapper[A, B]] with concurrent.Map[A, B] {
     override def get(k: A) = Option(underlying get k)
 
@@ -384,6 +400,7 @@ private[collection] trait Wrappers {
       underlying.replace(k, oldvalue, newvalue)
   }
 
+  @SerialVersionUID(3L)
   case class DictionaryWrapper[A, B](underlying: mutable.Map[A, B]) extends ju.Dictionary[A, B] {
     def size: Int = underlying.size
     def isEmpty: Boolean = underlying.isEmpty
@@ -411,6 +428,7 @@ private[collection] trait Wrappers {
     }
   }
 
+  @SerialVersionUID(3L)
   case class JDictionaryWrapper[A, B](underlying: ju.Dictionary[A, B]) extends mutable.AbstractMap[A, B] with mutable.Map[A, B] {
     override def size: Int = underlying.size
 
@@ -436,6 +454,7 @@ private[collection] trait Wrappers {
     def empty = mutable.HashMap.empty
   }
 
+  @SerialVersionUID(3L)
   case class JPropertiesWrapper(underlying: ju.Properties) extends mutable.AbstractMap[String, String]
             with mutable.MapOps[String, String, mutable.Map, mutable.Map[String, String]] {
 

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -139,7 +139,7 @@ private[collection] trait Wrappers {
     def subtractOne(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
   }
 
-  @SerialVersionUID(1L)
+  @SerialVersionUID(3L)
   class SetWrapper[A](underlying: Set[A]) extends ju.AbstractSet[A] with Serializable { self =>
     // Note various overrides to avoid performance gotchas.
     override def contains(o: Object): Boolean = {
@@ -209,7 +209,7 @@ private[collection] trait Wrappers {
     protected[this] def newSpecificBuilder() = mutable.HashSet.newBuilder()
   }
 
-  @SerialVersionUID(1L)
+  @SerialVersionUID(3L)
   class MapWrapper[A, B](underlying: Map[A, B]) extends ju.AbstractMap[A, B] with Serializable { self =>
     override def size = underlying.size
 
@@ -489,5 +489,5 @@ private[collection] trait Wrappers {
   }
 }
 
-@SerialVersionUID(0 - 5857859809262781311L)
+@SerialVersionUID(3L)
 object Wrappers extends Wrappers with Serializable

--- a/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -16,7 +16,7 @@ import scala.Predef.require
   *  @define Coll `immutable.BitSet`
   *  @define coll immutable bitset
   */
-@SerialVersionUID(1611436763290191562L)
+@SerialVersionUID(3L)
 sealed abstract class BitSet
   extends SortedSet[Int]
     with collection.BitSet
@@ -101,7 +101,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
     else new BitSetN(elems)
   }
 
-  @SerialVersionUID(2260107458435649300L)
+  @SerialVersionUID(3L)
   class BitSet1(val elems: Long) extends BitSet {
     protected[collection] def nwords = 1
     protected[collection] def word(idx: Int) = if (idx == 0) elems else 0L

--- a/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -111,6 +111,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       else fromBitMaskNoCopy(updateArray(Array(elems), idx, w))
   }
 
+  @SerialVersionUID(3L)
   class BitSet2(val elems0: Long, elems1: Long) extends BitSet {
     protected[collection] def nwords = 2
     protected[collection] def word(idx: Int) = if (idx == 0) elems0 else if (idx == 1) elems1 else 0L
@@ -120,10 +121,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
       else fromBitMaskNoCopy(updateArray(Array(elems0, elems1), idx, w))
   }
 
+  @SerialVersionUID(3L)
   class BitSetN(val elems: Array[Long]) extends BitSet {
     protected[collection] def nwords = elems.length
     protected[collection] def word(idx: Int) = if (idx < nwords) elems(idx) else 0L
     protected[collection] def updateWord(idx: Int, w: Long): BitSet = fromBitMaskNoCopy(updateArray(elems, idx, w))
   }
-
 }

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
@@ -26,7 +26,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
   *  @define coll immutable champ hash map
   */
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V], val cachedJavaKeySetHashCode: Int, val cachedSize: Int)
   extends Map[K, V]
     with MapOps[K, V, ChampHashMap, ChampHashMap[K, V]]
@@ -117,7 +117,7 @@ private[immutable] object MapNode {
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, V @uV]] with Serializable {
 
   def get(key: K, hash: Int, shift: Int): Option[V]
@@ -150,7 +150,7 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private final class BitmapIndexedMapNode[K, +V](val dataMap: Int, val nodeMap: Int, val content: Array[Any]) extends MapNode[K, V] {
 
   import Node._
@@ -501,7 +501,7 @@ private final class BitmapIndexedMapNode[K, +V](val dataMap: Int, val nodeMap: I
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private final class HashCollisionMapNode[K, +V](val hash: Int, val content: Vector[(K, V)]) extends MapNode[K, V] {
 
   import Node._

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
@@ -22,7 +22,7 @@ import java.lang.System.arraycopy
   *  @define Coll `immutable.ChampHashSet`
   *  @define coll immutable champ hash set
   */
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val cachedJavaHashCode: Int, val cachedSize: Int)
   extends Set[A]
     with SetOps[A, ChampHashSet, ChampHashSet[A]]
@@ -107,7 +107,7 @@ private[immutable] final object SetNode {
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private[immutable] sealed abstract class SetNode[A] extends Node[SetNode[A]] with Serializable {
 
   def contains(element: A, hash: Int, shift: Int): Boolean
@@ -136,7 +136,7 @@ private[immutable] sealed abstract class SetNode[A] extends Node[SetNode[A]] wit
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private final class BitmapIndexedSetNode[A](val dataMap: Int, val nodeMap: Int, val content: Array[Any]) extends SetNode[A] {
 
   import Node._
@@ -478,7 +478,7 @@ private final class BitmapIndexedSetNode[A](val dataMap: Int, val nodeMap: Int, 
 
 }
 
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 private final class HashCollisionSetNode[A](val hash: Int, val content: Vector[A]) extends SetNode[A] {
 
   import Node._

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -27,6 +27,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed abstract class HashMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -182,7 +182,7 @@ object HashMap extends MapFactory[HashMap] {
     */
   @`inline` private def nullToEmpty[A, B](m: HashMap[A, B]): HashMap[A, B] = if (m eq null) empty[A, B] else m
 
-  @SerialVersionUID(3806596116252973913L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+  @SerialVersionUID(3L)
   private object EmptyHashMap extends HashMap[Any, Nothing] {
 
     protected def updated0[V1 >: Nothing](key: Any, hash: Int, level: Int, value: V1, kv: (Any, V1), merger: Merger[Any, V1]): HashMap[Any, V1] =
@@ -214,7 +214,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
-  @SerialVersionUID(2971144592070775060L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+  @SerialVersionUID(3L)
   final class HashMap1[K, +V](private[collection] val key: K, private[collection] val hash: Int, private[collection] val value: V, private[collection] var kv: (K, V@uV)) extends HashMap[K, V] {
 
     def iterator(): Iterator[(K, V)] = Iterator.single(ensurePair)
@@ -267,7 +267,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
-  @SerialVersionUID(-2790842372316477099L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+  @SerialVersionUID(3L)
   private[collection] class HashMapCollision1[K, +V](private[collection] val hash: Int, val kvs: ListMap[K, V @uV])
     extends HashMap[K, V @uV] {
     // assert(kvs.size > 1)
@@ -339,7 +339,7 @@ object HashMap extends MapFactory[HashMap] {
 
   }
 
-  @SerialVersionUID(-6145486889358767209L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+  @SerialVersionUID(3L)
   final class HashTrieMap[K, +V](
     private[collection] val bitmap: Int,
     private[collection] val elems: Array[HashMap[K, V @uV]],

--- a/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -22,7 +22,7 @@ import java.lang.Integer
   *  @define Coll `immutable.HashSet`
   *  @define coll immutable hash set
   */
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 sealed abstract class HashSet[A]
   extends Set[A]
     with SetOps[A, HashSet, HashSet[A]]

--- a/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -77,6 +77,7 @@ object HashSet extends IterableFactory[HashSet] {
       def addOne(elem: A): this.type = { elems = elems + elem; this }
     }
 
+  @SerialVersionUID(3L)
   private object EmptyHashSet extends HashSet[Any] {
 
     def iterator(): Iterator[Any] = Iterator.empty
@@ -104,6 +105,7 @@ object HashSet extends IterableFactory[HashSet] {
   /**
     * Common superclass of HashSet1 and HashSetCollision1, which are the two possible leaves of the Trie
     */
+  @SerialVersionUID(3L)
   private[HashSet] sealed abstract class LeafHashSet[A] extends HashSet[A] {
     private[HashSet] def hash:Int
   }
@@ -233,6 +235,7 @@ object HashSet extends IterableFactory[HashSet] {
     * elems: [a,b]
     * children:        ---b----------------a-----------
     */
+  @SerialVersionUID(3L)
   private[immutable] final class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], private val size0: Int)
     extends HashSet[A] {
     assert(Integer.bitCount(bitmap) == elems.length)

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -4,7 +4,7 @@ package collection.immutable
 import strawman.collection.mutable.{ArrayBuffer, Builder}
 import strawman.collection.{IterableOnce, Iterator, SeqFactory, ClassTagSeqFactory, StrictOptimizedClassTagSeqFactory, View}
 
-import scala.{Any, ArrayIndexOutOfBoundsException, Boolean, Int, Nothing, UnsupportedOperationException, throws, Array, AnyRef, `inline`, Serializable, Byte, Short, Long, Double, Unit, Float, Char}
+import scala.{Any, ArrayIndexOutOfBoundsException, Boolean, Int, Nothing, UnsupportedOperationException, throws, Array, AnyRef, `inline`, Serializable, SerialVersionUID, Byte, Short, Long, Double, Unit, Float, Char}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.util.hashing.MurmurHash3
 import scala.reflect.ClassTag
@@ -179,6 +179,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     case x: Array[Unit]    => new ofUnit(x)
   }).asInstanceOf[ImmutableArray[T]]
 
+  @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ImmutableArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](unsafeArray.getClass.getComponentType)
     protected def finiteSize: Int = unsafeArray.length
@@ -191,6 +192,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofByte(val unsafeArray: Array[Byte]) extends ImmutableArray[Byte] with Serializable {
     protected[this] def elemTag = ClassTag.Byte
     protected def finiteSize: Int = unsafeArray.length
@@ -203,6 +205,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofShort(val unsafeArray: Array[Short]) extends ImmutableArray[Short] with Serializable {
     protected[this] def elemTag = ClassTag.Short
     protected def finiteSize: Int = unsafeArray.length
@@ -215,6 +218,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofChar(val unsafeArray: Array[Char]) extends ImmutableArray[Char] with Serializable {
     protected[this] def elemTag = ClassTag.Char
     protected def finiteSize: Int = unsafeArray.length
@@ -227,6 +231,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofInt(val unsafeArray: Array[Int]) extends ImmutableArray[Int] with Serializable {
     protected[this] def elemTag = ClassTag.Int
     protected def finiteSize: Int = unsafeArray.length
@@ -239,6 +244,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofLong(val unsafeArray: Array[Long]) extends ImmutableArray[Long] with Serializable {
     protected[this] def elemTag = ClassTag.Long
     protected def finiteSize: Int = unsafeArray.length
@@ -251,6 +257,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofFloat(val unsafeArray: Array[Float]) extends ImmutableArray[Float] with Serializable {
     protected[this] def elemTag = ClassTag.Float
     protected def finiteSize: Int = unsafeArray.length
@@ -263,6 +270,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofDouble(val unsafeArray: Array[Double]) extends ImmutableArray[Double] with Serializable {
     protected[this] def elemTag = ClassTag.Double
     protected def finiteSize: Int = unsafeArray.length
@@ -275,6 +283,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ImmutableArray[Boolean] with Serializable {
     protected[this] def elemTag = ClassTag.Boolean
     protected def finiteSize: Int = unsafeArray.length
@@ -287,6 +296,7 @@ object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] 
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofUnit(val unsafeArray: Array[Unit]) extends ImmutableArray[Unit] with Serializable {
     protected[this] def elemTag = ClassTag.Unit
     protected def finiteSize: Int = unsafeArray.length

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package immutable
 
-import scala.{Int, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Some, IllegalArgumentException, `inline`}
+import scala.{Int, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
 import java.lang.IllegalStateException
 import strawman.collection
 import strawman.collection.generic.BitOperations
@@ -51,6 +51,7 @@ object IntMap {
   def apply[T](elems: (Int, T)*): IntMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+  @SerialVersionUID(3L)
   private[immutable] case object Nil extends IntMap[Nothing] {
     // Important! Without this equals method in place, an infinite
     // loop from Map.equals => size => pattern-match-on-Nil => equals
@@ -63,11 +64,14 @@ object IntMap {
     }
   }
 
+  @SerialVersionUID(3L)
   private[immutable] case class Tip[+T](key: Int, value: T) extends IntMap[T]{
     def withValue[S](s: S) =
       if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[IntMap.Tip[S]]
       else IntMap.Tip(key, s)
   }
+
+  @SerialVersionUID(3L)
   private[immutable] case class Bin[+T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]) extends IntMap[T] {
     def bin[S](left: IntMap[S], right: IntMap[S]): IntMap[S] = {
       if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[IntMap.Bin[S]]
@@ -156,9 +160,11 @@ import IntMap._
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed abstract class IntMap[+T] extends Map[Int, T]
   with MapOps[Int, T, Map, IntMap[T]]
-  with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]] {
+  with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]]
+  with Serializable {
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Int, T)]): IntMap[T] =
     intMapFromIterable[T](coll)

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -400,7 +400,7 @@ sealed abstract class List[+A]
 
 }
 
-@SerialVersionUID(6493291385232469459L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+@SerialVersionUID(3L)
 case class :: [+A](x: A, private[strawman] var next: List[A @uncheckedVariance]) // sound because `next` is used only locally
   extends List[A] {
   override def isEmpty: Boolean = false
@@ -410,7 +410,7 @@ case class :: [+A](x: A, private[strawman] var next: List[A @uncheckedVariance])
   override def tail: List[A] = next
 }
 
-@SerialVersionUID(-5302509162483950757L) // value computed for strawman 0.6.0, scala 2.13.0-M2
+@SerialVersionUID(3L)
 case object Nil extends List[Nothing] {
   override def isEmpty: Boolean = true
   override def nonEmpty: Boolean = false
@@ -442,7 +442,7 @@ object List extends StrictOptimizedSeqFactory[List] {
 
   private[collection] val partialNotApplied = new Function1[Any, Any] { def apply(x: Any): Any = this }
 
-  @SerialVersionUID(1L)
+  @SerialVersionUID(3L)
   private class SerializationProxy[A](@transient private var orig: List[A]) extends Serializable {
 
     private def writeObject(out: ObjectOutputStream): Unit = {
@@ -476,5 +476,5 @@ object List extends StrictOptimizedSeqFactory[List] {
 
 
 /** Only used for list serialization */
-@SerialVersionUID(0L - 8476791151975527571L)
+@SerialVersionUID(3L)
 private[strawman] case object ListSerializeEnd

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -71,6 +71,7 @@ import scala.{Any, AnyRef, Boolean, Function1, IndexOutOfBoundsException, Int, N
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed abstract class List[+A]
   extends LinearSeq[A]
     with LinearSeqOps[A, List, List[A]]

--- a/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -42,7 +42,7 @@ import strawman.collection.mutable.{Builder, ImmutableBuilder}
   * @define mayNotTerminateInf
   * @define willNotTerminateInf
   */
-@SerialVersionUID(301002838095710379L)
+@SerialVersionUID(3L)
 sealed class ListMap[K, +V]
   extends Map[K, V]
     with MapOps[K, V, ListMap, ListMap[K, V]]
@@ -89,7 +89,7 @@ sealed class ListMap[K, +V]
   /**
     * Represents an entry in the `ListMap`.
     */
-  @SerialVersionUID(-6453056603889598734L)
+  @SerialVersionUID(3L)
   protected class Node[V1 >: V](override protected val key: K,
                                 override protected val value: V1) extends ListMap[K, V1] with Serializable {
 
@@ -159,7 +159,7 @@ object ListMap extends MapFactory[ListMap] {
 
   def empty[K, V]: ListMap[K, V] = EmptyListMap.asInstanceOf[ListMap[K, V]]
 
-  @SerialVersionUID(-8256686706655863282L)
+  @SerialVersionUID(3L)
   private object EmptyListMap extends ListMap[Any, Nothing]
 
   def from[K, V](it: collection.IterableOnce[(K, V)]): ListMap[K, V] =

--- a/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -29,7 +29,7 @@ import scala.{Any, Boolean, Int, NoSuchElementException, SerialVersionUID, Seria
   * @define mayNotTerminateInf
   * @define willNotTerminateInf
   */
-@SerialVersionUID(-8417059026623606218L)
+@SerialVersionUID(3L)
 sealed class ListSet[A]
   extends Set[A]
     with SetOps[A, ListSet, ListSet[A]]
@@ -67,7 +67,7 @@ sealed class ListSet[A]
   /**
     * Represents an entry in the `ListSet`.
     */
-  @SerialVersionUID(-787710309854855049L)
+  @SerialVersionUID(3L)
   protected class Node(override protected val elem: A) extends ListSet[A] with Serializable {
 
     override def size = sizeInternal(this, 0)
@@ -119,7 +119,7 @@ object ListSet extends IterableFactory[ListSet] {
       case _ => (newBuilder[E]() ++= it).result()
     }
 
-  @SerialVersionUID(5010379588739277132L)
+  @SerialVersionUID(3L)
   private object EmptyListSet extends ListSet[Any]
   private[collection] def emptyInstance: ListSet[Any] = EmptyListSet
 

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package immutable
 
-import scala.{Int, Long, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Some, IllegalArgumentException, `inline`}
+import scala.{Int, Long, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
 import java.lang.IllegalStateException
 import strawman.collection.generic.BitOperations
 import strawman.collection.mutable.{Builder, ImmutableBuilder, ListBuffer}
@@ -49,6 +49,7 @@ object LongMap {
   def apply[T](elems: (Long, T)*): LongMap[T] =
     elems.foldLeft(empty[T])((x, y) => x.updated(y._1, y._2))
 
+  @SerialVersionUID(3L)
   private[immutable] case object Nil extends LongMap[Nothing] {
     // Important, don't remove this! See IntMap for explanation.
     override def equals(that : Any) = that match {
@@ -58,11 +59,14 @@ object LongMap {
     }
   }
 
+  @SerialVersionUID(3L)
   private[immutable] case class Tip[+T](key: Long, value: T) extends LongMap[T] {
     def withValue[S](s: S) =
       if (s.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) this.asInstanceOf[LongMap.Tip[S]]
       else LongMap.Tip(key, s)
   }
+
+  @SerialVersionUID(3L)
   private[immutable] case class Bin[+T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]) extends LongMap[T] {
     def bin[S](left: LongMap[S], right: LongMap[S]): LongMap[S] = {
       if ((this.left eq left) && (this.right eq right)) this.asInstanceOf[LongMap.Bin[S]]
@@ -143,9 +147,11 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed abstract class LongMap[+T] extends Map[Long, T]
   with MapOps[Long, T, Map, LongMap[T]]
-  with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]] {
+  with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]]
+  with Serializable {
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, T)]): LongMap[T] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?

--- a/collections/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Map.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.mutable.Builder
 
-import scala.{Any, Boolean, `inline`, Int, None, NoSuchElementException, Nothing, Option, Some, Serializable, Unit}
+import scala.{Any, Boolean, `inline`, Int, None, NoSuchElementException, Nothing, Option, Some, Serializable, SerialVersionUID, Unit}
 import scala.Predef.<:<
 
 /** Base type of immutable Maps */
@@ -109,6 +109,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   override def keySet: Set[K] = new ImmutableKeySet
 
   /** The implementation class of the set returned by `keySet` */
+  @SerialVersionUID(3L)
   protected class ImmutableKeySet extends Set[K] with GenKeySet {
     def iterableFactory: IterableFactory[Set] = Set
     protected[this] def fromSpecificIterable(coll: collection.Iterable[K]): Set[K] = fromIterable(coll)
@@ -130,9 +131,11 @@ object Map extends MapFactory[Map] {
   private final val useBaseline: Boolean =
     scala.sys.props.get("strawman.collection.immutable.useBaseline").contains("true")
 
+  @SerialVersionUID(3L)
   class WithDefault[K, +V](val underlying: Map[K, V], val defaultValue: K => V)
     extends Map[K, V]
-    with MapOps[K, V, Map, WithDefault[K, V]]{
+      with MapOps[K, V, Map, WithDefault[K, V]]
+      with Serializable{
 
     def get(key: K): Option[V] = underlying.get(key)
 
@@ -181,6 +184,7 @@ object Map extends MapFactory[Map] {
     protected[this] def newSpecificBuilder(): Builder[(K, V), Map[K, V]] = mapFactory.newBuilder()
   }
 
+  @SerialVersionUID(3L)
   private object EmptyMap extends Map[Any, Nothing] with SmallMap[Any, Nothing] with Serializable {
     override def size: Int = 0
     override def apply(key: Any) = throw new NoSuchElementException("key not found: " + key)
@@ -191,6 +195,7 @@ object Map extends MapFactory[Map] {
     def remove(key: Any): Map[Any, Nothing] = this
   }
 
+  @SerialVersionUID(3L)
   final class Map1[K, +V](key1: K, value1: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
     override def size = 1
     override def apply(key: K) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
@@ -208,6 +213,7 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  @SerialVersionUID(3L)
   final class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
     override def size = 2
     override def apply(key: K) =
@@ -233,6 +239,7 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  @SerialVersionUID(3L)
   class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
     override def size = 3
     override def apply(key: K) =
@@ -262,6 +269,7 @@ object Map extends MapFactory[Map] {
     }
   }
 
+  @SerialVersionUID(3L)
   final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
     override def size = 4
     override def apply(key: K) =

--- a/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -3,7 +3,7 @@ package strawman.collection.immutable
 import strawman.collection
 import strawman.collection.{SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps, arrayToArrayOps}
 
-import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, Int, Integral, NoSuchElementException, Numeric, Ordering, Serializable, StringContext, Unit, `inline`, math, specialized, throws}
+import scala.{Any, Boolean, ClassCastException, IllegalArgumentException, IndexOutOfBoundsException, Int, Integral, NoSuchElementException, Numeric, Ordering, Serializable, SerialVersionUID, StringContext, Unit, `inline`, math, specialized, throws}
 import scala.Predef.ArrowAssoc
 import java.lang.String
 
@@ -30,6 +30,7 @@ import strawman.collection.mutable.Builder
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed class NumericRange[T](
   val start: T,
   val end: T,
@@ -401,6 +402,7 @@ object NumericRange {
     }
   }
 
+  @SerialVersionUID(3L)
   class Inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
     extends NumericRange(start, end, step, true) {
     override def copy(start: T, end: T, step: T): Inclusive[T] =
@@ -409,6 +411,7 @@ object NumericRange {
     def exclusive: Exclusive[T] = NumericRange(start, end, step)
   }
 
+  @SerialVersionUID(3L)
   class Exclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
     extends NumericRange(start, end, step, false) {
     override def copy(start: T, end: T, step: T): Exclusive[T] =

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -46,7 +46,7 @@ import strawman.collection.mutable.Builder
   *    '''Note:''' this method does not use builders to construct a new range,
   *         and its complexity is O(1).
   */
-@SerialVersionUID(7618862778670199309L)
+@SerialVersionUID(3L)
 sealed abstract class Range(
   val start: Int,
   val end: Int,

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -449,10 +449,12 @@ object Range {
     */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
+  @SerialVersionUID(3L)
   final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
     def isInclusive = true
   }
 
+  @SerialVersionUID(3L)
   final class Exclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
     def isInclusive = false
   }

--- a/collections/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/RedBlackTree.scala
@@ -14,7 +14,7 @@ import collection.Iterator
 import scala.annotation.tailrec
 import scala.annotation.meta.getter
 
-import scala.{Array, Boolean, Int, None, NoSuchElementException, Option, Ordering, Serializable, Some, sys, Unit, `inline`, throws}
+import scala.{Array, Boolean, Int, None, NoSuchElementException, Option, Ordering, Serializable, SerialVersionUID, Some, sys, Unit, `inline`, throws}
 import java.lang.{Integer, String}
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
@@ -456,6 +456,7 @@ private[collection] object RedBlackTree {
    *
    * An alternative is to implement the these classes using plain old Java code...
    */
+  @SerialVersionUID(3L)
   sealed abstract class Tree[A, +B](
     @(`inline` @getter) final val key: A,
     @(`inline` @getter) final val value: B,
@@ -466,6 +467,7 @@ private[collection] object RedBlackTree {
     def black: Tree[A, B]
     def red: Tree[A, B]
   }
+  @SerialVersionUID(3L)
   final class RedTree[A, +B](key: A,
     value: B,
     left: Tree[A, B],
@@ -474,6 +476,7 @@ private[collection] object RedBlackTree {
     override def red: Tree[A, B] = this
     override def toString: String = "RedTree(" + key + ", " + value + ", " + left + ", " + right + ")"
   }
+  @SerialVersionUID(3L)
   final class BlackTree[A, +B](key: A,
     value: B,
     left: Tree[A, B],

--- a/collections/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Set.scala
@@ -90,7 +90,7 @@ object Set extends IterableFactory[Set] {
   }
 
   /** An optimized representation for immutable empty sets */
-  @SerialVersionUID(-2443710944435909512L)
+  @SerialVersionUID(3L)
   private object EmptySet extends Set[Any] with SmallSet[Any] with Serializable {
     override def size: Int = 0
     def contains(elem: Any): Boolean = false
@@ -102,7 +102,7 @@ object Set extends IterableFactory[Set] {
   private[collection] def emptyInstance: Set[Any] = EmptySet
 
   /** An optimized representation for immutable sets of size 1 */
-  @SerialVersionUID(1233385750652442003L)
+  @SerialVersionUID(3L)
   final class Set1[A] private[collection] (elem1: A) extends Set[A] with SmallSet[A] with Serializable {
     override def size: Int = 1
     def contains(elem: A): Boolean = elem == elem1
@@ -124,7 +124,7 @@ object Set extends IterableFactory[Set] {
   }
 
   /** An optimized representation for immutable sets of size 2 */
-  @SerialVersionUID(-6443011234944830092L)
+  @SerialVersionUID(3L)
   final class Set2[A] private[collection] (elem1: A, elem2: A) extends Set[A] with SmallSet[A] with Serializable {
     override def size: Int = 2
     def contains(elem: A): Boolean = elem == elem1 || elem == elem2
@@ -155,7 +155,7 @@ object Set extends IterableFactory[Set] {
   }
 
   /** An optimized representation for immutable sets of size 3 */
-  @SerialVersionUID(-3590273538119220064L)
+  @SerialVersionUID(3L)
   final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends Set[A] with SmallSet[A] with Serializable {
     override def size: Int = 3
     def contains(elem: A): Boolean =
@@ -189,7 +189,7 @@ object Set extends IterableFactory[Set] {
   }
 
   /** An optimized representation for immutable sets of size 4 */
-  @SerialVersionUID(-3622399588156184395L)
+  @SerialVersionUID(3L)
   final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends Set[A] with SmallSet[A] with Serializable {
     override def size: Int = 4
     def contains(elem: A): Boolean =

--- a/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -3,7 +3,7 @@ package collection
 package immutable
 
 import strawman.collection.mutable.Builder
-import scala.{Option, Ordering, `inline`}
+import scala.{Option, Ordering, `inline`, Serializable, SerialVersionUID}
 
 trait SortedMap[K, +V]
   extends Map[K, V]
@@ -41,6 +41,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
     override def keySet: SortedSet[K] = new ImmutableKeySortedSet
 
     /** The implementation class of the set returned by `keySet` */
+    @SerialVersionUID(3L)
     protected class ImmutableKeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
       def iterableFactory: IterableFactory[Set] = Set
       def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
@@ -73,10 +74,12 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
 
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
+  @SerialVersionUID(3L)
   final class WithDefault[K, +V](underlying: SortedMap[K, V], defaultValue: K => V)
     extends Map.WithDefault[K, V](underlying, defaultValue)
-    with SortedMap[K, V]
-    with SortedMapOps[K, V, SortedMap, WithDefault[K, V]]{
+      with SortedMap[K, V]
+      with SortedMapOps[K, V, SortedMap, WithDefault[K, V]]
+      with Serializable {
 
     implicit def ordering: Ordering[K] = underlying.ordering
 

--- a/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -27,7 +27,7 @@ import scala.{Boolean, Int, math, Option, Ordering, SerialVersionUID, Serializab
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(1234)
+@SerialVersionUID(3L)
 final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]

--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -25,7 +25,7 @@ import scala.{Boolean, Int, math, NullPointerException, Option, Ordering, Serial
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(-5685982407650748405L)
+@SerialVersionUID(3L)
 final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -62,7 +62,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-@SerialVersionUID(-1334388273712300479L)
+@SerialVersionUID(3L)
 final class Vector[+A] private[immutable] (private[collection] val startIndex: Int, private[collection] val endIndex: Int, focus: Int)
   extends IndexedSeq[A]
     with IndexedSeqOps[A, Vector, Vector[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -28,7 +28,7 @@ import scala.math
  *  rapidly as 2^30^ is approached.
  *
  */
-@SerialVersionUID(1L)
+@SerialVersionUID(3L)
 class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initialBufferSize: Int, initBlank: Boolean)
   extends Map[K, V]
     with MapOps[K, V, Map, AnyRefMap[K, V]]
@@ -429,7 +429,7 @@ object AnyRefMap {
   private final val VacantBit  = 0x40000000
   private final val MissVacant = 0xC0000000
 
-  @SerialVersionUID(1L)
+  @SerialVersionUID(3L)
   private class ExceptionDefault extends (Any => Nothing) with Serializable {
     def apply(k: Any): Nothing = throw new NoSuchElementException(if (k == null) "(null)" else k.toString)
   }

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -29,7 +29,7 @@ import scala.Predef.intWrapper
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(1529165946227428979L)
+@SerialVersionUID(3L)
 class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
   extends AbstractBuffer[A]
     with IndexedSeq[A]

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuilder.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Array, Serializable, Byte, Short, Char, Int, Long, Float, Double, Boolean, Unit, AnyRef, Any}
+import scala.{Array, Serializable, SerialVersionUID, Byte, Short, Char, Int, Long, Float, Double, Boolean, Unit, AnyRef, Any}
 import scala.Predef.implicitly
 import scala.reflect.ClassTag
 import strawman.collection.immutable.ImmutableArray
@@ -12,7 +12,10 @@ import strawman.collection.immutable.ImmutableArray
  *
  *  @tparam T    the type of the elements for the builder.
  */
-sealed abstract class ArrayBuilder[T] extends ReusableBuilder[T, Array[T]] with Serializable {
+@SerialVersionUID(3L)
+sealed abstract class ArrayBuilder[T]
+  extends ReusableBuilder[T, Array[T]]
+    with Serializable {
   protected[this] var capacity: Int = 0
   protected var size: Int = 0
 
@@ -65,6 +68,7 @@ object ArrayBuilder {
    *
    *  @tparam T     type of elements for the array builder, subtype of `AnyRef` with a `ClassTag` context bound.
    */
+  @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef : ClassTag] extends ArrayBuilder[T] {
 
     private var elems: Array[T] = _
@@ -114,6 +118,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `byte`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofByte extends ArrayBuilder[Byte] {
 
     private var elems: Array[Byte] = _
@@ -163,6 +168,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `short`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofShort extends ArrayBuilder[Short] {
 
     private var elems: Array[Short] = _
@@ -212,6 +218,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `char`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofChar extends ArrayBuilder[Char] {
 
     private var elems: Array[Char] = _
@@ -261,6 +268,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `int`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofInt extends ArrayBuilder[Int] {
 
     private var elems: Array[Int] = _
@@ -310,6 +318,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `long`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofLong extends ArrayBuilder[Long] {
 
     private var elems: Array[Long] = _
@@ -359,6 +368,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `float`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofFloat extends ArrayBuilder[Float] {
 
     private var elems: Array[Float] = _
@@ -408,6 +418,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `double`s. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofDouble extends ArrayBuilder[Double] {
 
     private var elems: Array[Double] = _
@@ -457,6 +468,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `boolean`s. It can be reused. */
+  @SerialVersionUID(3L)
   class ofBoolean extends ArrayBuilder[Boolean] {
 
     private var elems: Array[Boolean] = _
@@ -506,6 +518,7 @@ object ArrayBuilder {
   }
 
   /** A class for array builders for arrays of `Unit` type. It can be reused. */
+  @SerialVersionUID(3L)
   final class ofUnit extends ArrayBuilder[Unit] {
 
     def addOne(elem: Unit): this.type = {

--- a/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -23,7 +23,7 @@ import scala.Predef.{require}
   * @define mayNotTerminateInf
   * @define willNotTerminateInf
   */
-@SerialVersionUID(8483111450368547763L)
+@SerialVersionUID(3L)
 class BitSet(protected[collection] final var elems: Array[Long])
   extends SortedSet[Int]
     with collection.BitSet

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -1,6 +1,6 @@
 package strawman.collection.mutable
 
-import scala.{Boolean, Any, Char, Int, Unit, Array, Byte, Float, Double, Long, Short, `inline`, deprecated, Serializable}
+import scala.{Boolean, Any, Char, Int, Unit, Array, Byte, Float, Double, Long, Short, `inline`, deprecated, Serializable, SerialVersionUID}
 import java.lang.String
 
 import strawman.collection.IterableOnce
@@ -73,6 +73,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
 
 }
 
+@SerialVersionUID(3L)
 class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Char, String]
   with IndexedSeq[Char]
   with IndexedOptimizedSeq[Char]

--- a/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -136,6 +136,7 @@ object HashMap extends MapFactory[HashMap] {
 /** Class used internally for default map model.
   *  @since 2.3
   */
+@SerialVersionUID(3L)
 final class DefaultEntry[A, B](val key: A, var value: B)
   extends HashEntry[A, DefaultEntry[A, B]]
     with Serializable {

--- a/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -20,7 +20,7 @@ import java.lang.String
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(1L)
+@SerialVersionUID(3L)
 class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, DefaultEntry[K, V]])
   extends AbstractMap[K, V]
     with MapOps[K, V, HashMap, HashMap[K, V]]

--- a/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -18,7 +18,7 @@ import scala.{Any, Boolean, Option, Serializable, SerialVersionUID, transient, U
   * @define mayNotTerminateInf
   * @define willNotTerminateInf
   */
-@SerialVersionUID(1L)
+@SerialVersionUID(3L)
 final class HashSet[A](contents: FlatHashTable.Contents[A])
   extends Set[A]
     with SetOps[A, HashSet, HashSet[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -45,7 +45,7 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
  *  @define orderDependent
  *  @define orderDependentFold
  */
-@SerialVersionUID(1L)
+@SerialVersionUID(3L)
 class LinkedHashMap[K, V]
   extends Map[K, V]
     with MapOps[K, V, LinkedHashMap, LinkedHashMap[K, V]]

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -23,6 +23,7 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
   /** Class for the linked hash map entry, used internally.
     *  @since 2.8
     */
+  @SerialVersionUID(3L)
   final class LinkedEntry[K, V](val key: K, var value: V)
     extends HashEntry[K, LinkedEntry[K, V]]
       with Serializable {
@@ -127,6 +128,7 @@ class LinkedHashMap[K, V]
       else Iterator.empty.next()
   }
 
+  @SerialVersionUID(3L)
   protected class LinkedKeySet extends KeySet {
     override def iterableFactory: IterableFactory[collection.Set] = LinkedHashSet
   }

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
@@ -145,6 +145,7 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
   /** Class for the linked hash set entry, used internally.
    *  @since 2.10
    */
+  @SerialVersionUID(3L)
   private[strawman] final class Entry[A](val key: A) extends HashEntry[A, Entry[A]] with Serializable {
     var earlier: Entry[A] = null
     var later: Entry[A] = null

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
@@ -22,7 +22,7 @@ import scala.{AnyRef, Boolean, Int, None, Option, Serializable, SerialVersionUID
  *  @define orderDependent
  *  @define orderDependentFold
  */
-@SerialVersionUID(1L)
+@SerialVersionUID(3L)
 class LinkedHashSet[A]
   extends Set[A]
     with SetOps[A, LinkedHashSet, LinkedHashSet[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
@@ -9,12 +9,13 @@
 package strawman.collection
 package mutable
 
-import scala.{Int, Unit, Serializable, Option, NoSuchElementException, IndexOutOfBoundsException, Some, None, Boolean}
+import scala.{Int, Unit, Serializable, SerialVersionUID, Option, NoSuchElementException, IndexOutOfBoundsException, Some, None, Boolean}
 import scala.Predef.require
 import scala.annotation.tailrec
 
 /** A linked list implementation which is used internally in MutableList and Queue.
   */
+@SerialVersionUID(3L)
 private[mutable] final class LinkedList[A]() extends AbstractSeq[A]
   with strawman.collection.LinearSeq[A]
   with LinearSeqOps[A, LinkedList, LinkedList[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -30,7 +30,7 @@ import scala.Predef.{assert, intWrapper}
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-@SerialVersionUID(3419063961353022662L)
+@SerialVersionUID(3L)
 class ListBuffer[A]
   extends Buffer[A]
      with SeqOps[A, ListBuffer, ListBuffer[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Long, AnyRef, Boolean, NoSuchElementException, Some, None, Option, Unit, Int, Array, Serializable, Nothing, math, deprecated}
+import scala.{Long, AnyRef, Boolean, NoSuchElementException, Some, None, Option, Unit, Int, Array, Serializable, SerialVersionUID, Nothing, math, deprecated}
 
 /** This class implements mutable maps with `Long` keys based on a hash table with open addressing.
   *
@@ -23,6 +23,7 @@ import scala.{Long, AnyRef, Boolean, NoSuchElementException, Some, None, Option,
   *  rapidly as 2^30 is approached.
   *
   */
+@SerialVersionUID(3L)
 final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBufferSize: Int, initBlank: Boolean)
   extends Map[Long, V]
     with MapOps[Long, V, Map, LongMap[V]]

--- a/collections/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Map.scala
@@ -4,7 +4,7 @@ package mutable
 
 import strawman.collection.{IterableOnce, MapFactory}
 
-import scala.{Boolean, None, Option, Some, Unit, `inline`, deprecated}
+import scala.{Boolean, None, Option, Serializable, SerialVersionUID, Some, Unit, `inline`, deprecated}
 
 /** Base type of mutable Maps */
 trait Map[K, V]
@@ -173,8 +173,11 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   */
 object Map extends MapFactory.Delegate[Map](HashMap) {
 
+  @SerialVersionUID(3L)
   class WithDefault[K, V](val underlying: Map[K, V], val defaultValue: K => V)
-    extends Map[K, V] with MapOps[K, V, Map, WithDefault[K, V]]{
+    extends Map[K, V]
+      with MapOps[K, V, Map, WithDefault[K, V]]
+      with Serializable {
 
     override def default(key: K): V = defaultValue(key)
 

--- a/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Unit, Int, Serializable, Option, NoSuchElementException, Boolean, IndexOutOfBoundsException}
+import scala.{Unit, Int, Serializable, SerialVersionUID, Option, NoSuchElementException, Boolean, IndexOutOfBoundsException}
 import scala.Predef.require
 import immutable.List
 
@@ -26,6 +26,7 @@ import immutable.List
   *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable_lists "Scala's Collection Library overview"]]
   *  section on `Mutable Lists` for more information.
   */
+@SerialVersionUID(3L)
 private[mutable] class MutableList[A]
   extends AbstractSeq[A]
     with strawman.collection.LinearSeq[A]

--- a/collections/src/main/scala/strawman/collection/mutable/PriorityQueue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/PriorityQueue.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package mutable
 
-import scala.{ Int, Unit, AnyRef, Array, Boolean, Serializable, NoSuchElementException }
+import scala.{ Int, Unit, AnyRef, Array, Boolean, Serializable, SerialVersionUID, NoSuchElementException }
 import scala.Predef.intWrapper
 import scala.math.Ordering
 
@@ -47,6 +47,7 @@ import scala.math.Ordering
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   extends AbstractIterable[A]
     with Iterable[A]
@@ -59,6 +60,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
 {
   import ord._
 
+  @SerialVersionUID(3L)
   private class ResizableArrayAccess[A] extends ArrayBuffer[A] {
     def p_size0 = size0
     def p_size0_=(s: Int) = size0 = s

--- a/collections/src/main/scala/strawman/collection/mutable/Queue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Queue.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Int, Boolean, Unit, Option, Some, None, NoSuchElementException, Serializable, deprecated}
+import scala.{Int, Boolean, Unit, Option, Some, None, NoSuchElementException, Serializable, SerialVersionUID, deprecated}
 
 /** `Queue` objects implement data structures that allow to
   *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
@@ -28,13 +28,7 @@ import scala.{Int, Boolean, Unit, Option, Some, None, NoSuchElementException, Se
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
-  /*
-extends Buffer[A]
-with SeqOps[A, ListBuffer, ListBuffer[A]]
-with StrictOptimizedSeqOps[A, ListBuffer, ListBuffer[A]]
-with ReusableBuilder[A, immutable.List[A]]
-with Serializable {*/
-
+@SerialVersionUID(3L)
 class Queue[A]
   extends MutableList[A]
     with LinearSeqOps[A, Queue, Queue[A]]

--- a/collections/src/main/scala/strawman/collection/mutable/RedBlackTree.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/RedBlackTree.scala
@@ -25,10 +25,10 @@ private[collection] object RedBlackTree {
   // Therefore, while obtaining the size of the whole tree is O(1), knowing the number of entries inside a range is O(n)
   // on the size of the range.
 
-  @SerialVersionUID(21575944040195605L)
+  @SerialVersionUID(3L)
   final class Tree[A, B](var root: Node[A, B], var size: Int) extends Serializable
 
-  @SerialVersionUID(1950599696441054720L)
+  @SerialVersionUID(3L)
   final class Node[A, B](var key: A, var value: B, var red: Boolean,
                          var left: Node[A, B], var right: Node[A, B], var parent: Node[A, B]) extends Serializable {
 

--- a/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -2,7 +2,7 @@ package strawman
 package collection.mutable
 
 import strawman.collection.SortedMapFactory
-import scala.{Option, Ordering}
+import scala.{Option, Ordering, Serializable, SerialVersionUID}
 
 /**
   * Base type for mutable sorted map collections
@@ -45,10 +45,12 @@ trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], 
 
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
+  @SerialVersionUID(3L)
   final class WithDefault[K, V](underlying: SortedMap[K, V], defaultValue: K => V)
     extends Map.WithDefault[K, V](underlying, defaultValue)
       with SortedMap[K, V]
-      with SortedMapOps[K, V, SortedMap, WithDefault[K, V]] {
+      with SortedMapOps[K, V, SortedMap, WithDefault[K, V]]
+      with Serializable {
 
     def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
 

--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -21,7 +21,7 @@ import java.lang.String
   * @define Coll mutable.TreeMap
   * @define coll mutable tree map
   */
-@SerialVersionUID(-2558985573956740112L)
+@SerialVersionUID(3L)
 sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends SortedMap[K, V]
     with SortedMapOps[K, V, TreeMap, TreeMap[K, V]]
@@ -110,7 +110,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
     *              bound.
     */
-  @SerialVersionUID(2219159283273389116L)
+  @SerialVersionUID(3L)
   private[this] final class TreeMapProjection(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
 
     /**

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -21,7 +21,7 @@ import java.lang.String
   * @define coll mutable tree set
   */
 // Original API designed in part by Lucien Pereira
-@SerialVersionUID(-3642111301929493640L)
+@SerialVersionUID(3L)
 sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
   extends SortedSet[A]
     with SortedSetOps[A, TreeSet, TreeSet[A]]
@@ -105,7 +105,7 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
     * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
     *              bound.
     */
-  @SerialVersionUID(7087824939194006086L)
+  @SerialVersionUID(3L)
   private[this] final class TreeSetProjection(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
 
     /**

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -43,7 +43,7 @@ import strawman.collection.immutable.Nil
   *  @author Aleksandar Prokopec
   *
   */
-@SerialVersionUID(2L)
+@SerialVersionUID(3L)
 sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   extends AbstractBuffer[T]
     with Buffer[T]

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -423,10 +423,3 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
 
 }
 
-
-// This is used by scala.collection.parallel.mutable.UnrolledParArrayCombiner:
-// Todo -- revisit whether inheritance is the best way to achieve this functionality
-private[collection] class DoublingUnrolledBuffer[T](implicit t: ClassTag[T]) extends UnrolledBuffer[T]()(t) {
-  override def calcNextLength(sz: Int) = if (sz < 10000) sz * 2 else sz
-  protected override def newUnrolled = new UnrolledBuffer.Unrolled[T](0, new Array[T](4), null, this)
-}

--- a/collections/src/main/scala/strawman/collection/mutable/WeakHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WeakHashMap.scala
@@ -12,6 +12,7 @@ package mutable
 
 import generic._
 import convert.Wrappers._
+import scala.SerialVersionUID
 
 /** A hash map with references to entries which are weakly reachable. Entries are
  *  removed from this map when the key is no longer (strongly) referenced. This class wraps
@@ -38,6 +39,7 @@ import convert.Wrappers._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(3L)
 class WeakHashMap[A, B] extends JMapWrapper[A, B](new java.util.WeakHashMap)
 			   with JMapWrapperLike[A, B, WeakHashMap[A, B]] {
   override def empty = new WeakHashMap[A, B]

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Unit, Int, Array, Boolean, Any, Byte, Short, Char, Long, Float, Double, AnyRef, Serializable, specialized}
+import scala.{Unit, Int, Array, Boolean, Any, Byte, Short, Char, Long, Float, Double, AnyRef, Serializable, SerialVersionUID, specialized}
 import scala.Predef.{Class, implicitly}
 import scala.runtime.ScalaRunTime
 import scala.reflect.ClassTag
@@ -25,6 +25,7 @@ import java.util.Arrays
   *  @define mayNotTerminateInf
   *  @define willNotTerminateInf
   */
+@SerialVersionUID(3L)
 abstract class WrappedArray[T]
   extends AbstractSeq[T]
     with IndexedSeq[T]
@@ -112,6 +113,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     case x: Array[Unit]    => new ofUnit(x)
   }).asInstanceOf[WrappedArray[T]]
 
+  @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
     lazy val elemTag = ClassTag[T](array.getClass.getComponentType)
     protected def finiteSize: Int = array.length
@@ -124,6 +126,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {
     def elemTag = ClassTag.Byte
     protected def finiteSize: Int = array.length
@@ -136,6 +139,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofShort(val array: Array[Short]) extends WrappedArray[Short] with Serializable {
     def elemTag = ClassTag.Short
     protected def finiteSize: Int = array.length
@@ -148,6 +152,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofChar(val array: Array[Char]) extends WrappedArray[Char] with Serializable {
     def elemTag = ClassTag.Char
     protected def finiteSize: Int = array.length
@@ -160,6 +165,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofInt(val array: Array[Int]) extends WrappedArray[Int] with Serializable {
     def elemTag = ClassTag.Int
     protected def finiteSize: Int = array.length
@@ -172,6 +178,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofLong(val array: Array[Long]) extends WrappedArray[Long] with Serializable {
     def elemTag = ClassTag.Long
     protected def finiteSize: Int = array.length
@@ -184,6 +191,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofFloat(val array: Array[Float]) extends WrappedArray[Float] with Serializable {
     def elemTag = ClassTag.Float
     protected def finiteSize: Int = array.length
@@ -196,6 +204,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofDouble(val array: Array[Double]) extends WrappedArray[Double] with Serializable {
     def elemTag = ClassTag.Double
     protected def finiteSize: Int = array.length
@@ -208,6 +217,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofBoolean(val array: Array[Boolean]) extends WrappedArray[Boolean] with Serializable {
     def elemTag = ClassTag.Boolean
     protected def finiteSize: Int = array.length
@@ -220,6 +230,7 @@ object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { se
     }
   }
 
+  @SerialVersionUID(3L)
   final class ofUnit(val array: Array[Unit]) extends WrappedArray[Unit] with Serializable {
     def elemTag = ClassTag.Unit
     protected def finiteSize: Int = array.length

--- a/test/junit/src/test/scala/strawman/collection/SeqTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/SeqTest.scala
@@ -63,4 +63,20 @@ class SeqTest {
     assertEquals(1, Vector(0, 1, 2, 0, 1, 2).lastIndexOfSlice(Vector(1, 2), end = 3))
     assertEquals(-1, List(0, 1).lastIndexOfSlice(List(1, 2)))
   }
+
+  @Test
+  def hasCorrectDiff(): Unit = {
+    val s1 = Seq(1, 2, 3, 4, 5)
+    val s2 = Seq(1, 3, 5, 7, 9)
+
+    assertEquals(Seq(2, 4), s1.diff(s2))
+  }
+
+  @Test
+  def hasCorrectIntersect(): Unit = {
+    val s1 = Seq(1, 2, 3, 4, 5)
+    val s2 = Seq(1, 3, 5, 7, 9)
+
+    assertEquals(Seq(1, 3, 5), s1.intersect(s2))
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/SerializationTest.scala
@@ -28,16 +28,28 @@ class SerializationTest {
     assertEqualsAfterDeserialization(HashMap(1 -> "one", 2 -> "two", 3 -> "three"))
   }
 
-    @Test
-    def intMap(): Unit = {
-      assertEqualsAfterDeserialization(IntMap.empty[String])
-      assertEqualsAfterDeserialization(IntMap(1 -> "one", 2 -> "two", 3 -> "three"))
-    }
+  @Test
+  def intMap(): Unit = {
+    assertEqualsAfterDeserialization(IntMap.empty[String])
+    assertEqualsAfterDeserialization(IntMap(1 -> "one", 2 -> "two", 3 -> "three"))
+  }
 
   @Test
   def longMap(): Unit = {
     assertEqualsAfterDeserialization(LongMap.empty[String])
     assertEqualsAfterDeserialization(LongMap(1L -> "one", 2L -> "two", 3L -> "three"))
+  }
+
+  @Test
+  def mapWithDefault(): Unit = {
+    assertEqualsAfterDeserialization(Map.empty[Int, String].withDefaultValue("none"))
+    assertEqualsAfterDeserialization(Map(1 -> "one").withDefaultValue("none"))
+  }
+
+  @Test
+  def sortedMapWithDefault(): Unit = {
+    assertEqualsAfterDeserialization(SortedMap.empty[Int, String].withDefaultValue("none"))
+    assertEqualsAfterDeserialization(SortedMap(1 -> "one").withDefaultValue("none"))
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/mutable/SerializationTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/SerializationTest.scala
@@ -52,6 +52,18 @@ class SerializationTest {
   }
 
   @Test
+  def mapWithDefault(): Unit = {
+    assertEqualsAfterDeserialization(mutable.Map.empty[Int, String].withDefaultValue("none"))
+    assertEqualsAfterDeserialization(mutable.Map(1 -> "one").withDefaultValue("none"))
+  }
+
+  @Test
+  def sortedMapWithDefault(): Unit = {
+    assertEqualsAfterDeserialization(mutable.SortedMap.empty[Int, String].withDefaultValue("none"))
+    assertEqualsAfterDeserialization(mutable.SortedMap(1 -> "one").withDefaultValue("none"))
+  }
+
+  @Test
   def hashSet(): Unit = {
     assertEqualsAfterDeserialization(mutable.HashSet.empty[Int])
     assertEqualsAfterDeserialization(mutable.HashSet(1, 2, 3))
@@ -73,6 +85,18 @@ class SerializationTest {
   def treeSet(): Unit = {
     assertEqualsAfterDeserialization(mutable.TreeSet.empty[Int])
     assertEqualsAfterDeserialization(mutable.TreeSet(1, 2, 3))
+  }
+
+  @Test
+  def priorityQueue(): Unit = {
+    assertEquals(Seq(), serializeDeserialize(mutable.PriorityQueue.empty[Int]).toSeq)
+    assertEquals(Seq(3, 2, 1), serializeDeserialize(mutable.PriorityQueue(1, 2, 3)).toSeq)
+  }
+
+  @Test
+  def queue(): Unit = {
+    assertEquals(Seq(), serializeDeserialize(mutable.Queue.empty[Int]).toSeq)
+    assertEquals(Seq(1, 2, 3), serializeDeserialize(mutable.Queue(1, 2, 3)).toSeq)
   }
 
   private def assertEqualsAfterDeserialization[A](original: mutable.Iterable[A]): Unit = {


### PR DESCRIPTION
This PR addresses #418:

- set all `@SerialVersionUID` to 3
- reviewed all classes implementing `Serializable` and added missing `@SerialVersionUID`
- made the following classes serializable: `immutable.LongMap`, `immutable.IntMap`, `immutable.Map.WithDefault`, `immutable.SortedMap.WithDefault`, `mutable.Map.WithDefault`, `mutable.SortedMap.WithDefault`

There are a few things left/questions:

- are the Java <-> Scala wrappers meant to be serializable? Almost all of them are case classes which auto-implement `Serializable`. However, most do not have a serial version uid: 
  - DictionaryWrapper
  - IterableWrapper
  - IteratorWrapper
  - JCollectionWrapper
  - JConcurrentMapWrapper
  - JDictionaryWrapper
  - JEnumerationWrapper
  - JIterableWrapper
  - JIteratorWrapper
  - JListWrapper
  - JMapWrapper
  - JPropertiesWrapper
  - JSetWrapper
  - WeakHashMap
  - MutableMapWrapper
  - ConcurrentMapWrapper
  - MutableBufferWrapper
  - MutableSeqWrapper
  - MutableSetWrapper
  - SeqWrapper
  - MutableSetWrapper


- The following classes are the type of sets returned by `Map.keySet`. These classes are serializable but do not have a serial version number either. An interesting detail is that they hold references to the concrete class where `MapOps` is mixed in, which would end up being part of the serialized form of the former:

  - KeySet
  - LinkedKeySet
  - KeySortedSet
  - ImmutableKeySortedSet
  - KeySortedSet
  - ImmutableKeySet
  - ImmutableKeySortedSet

Example:
```
scala> printOutputBytes(immutable.Map(1 -> 1).keySet)
��sr4strawman.collection.immutable.MapOps$ImmutableKeySet��kT�rL$outert&Lstrawman/collection/immutable/MapOps;xpsr*strawman.collection.immutable.ChampHashMapIcachedJavaKeySetHashCodeI
cachedSizerootNodet'Lstrawman/collection/immutable/MapNode;xp����sr2strawman.collection.immutable.BitmapIndexedMapNodeIdataMapInodeMap[contentt[Ljava/lang/Object;xr%strawman.collection.immutable.MapNodexp�ur[Ljava.lang.Object;��X�s)lxpsrjava.lang.Integer⠤���8Ivaluexrjava.lang.Number���
                                                                                                            ���xpq~


scala> serializeDeserialize(immutable.TreeMap(1 -> 1).keySet)
��sr@strawman.collection.immutable.SortedMapOps$ImmutableKeySortedSet�3,ؙ�L$outert,Lstrawman/collection/immutable/SortedMapOps;xpsr%strawman.collection.immutable.TreeMaporderingtLscala/math/Ordering;Ltreet1Lstrawman/collection/immutable/RedBlackTree$Tree;xpsrscala.math.Ordering$Int$��܂����xpsr4strawman.collection.immutable.RedBlackTree$BlackTreexr/strawman.collection.immutable.RedBlackTree$TreeIcountLkeytLjava/lang/Object;Lleftq~Lrightq~Lvalueq~
                                                                                            xpsrjava.lang.Integer⠤���8Ivaluexrjava.lang.Number���
                                                                                                                                                 ���xpppq~
```

Java's `Map` classes use similar strategy by returning inner classes which implement `Set`. However, those are **not** serializable:

```
scala> val j = new java.util.HashMap[Int, Int]()
j: java.util.HashMap[Int,Int] = {}

scala> serializeDeserialize(j.keySet)
java.io.NotSerializableException: java.util.HashMap$KeySet
  at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
  at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
  at .serializeDeserialize(<console>:18)
  ... 36 elided
```

Current Scala collections implement `keySet` similarly to Strawman in the sense that they return instances of anonymous classes holding references to the enclosing `Map`, are serializable but don't define a fixed serial version uid.

I was wondering what would be the best approach here: 1) keep things as is and just add the serial version uid annotation to the `KeySet` classes; 2) scrap those classes and replace implementation of `keySet` with something like `def keySet: Set[K] = Set.from(View.Map(toIterable, { case (k: K, _) => k }))` (it would make it strict though); 3) make `KeySet` not serializable


&nbsp;&nbsp;
- The final one: `NumericRange.mapRange` returns an anonymous class which has access to enclosing fields. That could be turned into a class in the companion object, but would require the mapping function to be serialized alongside with it, which in turn would potentially hold references to fields/variables in the enclosing scope of code using it. Any suggestion? 