### PR TITLE
Fix lazylist toString

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -615,8 +615,8 @@ object Stream extends LazyListFactory[Stream] {
     }
     def force: Evaluated[A] = Some((head, tail))
     private[immutable] def evaluatedElementsInString(): List[String] = {
-      if (tlEvaluated) return List(s"$head") ::: tail.evaluatedElementsInString
-      else return List(s"$head")
+      if (tlEvaluated) List(s"$head") ::: tail.evaluatedElementsInString
+      else List(s"$head", "?")
     }
   }
 

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -242,6 +242,7 @@ sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, Lazy
 }
 
 sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]], +C <: CC[A]] extends LinearSeqOps[A, CC, C] {
+  
   def iterableFactory: LazyListFactory[CC]
 
   def tail: C
@@ -373,7 +374,6 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
   override final def zip[B](that: collection.Iterable[B]): CC[(A, B)] =
     if (this.isEmpty || that.isEmpty) iterableFactory.empty
     else cons[(A, B)]((this.head, that.head), this.tail.zip(that.tail))
-
 
   override final def zipWithIndex: CC[(A, Int)] = this.zip(LazyList.from(0))
 }

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -4,7 +4,7 @@ package immutable
 
 import strawman.collection.mutable.{ArrayBuffer, Builder}
 
-import scala.{Any, AnyRef, Boolean, Int, None, NoSuchElementException, noinline, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, deprecated}
+import scala.{Any, AnyRef, Boolean, Int, None, NoSuchElementException, noinline, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, deprecated, StringBuilder}
 import scala.Predef.String
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
@@ -228,15 +228,14 @@ sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, Lazy
 
   override def toString: String = {
     @tailrec
-    def _toString(ll: LazyList[A], acc: List[String]): List[String] = ll.memberEvaluationState match {
-      case None                 => acc
-      case Some((true, false))  => "?" :: s"${ll.head}" :: acc
-      case Some((true, true))   => _toString(ll.tail, s"${ll.head}" :: acc)
-      case Some((false, false)) => "?" :: acc
-      case Some((false, true))  => _toString(ll.tail, "?" :: acc)
+    def _toStringBuilder(ll: LazyList[A], sb: StringBuilder): StringBuilder = ll.memberEvaluationState match {
+      case None                 => sb
+      case Some((true, false))  => sb.append(s"${ll.head}").append("?")
+      case Some((true, true))   => _toStringBuilder(ll.tail, sb.append(s"${ll.head}"))
+      case Some((false, false)) => sb.append("?")
+      case Some((false, true))  => _toStringBuilder(ll.tail, sb.append("?"))
     }
-
-    s"$className${_toString(this, List()).reverse.mkString("(", ", ", ")")}"
+    s"$className${_toStringBuilder(this, new StringBuilder).mkString("(", ", ", ")")}"
   }
 
 }
@@ -595,15 +594,14 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
 
   override def toString: String = {
     @tailrec
-    def _toString(ll: Stream[A], acc: List[String]): List[String] = ll.memberEvaluationState match {
-      case None                 => acc
-      case Some((true, false))  => "?" :: s"${ll.head}" :: acc
-      case Some((true, true))   => _toString(ll.tail, s"${ll.head}" :: acc)
-      case Some((false, false)) => "?" :: acc
-      case Some((false, true))  => _toString(ll.tail, "?" :: acc)
+    def _toStringBuilder(ll: Stream[A], sb: StringBuilder): StringBuilder = ll.memberEvaluationState match {
+      case None                 => sb
+      case Some((true, false))  => sb.append(s"${ll.head}").append("?")
+      case Some((true, true))   => _toStringBuilder(ll.tail, sb.append(s"${ll.head}"))
+      case Some((false, false)) => sb.append("?")
+      case Some((false, true))  => _toStringBuilder(ll.tail, sb.append("?"))
     }
-
-    s"$className${_toString(this, List()).reverse.mkString("(", ", ", ")")}"
+    s"$className${_toStringBuilder(this, new StringBuilder).mkString("(", ", ", ")")}"
   }
 
 }

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -603,7 +603,7 @@ object Stream extends LazyListFactory[Stream] {
     override def head: Nothing = throw new NoSuchElementException("head of empty lazy list")
     override def tail: Stream[Nothing] = throw new UnsupportedOperationException("tail of empty lazy list")
     def force: Evaluated[Nothing] = None
-    private[immutable] def evaluatedElementsInString() = List.empty[String]
+    private[immutable] def evaluatedElementsInString = List.empty[String]
   }
 
   final class Cons[A](override val head: A, tl: => Stream[A]) extends Stream[A] {
@@ -614,7 +614,7 @@ object Stream extends LazyListFactory[Stream] {
       tl
     }
     def force: Evaluated[A] = Some((head, tail))
-    private[immutable] def evaluatedElementsInString(): List[String] = {
+    private[immutable] def evaluatedElementsInString: List[String] = {
       if (tlEvaluated) List(s"$head") ::: tail.evaluatedElementsInString
       else List(s"$head", "?")
     }

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -240,7 +240,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
 
   override def nonEmpty: Boolean = !isEmpty
 
-  private[immutable] def evaluatedElementsInString: List[String]
+  private[immutable] def evaluatedElementsRepr: List[String]
 
   /** The stream resulting from the concatenation of this stream with the argument stream.
     *
@@ -365,7 +365,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
   override final def zipWithIndex: CC[(A, Int)] = this.zip(LazyList.from(0))
 
   override def toString: String =
-    s"$className${evaluatedElementsInString.flatMap(List(_)).mkString("(", ", ", ")")}"
+    s"$className${evaluatedElementsRepr.flatMap(List(_)).mkString("(", ", ", ")")}"
 }
 
 sealed private[immutable] trait LazyListFactory[+CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]]] extends SeqFactory[CC] {
@@ -466,7 +466,7 @@ object LazyList extends LazyListFactory[LazyList] {
     override def tail: LazyList[Nothing] = throw new UnsupportedOperationException("tail of empty lazy list")
     def force: Evaluated[Nothing] = None
     override def toString: String = "Empty"
-    def evaluatedElementsInString: List[String] = List.empty[String]
+    def evaluatedElementsRepr: List[String] = List.empty[String]
   }
 
   final class Cons[A](hd: => A, tl: => LazyList[A]) extends LazyList[A] {
@@ -483,11 +483,11 @@ object LazyList extends LazyListFactory[LazyList] {
     }
     def force: Evaluated[A] = Some((head, tail))
 
-    def evaluatedElementsInString: List[String] = (hdEvaluated, tlEvaluated) match {
+    def evaluatedElementsRepr: List[String] = (hdEvaluated, tlEvaluated) match {
       case (true, false) => List(s"$head", "?")
-      case (true, true) => List(s"$head") ::: tail.evaluatedElementsInString
+      case (true, true) => List(s"$head") ::: tail.evaluatedElementsRepr
       case (false, false) => List("?")
-      case (false, true) => List("?") ::: tail.evaluatedElementsInString
+      case (false, true) => List("?") ::: tail.evaluatedElementsRepr
     }
   }
 
@@ -603,7 +603,7 @@ object Stream extends LazyListFactory[Stream] {
     override def head: Nothing = throw new NoSuchElementException("head of empty lazy list")
     override def tail: Stream[Nothing] = throw new UnsupportedOperationException("tail of empty lazy list")
     def force: Evaluated[Nothing] = None
-    private[immutable] def evaluatedElementsInString = List.empty[String]
+    private[immutable] def evaluatedElementsRepr = List.empty[String]
   }
 
   final class Cons[A](override val head: A, tl: => Stream[A]) extends Stream[A] {
@@ -614,8 +614,8 @@ object Stream extends LazyListFactory[Stream] {
       tl
     }
     def force: Evaluated[A] = Some((head, tail))
-    private[immutable] def evaluatedElementsInString: List[String] = {
-      if (tlEvaluated) List(s"$head") ::: tail.evaluatedElementsInString
+    private[immutable] def evaluatedElementsRepr: List[String] = {
+      if (tlEvaluated) List(s"$head") ::: tail.evaluatedElementsRepr
       else List(s"$head", "?")
     }
   }

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -243,7 +243,7 @@ sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, Lazy
     * @return The original [[collection.mutable.StringBuilder]] containing the
     * resulting string.
     */
-  def toStringBuilder(b: StringBuilder): StringBuilder = {
+  protected def toStringBuilder(b: StringBuilder): StringBuilder = {
     if (!isEmpty) {
       if (headDefined && !tailDefined) b append head // For LazyList, head is also Lazy. Hence adds `?` if it not defined yet
       if (!headDefined && tailDefined) b append "?" // For LazyList, head is also Lazy. Hence adds `?` if it not defined yet
@@ -469,7 +469,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
 
   override final def zipWithIndex: CC[(A, Int)] = this.zip(LazyList.from(0))
 
-  def toStringBuilder(b: StringBuilder): StringBuilder
+  protected def toStringBuilder(b: StringBuilder): StringBuilder
 
   override def toString: String = {
     s"$className${toStringBuilder(new StringBuilder).mkString("(", ", ", ")")}"
@@ -709,7 +709,7 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
     * @return The original [[collection.mutable.StringBuilder]] containing the
     * resulting string.
     */
-  def toStringBuilder(b: StringBuilder): StringBuilder = {
+  protected def toStringBuilder(b: StringBuilder): StringBuilder = {
     if (!isEmpty) {
       b append head
       var cursor = this

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -257,7 +257,7 @@ sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, Lazy
       var cursor = this
       var n = 1
       if (cursor.tailDefined) {  // If tailDefined, also !isEmpty
-        var scout = tail
+        var scout = cursor.tail
         if (scout.isEmpty) {
           // Single element.  Bail out early.
           return b

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -135,14 +135,14 @@ class LazyListTest {
   @Test
   def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
-    assertEquals("LazyList(?)", l.toString())
+    assertEquals("LazyList(?)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenOnlyHeadIsEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
-    assertEquals("LazyList(1, ?)", l.toString())
+    assertEquals("LazyList(1, ?)", l.toString)
   }
 
   @Test
@@ -150,7 +150,7 @@ class LazyListTest {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     l.tail
-    assertEquals("LazyList(1, ?)", l.toString())
+    assertEquals("LazyList(1, ?)", l.toString)
   }
 
   @Test
@@ -158,28 +158,28 @@ class LazyListTest {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     l.tail.head
-    assertEquals("LazyList(1, 2, ?)", l.toString())
+    assertEquals("LazyList(1, 2, ?)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail
-    assertEquals("LazyList(?, ?)", l.toString())
+    assertEquals("LazyList(?, ?)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail.head
-    assertEquals("LazyList(?, 2, ?)", l.toString())
+    assertEquals("LazyList(?, 2, ?)", l.toString)
   }
 
   @Test
   def testLazyListToStringWhenLazyListIsForcedToList: Unit = {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: LazyList.Empty
     l.toList
-    assertEquals("LazyList(1, 2, 3, 4)", l.toString())
+    assertEquals("LazyList(1, 2, 3, 4)", l.toString)
   }
 
   def hasCorrectDrop(): Unit = {

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -132,6 +132,56 @@ class LazyListTest {
     assertEquals(0, i)
   }
 
+  @Test
+  def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    assertEquals("LazyList(?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhenOnlyHeadIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.head
+    assertEquals("LazyList(1, ?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhenHeadAndTailIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.head
+    l.tail
+    assertEquals("LazyList(1, ?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhenHeadAndTailHeadIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.head
+    l.tail.head
+    assertEquals("LazyList(1, 2, ?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.tail
+    assertEquals("LazyList(?, ?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.tail.head
+    assertEquals("LazyList(?, 2, ?)", l.toString())
+  }
+
+  @Test
+  def testLazyListToStringWhenLazyListIsForcedToList: Unit = {
+    val l = 1 #:: 2 #:: 3 #:: 4 #:: LazyList.Empty
+    l.toList
+    assertEquals("LazyList(1, 2, 3, 4)", l.toString())
+  }
+
   def hasCorrectDrop(): Unit = {
     assertEquals(LazyList(), LazyList().drop(2))
     assertEquals(LazyList(), LazyList(1).drop(2))

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -196,7 +196,7 @@ class LazyListTest {
     cyc.tail.tail.head
     cyc.tail.tail.tail.head
     cyc.tail.tail.tail.tail.head
-    assertEquals("LazyList(1, 2, 3, 4, -)", cyc.toString)
+    assertEquals("LazyList(1, 2, 3, 4, ...)", cyc.toString)
   }
 
   def hasCorrectDrop(): Unit = {

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -182,6 +182,12 @@ class LazyListTest {
     assertEquals("LazyList(1, 2, 3, 4)", l.toString)
   }
 
+  @Test
+  def testLazyListToStringWhenStreamIsEmpty: Unit = {
+    val l = LazyList.empty
+    assertEquals("LazyList()", l.toString)
+  }
+
   def hasCorrectDrop(): Unit = {
     assertEquals(LazyList(), LazyList().drop(2))
     assertEquals(LazyList(), LazyList(1).drop(2))

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -180,6 +180,11 @@ class LazyListTest {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: LazyList.Empty
     l.toList
     assertEquals("LazyList(1, 2, 3, 4)", l.toString)
+    val l1 = 10 #:: 20 #:: 30 #:: LazyList.Empty
+    l1.force
+    // after `force` this LazyList's, `head` would be present in the string but its tail's `head` won't be there,
+    // as both `head` and `tail` of that cons are lazy in nature.
+    assertEquals("LazyList(10, ?)", l1.toString)
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -188,6 +188,17 @@ class LazyListTest {
     assertEquals("LazyList()", l.toString)
   }
 
+  @Test
+  def testLaztListToStringWhenLazyListHasCyclicReference: Unit = {
+    lazy val cyc: LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
+    cyc.head
+    cyc.tail.head
+    cyc.tail.tail.head
+    cyc.tail.tail.tail.head
+    cyc.tail.tail.tail.tail.head
+    assertEquals("LazyList(1, 2, 3, 4, -)", cyc.toString)
+  }
+
   def hasCorrectDrop(): Unit = {
     assertEquals(LazyList(), LazyList().drop(2))
     assertEquals(LazyList(), LazyList(1).drop(2))

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -181,11 +181,6 @@ class LazyListTest {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: LazyList.Empty
     l.toList
     assertEquals("LazyList(1, 2, 3, 4)", l.toString)
-    val l1 = 10 #:: 20 #:: 30 #:: LazyList.Empty
-    l1.force
-    // after `force` this LazyList's, `head` would be present in the string but its tail's `head` won't be there,
-    // as both `head` and `tail` of that cons are lazy in nature.
-    assertEquals("LazyList(10, ?)", l1.toString)
   }
 
   @Test
@@ -230,7 +225,7 @@ class LazyListTest {
     assertEquals(3, i)
     // it's possible to implement `force` with incorrect string representation
     // (to forget about `tlEvaluated` update)
-    assertEquals( "1 #:: 2 #:: 3 #:: Empty", xs.toString())
+    assertEquals( "LazyList(1, 2, 3)", xs.toString())
   }
 
   val cycle1: LazyList[Int] = 1 #:: 2 #:: cycle1

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -134,9 +134,14 @@ class LazyListTest {
   }
 
   @Test
+  def testEmptyLazyListToString(): Unit = {
+    assertEquals("LazyList()", LazyList.Empty.toString)
+  }
+
+  @Test
   def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
-    assertEquals("LazyList(?, ?)", l.toString)
+    assertEquals("LazyList(_, ?)", l.toString)
   }
 
   @Test
@@ -151,7 +156,7 @@ class LazyListTest {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     l.tail
-    assertEquals("LazyList(1, ?)", l.toString)
+    assertEquals("LazyList(1, _, ?)", l.toString)
   }
 
   @Test
@@ -166,14 +171,28 @@ class LazyListTest {
   def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail
-    assertEquals("LazyList(?, ?)", l.toString)
+    assertEquals("LazyList(_, _, ?)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+  def testLazyListToStringWhendHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail.head
-    assertEquals("LazyList(?, 2, ?)", l.toString)
+    assertEquals("LazyList(_, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testLazyListToStringWhendHeadIsNotEvaluatedAndTailTailIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.tail.tail
+    assertEquals("LazyList(_, _, _, ?)", l.toString)
+  }
+
+  @Test
+  def testLazyListToStringWhendHeadIsNotEvaluatedAndTailTailHeadIsEvaluated = {
+    val l = LazyList(1, 2, 3, 4, 5)
+    l.tail.tail.head
+    assertEquals("LazyList(_, _, 3, ?)", l.toString)
   }
 
   @Test
@@ -197,12 +216,19 @@ class LazyListTest {
   }
 
   @Test
-  def testLaztListToStringWhenLazyListHasCyclicReference: Unit = {
+  def testLazyListToStringWhenLazyListHasCyclicReference: Unit = {
     lazy val cyc: LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
+    assertEquals("LazyList(_, ?)", cyc.toString)
     cyc.head
+    assertEquals("LazyList(1, ?)", cyc.toString)
+    cyc.tail
+    assertEquals("LazyList(1, _, ?)", cyc.toString)
     cyc.tail.head
+    assertEquals("LazyList(1, 2, ?)", cyc.toString)
     cyc.tail.tail.head
+    assertEquals("LazyList(1, 2, 3, ?)", cyc.toString)
     cyc.tail.tail.tail.head
+    assertEquals("LazyList(1, 2, 3, 4, ?)", cyc.toString)
     cyc.tail.tail.tail.tail.head
     assertEquals("LazyList(1, 2, 3, 4, ...)", cyc.toString)
   }

--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -135,7 +135,7 @@ class LazyListTest {
   @Test
   def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
     val l = LazyList(1, 2, 3, 4, 5)
-    assertEquals("LazyList(?)", l.toString)
+    assertEquals("LazyList(?, ?)", l.toString)
   }
 
   @Test
@@ -191,6 +191,13 @@ class LazyListTest {
   def testLazyListToStringWhenStreamIsEmpty: Unit = {
     val l = LazyList.empty
     assertEquals("LazyList()", l.toString)
+  }
+
+  @Test
+  def testLazyListToStringForSingleElementList: Unit = {
+    val l = LazyList(1)
+    l.force
+    assertEquals("LazyList(1)", l.toString)
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -181,4 +181,10 @@ class StreamTest {
     l.toList
     assertEquals("Stream(1, 2, 3, 4)", l.toString)
   }
+
+  @Test
+  def testStreamToStringWhenStreamIsEmpty: Unit = {
+    val l = Stream.empty
+    assertEquals("Stream()", l.toString)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -180,6 +180,11 @@ class StreamTest {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: Stream.empty
     l.toList
     assertEquals("Stream(1, 2, 3, 4)", l.toString)
+    val s1 = 10 #:: 20 #:: 30 #:: Stream.Empty
+    s1.force
+    // after `force` this Stream's, `head` would be present in the string along with its tail's `head`,
+    // as both `head` and `tail` of that cons are not lazy in nature.
+    assertEquals("Stream(10, 20, ?)", s1.toString)
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -187,4 +187,11 @@ class StreamTest {
     val l = Stream.empty
     assertEquals("Stream()", l.toString)
   }
+
+  @Test
+  def testStreamToStringWhenStreamHasCyclicReference: Unit = {
+    lazy val cyc: Stream[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
+    cyc.tail.tail.tail.tail
+    assertEquals("Stream(1, 2, 3, 4, -)", cyc.toString)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -134,7 +134,7 @@ class StreamTest {
     assertEquals(3, i)
     // it's possible to implement `force` with incorrect string representation
     // (to forget about `tlEvaluated` update)
-    assertEquals( "1 #:: 2 #:: 3 #:: Empty", xs.toString())
+    assertEquals( "Stream(1, 2, 3)", xs.toString())
   }
 
   val cycle1: Stream[Int] = 1 #:: 2 #:: cycle1
@@ -199,11 +199,6 @@ class StreamTest {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: Stream.empty
     l.toList
     assertEquals("Stream(1, 2, 3, 4)", l.toString)
-    val s1 = 10 #:: 20 #:: 30 #:: Stream.Empty
-    s1.force
-    // after `force` this Stream's, `head` would be present in the string along with its tail's `head`,
-    // as both `head` and `tail` of that cons are not lazy in nature.
-    assertEquals("Stream(10, 20, ?)", s1.toString)
   }
 
   @Test

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -131,4 +131,54 @@ class StreamTest {
     val s = f #:: f #:: f #:: Stream.empty
     assertEquals(1, i)
   }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailBothAreNotEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    assertEquals("Stream(1, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenOnlyHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    assertEquals("Stream(1, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    l.tail
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    l.tail.head
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.tail
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.tail.head
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenStreamIsForcedToList: Unit = {
+    val l = 1 #:: 2 #:: 3 #:: 4 #:: Stream.empty
+    l.toList
+    assertEquals("Stream(1, 2, 3, 4)", l.toString)
+  }
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -192,6 +192,6 @@ class StreamTest {
   def testStreamToStringWhenStreamHasCyclicReference: Unit = {
     lazy val cyc: Stream[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
     cyc.tail.tail.tail.tail
-    assertEquals("Stream(1, 2, 3, 4, -)", cyc.toString)
+    assertEquals("Stream(1, 2, 3, 4, ...)", cyc.toString)
   }
 }


### PR DESCRIPTION
This PR changes `LazyList` `toString` implementation, to make it more aligned with Scala's current `Stream` collection. This is an original issue #376 . Along with that it tries to fix #420 by providing tail recursive / stack free toString implementation