### PR TITLE
LazyList.force returns LazyList. 

### DIFF
--- a/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/LazyListTest.scala
@@ -1,5 +1,6 @@
 package strawman.collection.immutable
 
+import strawman.collection.Iterator
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.{Test, Ignore}
@@ -139,4 +140,28 @@ class LazyListTest {
     assertEquals(LazyList(3), LazyList(1, 2, 3).drop(2))
     assertEquals(LazyList(3, 4), LazyList(1, 2, 3, 4).drop(2))
   }
+
+  @Test
+  def testForceReturnsEvaluatedLazyList() : Unit = {
+    var i = 0
+    def f: Int = { i += 1; i }
+    val xs = LazyList.from(Iterator.fill(3)(f))
+    assertEquals(0, i)
+    xs.force
+    assertEquals(3, i)
+    // it's possible to implement `force` with incorrect string representation
+    // (to forget about `tlEvaluated` update)
+    assertEquals( "1 #:: 2 #:: 3 #:: Empty", xs.toString())
+  }
+
+  @Test
+  def testSameElements(): Unit = {
+    assert(LazyList().sameElements(LazyList()))
+    assert(!LazyList().sameElements(LazyList(1)))
+    assert(LazyList(1,2).sameElements(LazyList(1,2)))
+    assert(!LazyList(1,2).sameElements(LazyList(1)))
+    assert(!LazyList(1).sameElements(LazyList(1,2)))
+    assert(!LazyList(1).sameElements(LazyList(2)))
+  }
+
 }

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -125,10 +125,25 @@ class StreamTest {
   }
 
   @Test
-  def testStreamForcesHead: Unit = {
+  def testForceReturnsEvaluatedStream() : Unit = {
     var i = 0
     def f: Int = { i += 1; i }
-    val s = f #:: f #:: f #:: Stream.empty
+    val xs = f #:: f #:: f #:: Stream.empty
     assertEquals(1, i)
+    xs.force
+    assertEquals(3, i)
+    // it's possible to implement `force` with incorrect string representation
+    // (to forget about `tlEvaluated` update)
+    assertEquals( "1 #:: 2 #:: 3 #:: Empty", xs.toString())
+  }
+
+  @Test
+  def testSameElements(): Unit = {
+    assert(Stream().sameElements(Stream()))
+    assert(!Stream().sameElements(Stream(1)))
+    assert(Stream(1,2).sameElements(Stream(1,2)))
+    assert(!Stream(1,2).sameElements(Stream(1)))
+    assert(!Stream(1).sameElements(Stream(1,2)))
+    assert(!Stream(1).sameElements(Stream(2)))
   }
 }


### PR DESCRIPTION
Fixes #422.

* Add `force` tests for LazyList and Stream.
* Add `sameElements` tests for LazyList and Stream.
* Change `force` result type from `Option[(head, tail)]` to `CC[A]`.
* Force `force` to evaluate whole LazyList and Stream.
* Update methods depended on `force`: `unapply` and `sameElements`.
* Reimplement `sameElements`.
** Remove Tuple allocation.
** Check reference equality on every step.