### PR TITLE
Remove mapFromIterable and sortedMapFromIterable

### DIFF
--- a/collections/src/main/scala/strawman/collection/DefaultMap.scala
+++ b/collections/src/main/scala/strawman/collection/DefaultMap.scala
@@ -33,5 +33,4 @@ trait DefaultMap[K, +V] extends Map[K, V] { self =>
   // Members declared in MapOps
   def mapFactory: MapFactory[Map] = Map
   def empty: Map[K,V] = mapFactory.empty
-  protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
 }

--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -52,9 +52,6 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     with PartialFunction[K, V]
     with Equals {
 
-  /** Similar to fromIterable, but returns a Map collection type */
-  protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): CC[K2, V2]
-
   def mapFactory: MapFactory[CC]
 
   /** Optionally returns the value associated with a key.
@@ -223,7 +220,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     *  @return       a new $coll resulting from applying the given function
     *                `f` to each element of this $coll and collecting the results.
     */
-  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFromIterable(View.Map(toIterable, f))
+  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFactory.from(View.Map(toIterable, f))
 
   /** Builds a new collection by applying a partial function to all elements of this $coll
     *  on which the function is defined.
@@ -248,7 +245,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     *  @return       a new $coll resulting from applying the given collection-valued function
     *                `f` to each element of this $coll and concatenating the results.
     */
-  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFromIterable(View.FlatMap(toIterable, f))
+  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFactory.from(View.FlatMap(toIterable, f))
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
@@ -258,7 +255,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     *  @return       a new $coll which contains all elements
     *                of this $coll followed by all elements of `suffix`.
     */
-  def concat[V2 >: V](suffix: collection.Iterable[(K, V2)]): CC[K, V2] = mapFromIterable(View.Concat(toIterable, suffix))
+  def concat[V2 >: V](suffix: collection.Iterable[(K, V2)]): CC[K, V2] = mapFactory.from(View.Concat(toIterable, suffix))
 
   /** Alias for `concat` */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
@@ -269,7 +266,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     iterator().map { case (k, v) => s"$k -> $v" }.mkString(start, sep, end)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat ", "2.13.0")
-  def + [V1 >: V](kv: (K, V1)): CC[K, V1] = mapFromIterable(View.Append(toIterable, kv))
+  def + [V1 >: V](kv: (K, V1)): CC[K, V1] = mapFactory.from(View.Append(toIterable, kv))
 }
 
 /**

--- a/collections/src/main/scala/strawman/collection/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/SortedMap.scala
@@ -20,8 +20,6 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   def sortedMapFactory: SortedMapFactory[CC]
 
-  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2]
-
   def unsorted: Map[K, V]
 
   /**
@@ -136,7 +134,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                `f` to each element of this $coll and collecting the results.
     */
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.Map[(K, V), (K2, V2)](toIterable, f))
+    sortedMapFactory.from(View.Map[(K, V), (K2, V2)](toIterable, f))
 
   /** Builds a new sorted map by applying a function to all elements of this $coll
     *  and using the elements of the resulting collections.
@@ -146,7 +144,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                `f` to each element of this $coll and concatenating the results.
     */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFromIterable(View.FlatMap(toIterable, f))
+    sortedMapFactory.from(View.FlatMap(toIterable, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
     *  on which the function is defined.
@@ -172,13 +170,13 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *  @return     a new collection of type `CC[K2, V2]` which contains all elements
     *              of this $coll followed by all elements of `xs`.
     */
-  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFromIterable(View.Concat(toIterable, xs))
+  def concat[K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFactory.from(View.Concat(toIterable, xs))
 
   /** Alias for `concat` */
   @`inline` final def ++ [K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
-  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFromIterable(View.Concat(toIterable, xs))
+  override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFactory.from(View.Concat(toIterable, xs))
   override def ++ [V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = concat(xs)
   // TODO Also override mapValues
 

--- a/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
+++ b/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
@@ -666,7 +666,6 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
 
   def mapFactory: MapFactory[TrieMap] = TrieMap
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TrieMap[K,V] = TrieMap.from(coll)
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): TrieMap[K2,V2] = TrieMap.from(it)
   protected[this] def newSpecificBuilder(): Builder[(K, V), TrieMap[K,V]] = TrieMap.newBuilder[K, V]()
 
   /* internal methods */

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -342,7 +342,6 @@ private[collection] trait Wrappers {
     protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]) = mutable.HashMap.from(coll)
     protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
     def mapFactory = mutable.HashMap
-    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
   }
 
   /** Wraps a Java map as a Scala one.  If the map is to support concurrent access,
@@ -450,7 +449,6 @@ private[collection] trait Wrappers {
     protected[this] def fromSpecificIterable(coll: Iterable[(A, B)]) = mutable.HashMap.from(coll)
     protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
     def mapFactory = mutable.HashMap
-    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
     def empty = mutable.HashMap.empty
   }
 
@@ -504,7 +502,6 @@ private[collection] trait Wrappers {
     protected[this] def fromSpecificIterable(coll: Iterable[(String, String)]) = mutable.HashMap.from(coll)
     protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
     def mapFactory = mutable.HashMap
-    protected[this] def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]) = mutable.HashMap.from(it)
   }
 }
 

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
@@ -37,8 +37,6 @@ final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V],
 
   def mapFactory: MapFactory[ChampHashMap] = ChampHashMap
 
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ChampHashMap[K2, V2] = ChampHashMap.from(it)
-
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ChampHashMap[K, V] = ChampHashMap.from(coll)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), ChampHashMap[K, V]] = ChampHashMap.newBuilder()

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -41,9 +41,6 @@ sealed abstract class HashMap[K, +V]
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
 
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] =
-    HashMap.from(it)
-
   protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
 
   def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -183,7 +183,6 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
       def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
     }
   def mapFactory: MapFactory[Map] = Map
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
 
   override def empty: IntMap[T] = IntMap.Nil
 

--- a/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -52,8 +52,6 @@ sealed class ListMap[K, +V]
   def iterableFactory = List
   def mapFactory = ListMap
 
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): ListMap[K2,V2] = ListMap.from(it)
-
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ListMap[K, V] = ListMap.from(coll)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), ListMap[K, V]] = ListMap.newBuilder()

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -174,7 +174,6 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
       def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
     }
   def mapFactory: MapFactory[Map] = Map
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
 
   override def empty: LongMap[T] = LongMap.Nil
 

--- a/collections/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Map.scala
@@ -154,9 +154,6 @@ object Map extends MapFactory[Map] {
 
     def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
-      mapFactory.from(it)
-
     protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
@@ -180,7 +177,6 @@ object Map extends MapFactory[Map] {
     def mapFactory: MapFactory[Map] = Map
     def empty: Map[K, V] = mapFactory.empty
     protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): Map[K, V] = mapFactory.from(coll)
-    protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = mapFactory.from(it)
     protected[this] def newSpecificBuilder(): Builder[(K, V), Map[K, V]] = mapFactory.newBuilder()
   }
 

--- a/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -57,9 +57,6 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
       def excl(elem: K): SortedSet[K] = fromSpecificIterable(this).excl(elem)
     }
 
-    protected def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
-      Map.from(it)
-
     // We override these methods to fix their return type (which would be `Map` otherwise)
     def updated[V1 >: V](key: K, value: V1): CC[K, V1]
     @`inline` final override def +[V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
@@ -87,9 +84,6 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     def iteratorFrom(start: K): strawman.collection.Iterator[(K, V)] = underlying.iteratorFrom(start)
 
-    protected[this] def sortedMapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): SortedMap[K2, V2] =
-      sortedMapFactory.from(it)
-
     def keysIteratorFrom(start: K): strawman.collection.Iterator[K] = underlying.keysIteratorFrom(start)
 
     def rangeImpl(from: Option[K], until: Option[K]): WithDefault[K, V] =
@@ -97,9 +91,6 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     // Need to override following methods to match type signatures of `SortedMap.WithDefault`
     // for operations preserving default value
-
-    override protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] =
-      mapFactory.from(it)
 
     override def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)

--- a/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -43,9 +43,6 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
     TreeMap.from(coll)
 
-  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] =
-    TreeMap.from(it)
-
   protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -77,7 +77,6 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   def mapFactory: strawman.collection.MapFactory[Map] = Map
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
     var sz = coll.knownSize
     if(sz < 0) sz = 4

--- a/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -42,7 +42,6 @@ class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, Default
     }
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): HashMap[K2, V2] = HashMap.from(it)
 
   protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] =  HashMap.newBuilder()
 

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -85,8 +85,7 @@ class LinkedHashMap[K, V]
 
   def mapFactory = LinkedHashMap
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]) = mapFromIterable(coll)
-  protected[this] def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]) = mapFactory.from(it)
+  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]) = mapFactory.from(coll)
 
   protected[this] def newSpecificBuilder() = mapFactory.newBuilder()
 

--- a/collections/src/main/scala/strawman/collection/mutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListMap.scala
@@ -37,7 +37,6 @@ class ListMap[K, V]
 
   protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): ListMap[K,V] = mapFactory.from(coll)
   protected[this] def newSpecificBuilder(): Builder[(K, V), ListMap[K,V]] = mapFactory.newBuilder()
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): ListMap[K2,V2] = mapFactory.from(it)
 
   private var elems: List[(K, V)] = List()
   private var siz: Int = 0

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -44,7 +44,6 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   }
   protected[this] def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
   def mapFactory: strawman.collection.MapFactory[Map] = Map
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2,V2] = mapFactory.from(it)
 
   /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
   def this(defaultEntry: Long => V) = this(defaultEntry, 16, true)

--- a/collections/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Map.scala
@@ -200,9 +200,6 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
       Map.newBuilder().mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
-
-    protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): Map[K2, V2] =
-      mapFactory.from(it)
   }
 
 }

--- a/collections/src/main/scala/strawman/collection/mutable/OpenHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/OpenHashMap.scala
@@ -74,7 +74,6 @@ class OpenHashMap[Key, Value](initialSize : Int)
   protected[this] def newSpecificBuilder(): Builder[(Key, Value), OpenHashMap[Key, Value]] = mapFactory.newBuilder()
 
   def mapFactory: MapFactory[OpenHashMap] = OpenHashMap
-  protected[this] def mapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)]): OpenHashMap[K2,V2] = mapFactory.from(it)
 
   override def empty: OpenHashMap[Key, Value] = OpenHashMap.empty[Key, Value]
 

--- a/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -37,11 +37,7 @@ trait SortedMap[K, V]
 
 trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends collection.SortedMapOps[K, V, CC, C]
-    with MapOps[K, V, Map, C] {
-
-  def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = Map.from(it)
-
-}
+    with MapOps[K, V, Map, C]
 
 object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
@@ -60,16 +56,11 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     implicit def ordering: Ordering[K] = underlying.ordering
 
-    protected[this] def sortedMapFromIterable[K2, V2](it: strawman.collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): SortedMap[K2, V2] =
-      sortedMapFactory.from(it)
-
     def rangeImpl(from: Option[K], until: Option[K]): WithDefault[K, V] =
       new WithDefault[K, V](underlying.rangeImpl(from, until), defaultValue)
 
     // Need to override following methods to match type signatures of `SortedMap.WithDefault`
     // for operations preserving default value
-    override def mapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)]): Map[K2, V2] = mapFactory.from(it)
-
     override def subtractOne(elem: K): WithDefault.this.type = { underlying.subtractOne(elem); this }
 
     override def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }

--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -40,8 +40,6 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.from(coll)
 
-  protected[this] def sortedMapFromIterable[K2, V2](it: collection.Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): TreeMap[K2, V2] = TreeMap.from(it)
-
   protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
 
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)


### PR DESCRIPTION
The scaladoc comment claims that `mapFromIterable` is “similar to
fromIterable” but that method doesn’t exist (anymore). Unlike
`fromSpecificIterable`, `mapFromIterable` is not specific to the
source element type and therefore can never do more than
`mapFactory.from`. The same goes for `sortedMapFromIterable`.