### PR TITLE
Remove the boilerplate associated with the new design (and more)

### DIFF
--- a/collections-contrib/src/main/scala/strawman/collection/MultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/MultiDict.scala
@@ -11,6 +11,11 @@ trait MultiDict[K, V]
     with MultiDictOps[K, V, MultiDict, MultiDict[K, V]]
     with Equals {
 
+  def multiMapFactory: MapFactory[MultiDictCC] = MultiDict
+
+  override protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]): MultiDictCC[K, V] = multiMapFactory.from(coll)
+  override protected[this] def newSpecificBuilder(): mutable.Builder[(K, V), MultiDictCC[K, V]] = multiMapFactory.newBuilder[K, V]()
+
   def canEqual(that: Any): Boolean = true
 
   override def equals(o: Any): Boolean = o match {
@@ -35,7 +40,9 @@ trait MultiDict[K, V]
 trait MultiDictOps[K, V, +CC[X, Y] <: MultiDict[X, Y], +C <: MultiDict[K, V]]
   extends IterableOps[(K, V), Iterable, C] {
 
-  def multiMapFactory: MapFactory[CC]
+  protected[this] type MultiDictCC[K, V] = CC[K, V]
+
+  def multiMapFactory: MapFactory[MultiDictCC]
 
   protected[this] def multiMapFromIterable[L, W](it: Iterable[(L, W)]): CC[L, W] =
     multiMapFactory.from(it)

--- a/collections-contrib/src/main/scala/strawman/collection/SortedMultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/SortedMultiDict.scala
@@ -12,14 +12,17 @@ trait SortedMultiDict[K, V]
 
   def unsorted: MultiDict[K, V] = this
 
+  override protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]): SortedMultiDictCC[K, V] = sortedMultiMapFactory.from(coll)
+  override protected[this] def newSpecificBuilder(): mutable.Builder[(K, V), SortedMultiDictCC[K, V]] = sortedMultiMapFactory.newBuilder[K, V]()
 }
 
 trait SortedMultiDictOps[K, V, +CC[X, Y] <: MultiDict[X, Y], +C <: MultiDict[K, V]]
   extends MultiDictOps[K, V, MultiDict, C]
     with SortedOps[K, C] {
 
-  def multiMapFactory: MapFactory[MultiDict] = MultiDict
-  def sortedMultiMapFactory: SortedMapFactory[CC]
+  protected[this] type SortedMultiDictCC[K, V] = CC[K, V]
+
+  def sortedMultiMapFactory: SortedMapFactory[SortedMultiDictCC]
 
   protected[this] def sortedFromIterable[L : Ordering, W](it: Iterable[(L, W)]): CC[L, W]
   protected[this] def sortedFromSets[L : Ordering, W](it: Iterable[(L, Set[W])]): CC[L, W] =

--- a/collections-contrib/src/main/scala/strawman/collection/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/SortedMultiSet.scala
@@ -12,15 +12,23 @@ trait SortedMultiSet[A]
 
   def unsorted: MultiSet[A] = this
 
+  override protected[this] def fromSpecificIterable(coll: Iterable[A]): SortedIterableCC[A] = sortedIterableFactory.from(coll)
+  override protected[this] def newSpecificBuilder(): mutable.Builder[A, SortedIterableCC[A]] = sortedIterableFactory.newBuilder[A]()
+
+  protected[this] def sortedFromIterable[B : Ordering](it: strawman.collection.Iterable[B]): SortedIterableCC[B] = sortedIterableFactory.from(it)
+
+  def sortedIterableFactory: SortedIterableFactory[SortedIterableCC] = SortedMultiSet
 }
 
 trait SortedMultiSetOps[A, +CC[X] <: MultiSet[X], +C <: MultiSet[A]]
   extends MultiSetOps[A, MultiSet, C]
     with SortedOps[A, C] {
 
-  def sortedIterableFactory: SortedIterableFactory[CC]
+  protected[this] type SortedIterableCC[X] = CC[X]
 
-  protected[this] def sortedFromIterable[B : Ordering](it: Iterable[B]): CC[B]
+  def sortedIterableFactory: SortedIterableFactory[SortedIterableCC]
+
+  protected[this] def sortedFromIterable[B : Ordering](it: Iterable[B]): SortedIterableCC[B]
   protected[this] def sortedFromOccurrences[B : Ordering](it: Iterable[(B, Int)]): CC[B] =
     sortedFromIterable(it.view.flatMap { case (b, n) => View.Fill(n)(b) })
 

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/MultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/MultiDict.scala
@@ -18,11 +18,7 @@ class MultiDict[K, V] private (elems: Map[K, Set[V]])
 
   def sets: Map[K, Set[V]] = elems
 
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-  def multiMapFactory: MapFactory[MultiDict] = MultiDict
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): MultiDict[K, V] = multiMapFromIterable(coll)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), MultiDict[K, V]] = multiMapFactory.newBuilder[K, V]()
+  override def multiMapFactory: MapFactory[MultiDict] = MultiDict
 
   /**
     * @return a new multidict that contains all the entries of this multidict

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/MultiSet.scala
@@ -17,9 +17,7 @@ class MultiSet[A] private (elems: Map[A, Int])
 
   def occurrences: Map[A, Int] = elems
 
-  def iterableFactory: IterableFactory[MultiSet] = MultiSet
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): MultiSet[A] = fromIterable(coll)
-  protected[this] def newSpecificBuilder(): Builder[A, MultiSet[A]] = iterableFactory.newBuilder()
+  override def iterableFactory: IterableFactory[MultiSet] = MultiSet
 
   /**
     * @return an immutable multiset containing all the elements of this multiset

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiDict.scala
@@ -17,11 +17,8 @@ class SortedMultiDict[K, V] private (elems: SortedMap[K, Set[V]])(implicit val o
     with collection.IterableOps[(K, V), Iterable, SortedMultiDict[K, V]] {
 
   def sortedMultiMapFactory: SortedMapFactory[SortedMultiDict] = SortedMultiDict
-  def iterableFactory: IterableFactory[Iterable] = Iterable
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): SortedMultiDict[K, V] = sortedMultiMapFactory.from(coll)
   protected[this] def sortedFromIterable[L: Ordering, W](it: collection.Iterable[(L, W)]): SortedMultiDict[L, W] = sortedMultiMapFactory.from(it)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), SortedMultiDict[K, V]] = sortedMultiMapFactory.newBuilder()
 
   def sets: SortedMap[K, Set[V]] = elems
 

--- a/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/immutable/SortedMultiSet.scala
@@ -17,12 +17,8 @@ class SortedMultiSet[A] private (elems: SortedMap[A, Int])(implicit val ordering
 
   def occurrences: SortedMap[A, Int] = elems
 
-  def iterableFactory: IterableFactory[MultiSet] = MultiSet
-  def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): SortedMultiSet[A] = sortedFromIterable(coll)
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedMultiSet[B] = sortedIterableFactory.from(it)
-  protected[this] def newSpecificBuilder(): Builder[A, SortedMultiSet[A]] = sortedIterableFactory.newBuilder()
+  override def iterableFactory: IterableFactory[MultiSet] = MultiSet
+  override def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
 
   def rangeImpl(from: Option[A], until: Option[A]): SortedMultiSet[A] =
     new SortedMultiSet(elems.rangeImpl(from, until))

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/MultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/MultiDict.scala
@@ -15,10 +15,7 @@ class MultiDict[K, V] private (elems: Map[K, Set[V]])
     with Growable[(K, V)]
     with Shrinkable[(K, V)] {
 
-  def iterableFactory: IterableFactory[collection.Iterable] = collection.Iterable
-  def multiMapFactory: MapFactory[MultiDict] = MultiDict
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): MultiDict[K, V] = multiMapFactory.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), MultiDict[K, V]] = multiMapFactory.newBuilder()
+  override def multiMapFactory: MapFactory[MultiDict] = MultiDict
 
   def sets: collection.Map[K, collection.Set[V]] = elems
 

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/MultiSet.scala
@@ -13,9 +13,7 @@ class MultiSet[A] private (val elems: Map[A, Int])
     with Growable[A]
     with Shrinkable [A] {
 
-  def iterableFactory: IterableFactory[MultiSet] = MultiSet
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): MultiSet[A] = fromIterable(coll)
-  protected[this] def newSpecificBuilder(): Builder[A, MultiSet[A]] = iterableFactory.newBuilder()
+  override def iterableFactory: IterableFactory[MultiSet] = MultiSet
 
   def occurrences: collection.Map[A, Int] = elems
 

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiDict.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiDict.scala
@@ -17,12 +17,9 @@ class SortedMultiDict[K, V] private (elems: SortedMap[K, Set[V]])(implicit val o
 
   def sets: collection.SortedMap[K, collection.Set[V]] = elems
 
-  def iterableFactory: IterableFactory[collection.Iterable] = collection.Iterable
   def sortedMultiMapFactory: SortedMapFactory[SortedMultiDict] = SortedMultiDict
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): SortedMultiDict[K, V] = sortedMultiMapFactory.from(coll)
   protected[this] def sortedFromIterable[L: Ordering, W](it: collection.Iterable[(L, W)]): SortedMultiDict[L, W] = sortedMultiMapFactory.from(it)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), SortedMultiDict[K, V]] = sortedMultiMapFactory.newBuilder()
 
   def rangeImpl(from: Option[K], until: Option[K]): SortedMultiDict[K, V] =
     new SortedMultiDict(elems.rangeImpl(from, until))

--- a/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiSet.scala
+++ b/collections-contrib/src/main/scala/strawman/collection/mutable/SortedMultiSet.scala
@@ -17,12 +17,7 @@ class SortedMultiSet[A] private (elems: SortedMap[A, Int])(implicit val ordering
 
   def occurrences: collection.SortedMap[A, Int] = elems
 
-  def iterableFactory: IterableFactory[MultiSet] = MultiSet
-  def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): SortedMultiSet[A] = sortedFromIterable(coll)
-  protected[this] def sortedFromIterable[B: Ordering](it: collection.Iterable[B]): SortedMultiSet[B] = sortedIterableFactory.from(it)
-  protected[this] def newSpecificBuilder(): Builder[A, SortedMultiSet[A]] = sortedIterableFactory.newBuilder()
+  override def sortedIterableFactory: SortedIterableFactory[SortedMultiSet] = SortedMultiSet
 
   def rangeImpl(from: Option[A], until: Option[A]): SortedMultiSet[A] =
     new SortedMultiSet(elems.rangeImpl(from, until))

--- a/collections/src/main/scala/strawman/collection/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/BitSet.scala
@@ -18,7 +18,11 @@ import scala.Predef.{assert, intWrapper}
   * @define coll bitset
   * @define Coll `BitSet`
   */
-trait BitSet extends SortedSet[Int] with BitSetOps[BitSet]
+trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] {
+  override protected[this] def fromSpecificIterable(coll: Iterable[Int]): BitSetC = bitSetFactory.fromSpecific(coll)
+  override protected[this] def newSpecificBuilder(): Builder[Int, BitSetC] = bitSetFactory.newBuilder()
+  override def empty: BitSetC = bitSetFactory.empty
+}
 
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
   def empty: BitSet = immutable.BitSet.empty
@@ -30,6 +34,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
+
+  def bitSetFactory: SpecificIterableFactory[Int, BitSetC]
+
+  protected[this] type BitSetC = C
 
   final def ordering: Ordering[Int] = Ordering.Int
 

--- a/collections/src/main/scala/strawman/collection/DefaultMap.scala
+++ b/collections/src/main/scala/strawman/collection/DefaultMap.scala
@@ -9,28 +9,12 @@
 package strawman
 package collection
 
+import scala.deprecated
+
 /** A default map which builds a default `immutable.Map` implementation for all
   * transformations.
   *
-  *  Instances that inherit from `DefaultMap[K, V]` still have to define:
-  *  {{{
-  *    def get(key: K): Option[V]
-  *    def iterator(): Iterator[(K, V)]
-  *  }}}
-  *
-  *  It might also be advisable to override `foreach` or `size` if efficient
-  *  implementations can be found.
-  *
   *  @since 2.8
   */
-trait DefaultMap[K, +V] extends Map[K, V] { self =>
-
-  // Members declared in IterableOps
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-  protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]): Map[K,V] = mapFactory.from(coll)
-  protected[this] def newSpecificBuilder(): mutable.Builder[(K, V), Map[K,V]] = mapFactory.newBuilder()
-
-  // Members declared in MapOps
-  def mapFactory: MapFactory[Map] = Map
-  def empty: Map[K,V] = mapFactory.empty
-}
+@deprecated("DefaultMap is no longer necessary; extend Map directly", "2.13.0")
+trait DefaultMap[K, +V] extends Map[K, V]

--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -26,6 +26,10 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   //TODO scalac generates an override for this in AbstractMap; Making it final leads to a VerifyError
   protected[this] def coll: this.type = this
 
+  protected[this] def fromSpecificIterable(coll: Iterable[A]): IterableCC[A] = iterableFactory.from(coll)
+  protected[this] def newSpecificBuilder(): Builder[A, IterableCC[A]] = iterableFactory.newBuilder[A]()
+
+  def iterableFactory: IterableFactory[IterableCC] = Iterable
 }
 
 /** Base trait for Iterable operations
@@ -64,6 +68,8 @@ trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterabl
   */
 trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
 
+  protected[this] type IterableCC[X] = CC[X]
+
   /**
     * @return This collection as an `Iterable[A]`. No new collection will be built if `this` is already an `Iterable[A]`.
     */
@@ -91,7 +97,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] {
   /**
     * @return The companion object of this ${coll}, providing various factory methods.
     */
-  def iterableFactory: IterableFactory[CC]
+  def iterableFactory: IterableFactory[IterableCC]
 
   /**
     * @return a strict builder for the same collection type.

--- a/collections/src/main/scala/strawman/collection/Map.scala
+++ b/collections/src/main/scala/strawman/collection/Map.scala
@@ -15,6 +15,13 @@ trait Map[K, +V]
     with MapOps[K, V, Map, Map[K, V]]
     with Equals {
 
+  override protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]): MapCC[K, V] = mapFactory.from(coll)
+  override protected[this] def newSpecificBuilder(): mutable.Builder[(K, V), MapCC[K, V]] = mapFactory.newBuilder[K, V]()
+
+  def mapFactory: strawman.collection.MapFactory[MapCC] = Map
+
+  def empty: MapCC[K, V] = mapFactory.empty
+
   def canEqual(that: Any): Boolean = true
 
   override def equals(o: Any): Boolean = o match {
@@ -52,7 +59,14 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     with PartialFunction[K, V]
     with Equals {
 
-  def mapFactory: MapFactory[CC]
+  protected[this] type MapCC[K, V] = CC[K, V]
+
+  /** Similar to `fromIterable`, but returns a Map collection type.
+    * Note that the return type is now `CC[K2, V2]` aka `MapCC[K2, V2]` rather than `IterableCC[(K2, V2)]`.
+    */
+  @`inline` protected[this] final def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]): CC[K2, V2] = mapFactory.from(it)
+
+  def mapFactory: MapFactory[MapCC]
 
   /** Optionally returns the value associated with a key.
     *
@@ -104,11 +118,7 @@ trait MapOps[K, +V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C]
     */
   @SerialVersionUID(3L)
   protected class KeySet extends Set[K] with GenKeySet {
-    def iterableFactory: IterableFactory[Set] = Set
-    protected[this] def fromSpecificIterable(coll: Iterable[K]): Set[K] = fromIterable(coll)
-    protected[this] def newSpecificBuilder(): Builder[K, Set[K]] = iterableFactory.newBuilder()
     def diff(that: Set[K]): Set[K] = fromSpecificIterable(view.filterNot(that))
-    def empty: Set[K] = iterableFactory.empty
   }
 
   /** A generic trait that is reused by keyset implementations */

--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -20,7 +20,7 @@ trait Seq[+A]
     with SeqOps[A, Seq, Seq[A]]
     with Equals {
 
-  def iterableFactory: SeqFactory[Seq]
+  override def iterableFactory: SeqFactory[IterableCC] = Seq
 
   /** Method called from equality methods, so that user-defined subclasses can
     *  refuse to be equal to other collections of the same kind.

--- a/collections/src/main/scala/strawman/collection/Set.scala
+++ b/collections/src/main/scala/strawman/collection/Set.scala
@@ -28,6 +28,7 @@ trait Set[A]
 
   override def hashCode(): Int = Set.setHash(toIterable)
 
+  def empty: IterableCC[A] = iterableFactory.empty
 }
 
 /** Base trait for set operations

--- a/collections/src/main/scala/strawman/collection/View.scala
+++ b/collections/src/main/scala/strawman/collection/View.scala
@@ -15,12 +15,7 @@ import scala.Predef.{<:<, intWrapper}
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] {
   override def view = this
 
-  def iterableFactory = View
-
-  protected[this] def fromSpecificIterable(coll: Iterable[A]): View[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, View[A]] =
-    immutable.IndexedSeq.newBuilder().mapResult(_.view)
+  override def iterableFactory = View
 
   override def toString = "View(?)"
 

--- a/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
+++ b/collections/src/main/scala/strawman/collection/concurrent/TrieMap.scala
@@ -664,9 +664,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
 
   def this() = this(Hashing.default, Equiv.universal)
 
-  def mapFactory: MapFactory[TrieMap] = TrieMap
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TrieMap[K,V] = TrieMap.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), TrieMap[K,V]] = TrieMap.newBuilder[K, V]()
+  override def mapFactory: MapFactory[TrieMap] = TrieMap
 
   /* internal methods */
 

--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -59,9 +59,7 @@ private[collection] trait Wrappers {
   @SerialVersionUID(3L)
   case class JIterableWrapper[A](underlying: jl.Iterable[A]) extends AbstractIterable[A] with Iterable[A] {
     def iterator() = underlying.iterator().asScala
-    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
-    def iterableFactory = mutable.ArrayBuffer
-    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+    override def iterableFactory = mutable.ArrayBuffer
   }
 
   @SerialVersionUID(3L)
@@ -69,9 +67,7 @@ private[collection] trait Wrappers {
     def iterator() = underlying.iterator().asScala
     override def size = underlying.size
     override def isEmpty = underlying.isEmpty
-    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
-    def iterableFactory = mutable.ArrayBuffer
-    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+    override def iterableFactory = mutable.ArrayBuffer
   }
 
   @SerialVersionUID(3L)
@@ -143,9 +139,7 @@ private[collection] trait Wrappers {
       }
       this
     }
-    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.ArrayBuffer.from(coll)
-    def iterableFactory = mutable.ArrayBuffer
-    protected[this] def newSpecificBuilder() = mutable.ArrayBuffer.newBuilder()
+    override def iterableFactory = mutable.ArrayBuffer
     def subtractOne(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
   }
 
@@ -216,9 +210,7 @@ private[collection] trait Wrappers {
     override def clone() =
       new JSetWrapper[A](new ju.LinkedHashSet[A](underlying))
 
-    protected[this] def fromSpecificIterable(coll: Iterable[A]) = mutable.HashSet.from(coll)
-    def iterableFactory = mutable.HashSet
-    protected[this] def newSpecificBuilder() = mutable.HashSet.newBuilder()
+    override def iterableFactory = mutable.HashSet
   }
 
   @SerialVersionUID(3L)
@@ -339,9 +331,7 @@ private[collection] trait Wrappers {
 
     override def empty: C = null.asInstanceOf[C]
 
-    protected[this] def fromSpecificIterable(coll: Iterable[(K, V)]) = mutable.HashMap.from(coll)
-    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
-    def mapFactory = mutable.HashMap
+    override def mapFactory = mutable.HashMap
   }
 
   /** Wraps a Java map as a Scala one.  If the map is to support concurrent access,
@@ -446,10 +436,7 @@ private[collection] trait Wrappers {
 
     def clear() = iterator().foreach(entry => underlying.remove(entry._1))
 
-    protected[this] def fromSpecificIterable(coll: Iterable[(A, B)]) = mutable.HashMap.from(coll)
-    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
-    def mapFactory = mutable.HashMap
-    def empty = mutable.HashMap.empty
+    override def mapFactory = mutable.HashMap
   }
 
   @SerialVersionUID(3L)
@@ -499,9 +486,7 @@ private[collection] trait Wrappers {
     def setProperty(key: String, value: String) =
       underlying.setProperty(key, value)
 
-    protected[this] def fromSpecificIterable(coll: Iterable[(String, String)]) = mutable.HashMap.from(coll)
-    protected[this] def newSpecificBuilder() = mutable.HashMap.newBuilder()
-    def mapFactory = mutable.HashMap
+    override def mapFactory = mutable.HashMap
   }
 }
 

--- a/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/BitSet.scala
@@ -25,14 +25,7 @@ sealed abstract class BitSet
     with StrictOptimizedIterableOps[Int, Set, BitSet]
     with Serializable {
 
-  def empty: BitSet = BitSet.empty
-
-  def iterableFactory = Set
-  def sortedIterableFactory = SortedSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet = BitSet.fromSpecific(coll)
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): SortedSet[B] = SortedSet.from(it)
-  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
+  def bitSetFactory = BitSet
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashMap.scala
@@ -33,13 +33,7 @@ final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V],
     with StrictOptimizedIterableOps[(K, V), Iterable /* ChampHashMap */, ChampHashMap[K, V]]
     with Serializable {
 
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-
-  def mapFactory: MapFactory[ChampHashMap] = ChampHashMap
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ChampHashMap[K, V] = ChampHashMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), ChampHashMap[K, V]] = ChampHashMap.newBuilder()
+  override def mapFactory: MapFactory[ChampHashMap] = ChampHashMap
 
   override def knownSize: Int = cachedSize
 
@@ -79,8 +73,6 @@ final class ChampHashMap[K, +V] private[immutable] (val rootNode: MapNode[K, V],
       ChampHashMap(newRootNode, cachedJavaKeySetHashCode - keyHash, cachedSize - 1)
     else this
   }
-
-  def empty: ChampHashMap[K, V] = ChampHashMap.empty
 
   override def tail: ChampHashMap[K, V] = this - head._1
 

--- a/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ChampHashSet.scala
@@ -29,11 +29,7 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
     with StrictOptimizedIterableOps[A, ChampHashSet, ChampHashSet[A]]
     with Serializable {
 
-  def iterableFactory: IterableFactory[ChampHashSet] = ChampHashSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ChampHashSet[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, ChampHashSet[A]] = ChampHashSet.newBuilder()
+  override def iterableFactory: IterableFactory[ChampHashSet] = ChampHashSet
 
   override def knownSize: Int = cachedSize
 
@@ -66,8 +62,6 @@ final class ChampHashSet[A] private[immutable] (val rootNode: SetNode[A], val ca
       ChampHashSet(newRootNode, cachedJavaHashCode - elementHash, cachedSize - 1)
     else this
   }
-
-  def empty: ChampHashSet[A] = ChampHashSet.empty
 
   override def tail: ChampHashSet[A] = this - head
 

--- a/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashMap.scala
@@ -36,12 +36,7 @@ sealed abstract class HashMap[K, +V]
 
   import HashMap.{bufferSize, liftMerger, Merger, MergeFunction, nullToEmpty}
 
-  def iterableFactory = List
-  def mapFactory = HashMap
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] = HashMap.newBuilder()
+  override def mapFactory: MapFactory[HashMap] = HashMap
 
   def remove(key: K): HashMap[K, V] = removed0(key, computeHash(key), 0)
 
@@ -49,8 +44,6 @@ sealed abstract class HashMap[K, +V]
     updated0(key, computeHash(key), 0, value, null, null)
 
   @`inline` override final def +[V1 >: V](kv: (K, V1)): HashMap[K, V1] = updated(kv._1, kv._2)
-
-  def empty: HashMap[K, V] = HashMap.empty[K, V]
 
   def get(key: K): Option[V] = get0(key, computeHash(key), 0)
 

--- a/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/HashSet.scala
@@ -35,11 +35,7 @@ sealed abstract class HashSet[A]
 
   import HashSet.{bufferSize, LeafHashSet, nullToEmpty}
 
-  def iterableFactory = HashSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder()
+  override def iterableFactory = HashSet
 
   def contains(elem: A): Boolean = get0(elem, computeHash(elem), 0)
 
@@ -86,8 +82,6 @@ sealed abstract class HashSet[A]
     val buffer = new Array[HashSet[A]](bufferSize(size))
     nullToEmpty(filter0(p, true, 0, buffer, 0))
   }
-
-  def empty: HashSet[A] = HashSet.empty
 
   override def tail: HashSet[A] = this - head
 

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -28,7 +28,7 @@ sealed abstract class ImmutableArray[+A]
   /** The tag of the element type */
   protected[this] def elemTag: ClassTag[A]
 
-  def iterableFactory: SeqFactory[ImmutableArray] = ImmutableArray.untagged
+  override def iterableFactory: SeqFactory[ImmutableArray] = ImmutableArray.untagged
 
   /** The wrapped mutable `Array` that backs this `ImmutableArray`. Any changes to this array will break
     * the expected immutability. */
@@ -36,9 +36,9 @@ sealed abstract class ImmutableArray[+A]
   // uncheckedVariance should be safe: Array[A] for reference types A is covariant at the JVM level. Array[A] for
   // primitive types A can only be widened to Array[Any] which erases to Object.
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): ImmutableArray[A] = fromIterable(coll)
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): ImmutableArray[A] = ImmutableArray.from[A](coll)(elemTag)
 
-  protected[this] def newSpecificBuilder(): Builder[A, ImmutableArray[A]] = ImmutableArray.newBuilder[A]()(elemTag)
+  override protected[this] def newSpecificBuilder(): Builder[A, ImmutableArray[A]] = ImmutableArray.newBuilder[A]()(elemTag)
 
   @throws[ArrayIndexOutOfBoundsException]
   def apply(i: Int): A

--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -169,7 +169,7 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
   with StrictOptimizedIterableOps[(Int, T), Iterable, IntMap[T]]
   with Serializable {
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Int, T)]): IntMap[T] =
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Int, T)]): IntMap[T] =
     intMapFromIterable[T](coll)
   protected[this] def intMapFromIterable[V2](coll: strawman.collection.Iterable[(Int, V2)]): IntMap[V2] = {
     val b = IntMap.newBuilder[V2]()
@@ -177,12 +177,10 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
     b.addAll(coll)
     b.result()
   }
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-  protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
+  override protected[this] def newSpecificBuilder(): Builder[(Int, T), IntMap[T]] =
     new ImmutableBuilder[(Int, T), IntMap[T]](empty) {
       def addOne(elem: (Int, T)): this.type = { elems = elems + elem; this }
     }
-  def mapFactory: MapFactory[Map] = Map
 
   override def empty: IntMap[T] = IntMap.Nil
 

--- a/collections/src/main/scala/strawman/collection/immutable/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Iterable.scala
@@ -22,6 +22,9 @@ import strawman.collection.IterableFactory
   * @define Coll `immutable.Iterable`
   */
 trait Iterable[+A] extends collection.Iterable[A]
-                      with collection.IterableOps[A, Iterable, Iterable[A]]
+                      with collection.IterableOps[A, Iterable, Iterable[A]] {
+
+  override def iterableFactory: IterableFactory[IterableCC] = Iterable
+}
 
 object Iterable extends IterableFactory.Delegate[Iterable](List)

--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -184,12 +184,7 @@ import scala.annotation.unchecked.uncheckedVariance
   *  @define orderDependentFold
   */
 sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, LazyList, LazyList[A]] {
-  def iterableFactory: LazyListFactory[LazyList] = LazyList
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): LazyList[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, LazyList[A]] =
-    IndexedSeq.newBuilder().mapResult(_.to(LazyList))
+  override def iterableFactory: LazyListFactory[LazyList] = LazyList
 
   protected[this] def cons[T](hd: => T, tl: => LazyList[T]): LazyList[T] = new LazyList.Cons(hd, tl)
 
@@ -533,12 +528,7 @@ object LazyList extends LazyListFactory[LazyList] {
 
 @deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")
 sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream, Stream[A]] {
-  def iterableFactory: LazyListFactory[Stream] = Stream
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): Stream[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, Stream[A]] =
-    IndexedSeq.newBuilder().mapResult(_.to(Stream))
+  override def iterableFactory: LazyListFactory[Stream] = Stream
 
   protected[this] def cons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
 

--- a/collections/src/main/scala/strawman/collection/immutable/List.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/List.scala
@@ -78,11 +78,7 @@ sealed abstract class List[+A]
     with StrictOptimizedSeqOps[A, List, List[A]]
     with Serializable {
 
-  def iterableFactory: SeqFactory[List] = List
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): List[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder() = List.newBuilder[A]()
+  override def iterableFactory: SeqFactory[List] = List
 
   /** Adds an element at the beginning of this list.
     *  @param elem the element to prepend.

--- a/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListMap.scala
@@ -49,14 +49,7 @@ sealed class ListMap[K, +V]
     with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
     with Serializable {
 
-  def iterableFactory = List
-  def mapFactory = ListMap
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): ListMap[K, V] = ListMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), ListMap[K, V]] = ListMap.newBuilder()
-
-  def empty: ListMap[K, V] = ListMap.empty[K, V]
+  override def mapFactory: MapFactory[ListMap] = ListMap
 
   override def size: Int = 0
 

--- a/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ListSet.scala
@@ -44,8 +44,6 @@ sealed class ListSet[A]
   def incl(elem: A): ListSet[A] = new Node(elem)
   def excl(elem: A): ListSet[A] = this
 
-  def empty: ListSet[A] = ListSet.empty
-
   def iterator(): strawman.collection.Iterator[A] = {
     var curr: ListSet[A] = this
     var res: List[A] = Nil
@@ -59,10 +57,7 @@ sealed class ListSet[A]
   protected def elem: A = throw new NoSuchElementException("elem of empty set")
   protected def next: ListSet[A] = throw new NoSuchElementException("next of empty set")
 
-  def iterableFactory = ListSet
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListSet[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, ListSet[A]] = ListSet.newBuilder()
+  override def iterableFactory: IterableFactory[ListSet] = ListSet
 
   /**
     * Represents an entry in the `ListSet`.

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -161,19 +161,17 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
   with StrictOptimizedIterableOps[(Long, T), Iterable, LongMap[T]]
   with Serializable {
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, T)]): LongMap[T] = {
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, T)]): LongMap[T] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder()
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-  protected[this] def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] =
+  override protected[this] def newSpecificBuilder(): Builder[(Long, T), LongMap[T]] =
     new ImmutableBuilder[(Long, T), LongMap[T]](empty) {
       def addOne(elem: (Long, T)): this.type = { elems = elems + elem; this }
     }
-  def mapFactory: MapFactory[Map] = Map
 
   override def empty: LongMap[T] = LongMap.Nil
 

--- a/collections/src/main/scala/strawman/collection/immutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Map.scala
@@ -13,6 +13,8 @@ trait Map[K, +V]
      with collection.Map[K, V]
      with MapOps[K, V, Map, Map[K, V]] {
 
+  override def mapFactory: strawman.collection.MapFactory[MapCC] = Map
+
   override final def toMap[K2, V2](implicit ev: (K, V) <:< (K2, V2)): Map[K2, V2] = this.asInstanceOf[Map[K2, V2]]
 
   /** The same map with a given default function.
@@ -111,10 +113,6 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   /** The implementation class of the set returned by `keySet` */
   @SerialVersionUID(3L)
   protected class ImmutableKeySet extends Set[K] with GenKeySet {
-    def iterableFactory: IterableFactory[Set] = Set
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[K]): Set[K] = fromIterable(coll)
-    protected[this] def newSpecificBuilder(): Builder[K, Set[K]] = iterableFactory.newBuilder()
-    def empty: Set[K] = iterableFactory.empty
     def incl(elem: K): Set[K] = if (this(elem)) this else empty ++ this + elem
     def excl(elem: K): Set[K] = if (this(elem)) empty ++ this - elem else this
   }
@@ -141,23 +139,23 @@ object Map extends MapFactory[Map] {
 
     override def default(key: K): V = defaultValue(key)
 
-    def iterableFactory: IterableFactory[Iterable] = underlying.iterableFactory
+    override def iterableFactory: IterableFactory[Iterable] = underlying.iterableFactory
 
     def iterator(): Iterator[(K, V)] = underlying.iterator()
 
-    def mapFactory: MapFactory[Map] = underlying.mapFactory
+    override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
     def remove(key: K): WithDefault[K, V] = new WithDefault[K, V](underlying.remove(key), defaultValue)
 
     def updated[V1 >: V](key: K, value: V1): WithDefault[K, V1] =
       new WithDefault[K, V1](underlying.updated(key, value), defaultValue)
 
-    def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
+    override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
-    protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
       Map.newBuilder().mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 
@@ -172,16 +170,8 @@ object Map extends MapFactory[Map] {
   def newBuilder[K, V](): Builder[(K, V), Map[K, V]] =
     if (useBaseline) HashMap.newBuilder() else ChampHashMap.newBuilder()
 
-  trait SmallMap[K, +V] extends Map[K, V] {
-    def iterableFactory: IterableFactory[Iterable] = Iterable
-    def mapFactory: MapFactory[Map] = Map
-    def empty: Map[K, V] = mapFactory.empty
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): Map[K, V] = mapFactory.from(coll)
-    protected[this] def newSpecificBuilder(): Builder[(K, V), Map[K, V]] = mapFactory.newBuilder()
-  }
-
   @SerialVersionUID(3L)
-  private object EmptyMap extends Map[Any, Nothing] with SmallMap[Any, Nothing] with Serializable {
+  private object EmptyMap extends Map[Any, Nothing] with Serializable {
     override def size: Int = 0
     override def apply(key: Any) = throw new NoSuchElementException("key not found: " + key)
     override def contains(key: Any) = false
@@ -192,7 +182,7 @@ object Map extends MapFactory[Map] {
   }
 
   @SerialVersionUID(3L)
-  final class Map1[K, +V](key1: K, value1: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
+  final class Map1[K, +V](key1: K, value1: V) extends Map[K, V] with Serializable {
     override def size = 1
     override def apply(key: K) = if (key == key1) value1 else throw new NoSuchElementException("key not found: " + key)
     override def contains(key: K) = key == key1
@@ -210,7 +200,7 @@ object Map extends MapFactory[Map] {
   }
 
   @SerialVersionUID(3L)
-  final class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
+  final class Map2[K, +V](key1: K, value1: V, key2: K, value2: V) extends Map[K, V] with Serializable {
     override def size = 2
     override def apply(key: K) =
       if (key == key1) value1
@@ -236,7 +226,7 @@ object Map extends MapFactory[Map] {
   }
 
   @SerialVersionUID(3L)
-  class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
+  class Map3[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V) extends Map[K, V] with Serializable {
     override def size = 3
     override def apply(key: K) =
       if (key == key1) value1
@@ -266,7 +256,7 @@ object Map extends MapFactory[Map] {
   }
 
   @SerialVersionUID(3L)
-  final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends Map[K, V] with SmallMap[K, V] with Serializable {
+  final class Map4[K, +V](key1: K, value1: V, key2: K, value2: V, key3: K, value3: V, key4: K, value4: V) extends Map[K, V] with Serializable {
     override def size = 4
     override def apply(key: K) =
       if (key == key1) value1

--- a/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/NumericRange.scala
@@ -61,12 +61,6 @@ sealed class NumericRange[T](
     }
   }
 
-  def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
-
-  protected[this] def fromSpecificIterable(it: collection.Iterable[T]): IndexedSeq[T] = fromIterable(it)
-
-  protected[this] def newSpecificBuilder(): Builder[T, IndexedSeq[T]] = IndexedSeq.newBuilder()
-
   /** Note that NumericRange must be invariant so that constructs
     *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
     */

--- a/collections/src/main/scala/strawman/collection/immutable/Queue.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Queue.scala
@@ -43,11 +43,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     with StrictOptimizedSeqOps[A, Queue, Queue[A]]
     with Serializable {
 
-  def iterableFactory: SeqFactory[Queue] = Queue
-
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): Queue[A] = iterableFactory.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, Queue[A]] = iterableFactory.newBuilder()
+  override def iterableFactory: SeqFactory[Queue] = Queue
 
   /** Returns the `n`-th element of this queue.
     *  The first element is at position `0`.

--- a/collections/src/main/scala/strawman/collection/immutable/Range.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Range.scala
@@ -57,13 +57,6 @@ sealed abstract class Range(
     with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
     with Serializable { range =>
 
-  def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): IndexedSeq[Int] =
-    fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[Int, IndexedSeq[Int]] = IndexedSeq.newBuilder()
-
   override def iterator(): Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
   private def gap           = end.toLong - start.toLong

--- a/collections/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -9,6 +9,8 @@ trait Seq[+A] extends Iterable[A]
                  with SeqOps[A, Seq, Seq[A]] {
 
   override final def toSeq: this.type = this
+
+  override def iterableFactory: SeqFactory[Seq] = Seq
 }
 
 /**
@@ -41,6 +43,7 @@ trait IndexedSeq[+A] extends Seq[A]
 
   final override def toIndexedSeq: IndexedSeq[A] = this
 
+  override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
 }
 
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector)
@@ -52,7 +55,10 @@ trait IndexedSeqOps[+A, +CC[X] <: IndexedSeq[X], +C] extends SeqOps[A, CC, C] wi
 trait LinearSeq[+A]
   extends Seq[A]
     with collection.LinearSeq[A]
-    with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
+    with LinearSeqOps[A, LinearSeq, LinearSeq[A]] {
+
+  override def iterableFactory: SeqFactory[LinearSeq] = LinearSeq
+}
 
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](List)
 

--- a/collections/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Set.scala
@@ -7,7 +7,9 @@ import strawman.collection.mutable.Builder
 import scala.{Any, Boolean, Int, deprecatedName, `inline`, None, Option, Serializable, SerialVersionUID, Some, Unit}
 
 /** Base trait for immutable set collections */
-trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]]
+trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]] {
+  override def iterableFactory: IterableFactory[Set] = Set
+}
 
 /** Base trait for immutable set operations
   *
@@ -75,17 +77,9 @@ object Set extends IterableFactory[Set] {
   def newBuilder[A](): Builder[A, Set[A]] =
     if (useBaseline) HashSet.newBuilder() else ChampHashSet.newBuilder()
 
-  // Reusable implementations for the small sets defined below
-  trait SmallSet[A] extends Set[A] {
-    def iterableFactory: IterableFactory[Set] = Set
-    def empty: Set[A] = iterableFactory.empty
-    protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): Set[A] = iterableFactory.from(coll)
-    protected[this] def newSpecificBuilder(): Builder[A, Set[A]] = iterableFactory.newBuilder()
-  }
-
   /** An optimized representation for immutable empty sets */
   @SerialVersionUID(3L)
-  private object EmptySet extends Set[Any] with SmallSet[Any] with Serializable {
+  private object EmptySet extends Set[Any] with Serializable {
     override def size: Int = 0
     def contains(elem: Any): Boolean = false
     def incl(elem: Any): Set[Any] = new Set1(elem)
@@ -97,7 +91,7 @@ object Set extends IterableFactory[Set] {
 
   /** An optimized representation for immutable sets of size 1 */
   @SerialVersionUID(3L)
-  final class Set1[A] private[collection] (elem1: A) extends Set[A] with SmallSet[A] with Serializable {
+  final class Set1[A] private[collection] (elem1: A) extends Set[A] with Serializable {
     override def size: Int = 1
     def contains(elem: A): Boolean = elem == elem1
     def incl(elem: A): Set[A] =
@@ -119,7 +113,7 @@ object Set extends IterableFactory[Set] {
 
   /** An optimized representation for immutable sets of size 2 */
   @SerialVersionUID(3L)
-  final class Set2[A] private[collection] (elem1: A, elem2: A) extends Set[A] with SmallSet[A] with Serializable {
+  final class Set2[A] private[collection] (elem1: A, elem2: A) extends Set[A] with Serializable {
     override def size: Int = 2
     def contains(elem: A): Boolean = elem == elem1 || elem == elem2
     def incl(elem: A): Set[A] =
@@ -150,7 +144,7 @@ object Set extends IterableFactory[Set] {
 
   /** An optimized representation for immutable sets of size 3 */
   @SerialVersionUID(3L)
-  final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends Set[A] with SmallSet[A] with Serializable {
+  final class Set3[A] private[collection] (elem1: A, elem2: A, elem3: A) extends Set[A] with Serializable {
     override def size: Int = 3
     def contains(elem: A): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3
@@ -184,7 +178,7 @@ object Set extends IterableFactory[Set] {
 
   /** An optimized representation for immutable sets of size 4 */
   @SerialVersionUID(3L)
-  final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends Set[A] with SmallSet[A] with Serializable {
+  final class Set4[A] private[collection] (elem1: A, elem2: A, elem3: A, elem4: A) extends Set[A] with Serializable {
     override def size: Int = 4
     def contains(elem: A): Boolean =
       elem == elem1 || elem == elem2 || elem == elem3 || elem == elem4

--- a/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/SortedMap.scala
@@ -10,6 +10,8 @@ trait SortedMap[K, +V]
     with collection.SortedMap[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]] {
 
+  override def sortedMapFactory: SortedMapFactory[SortedMapCC] = SortedMap
+
   /** The same map with a given default function.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
     *  are not affected by `withDefault`.
@@ -43,16 +45,10 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
     /** The implementation class of the set returned by `keySet` */
     @SerialVersionUID(3L)
     protected class ImmutableKeySortedSet extends SortedSet[K] with GenKeySet with GenKeySortedSet {
-      def iterableFactory: IterableFactory[Set] = Set
-      def sortedIterableFactory: SortedIterableFactory[SortedSet] = SortedSet
-      protected[this] def sortedFromIterable[B: Ordering](it: collection.Iterable[B]): SortedSet[B] = sortedIterableFactory.from(it)
-      protected[this] def fromSpecificIterable(coll: collection.Iterable[K]): SortedSet[K] = sortedIterableFactory.from(coll)
-      protected[this] def newSpecificBuilder(): Builder[K, SortedSet[K]] = sortedIterableFactory.newBuilder()
       def rangeImpl(from: Option[K], until: Option[K]): SortedSet[K] = {
         val map = self.rangeImpl(from, until)
         new map.ImmutableKeySortedSet
       }
-      def empty: SortedSet[K] = sortedIterableFactory.empty
       def incl(elem: K): SortedSet[K] = fromSpecificIterable(this).incl(elem)
       def excl(elem: K): SortedSet[K] = fromSpecificIterable(this).excl(elem)
     }
@@ -80,7 +76,7 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
 
     implicit def ordering: Ordering[K] = underlying.ordering
 
-    def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
+    override def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
 
     def iteratorFrom(start: K): strawman.collection.Iterator[(K, V)] = underlying.iteratorFrom(start)
 

--- a/collections/src/main/scala/strawman/collection/immutable/SortedSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/SortedSet.scala
@@ -6,7 +6,10 @@ package immutable
 trait SortedSet[A]
   extends Set[A]
      with collection.SortedSet[A]
-     with SortedSetOps[A, SortedSet, SortedSet[A]]
+     with SortedSetOps[A, SortedSet, SortedSet[A]] {
+
+  override def sortedIterableFactory: SortedIterableFactory[SortedIterableCC] = SortedSet
+}
 
 /**
   * @define coll immutable sorted set

--- a/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeMap.scala
@@ -37,14 +37,7 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def this()(implicit ordering: Ordering[K]) = this(null)(ordering)
 
-  def iterableFactory = List
-  def mapFactory = Map
-  def sortedMapFactory = TreeMap
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] =
-    TreeMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
+  override def sortedMapFactory = TreeMap
 
   def iterator(): collection.Iterator[(K, V)] = RB.iterator(tree)
 
@@ -75,8 +68,6 @@ final class TreeMap[K, +V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     assert(!RB.contains(tree, key))
     new TreeMap(RB.update(tree, key, value, overwrite = true))
   }
-
-  def empty: TreeMap[K, V] = TreeMap.empty[K, V](ordering)
 
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMap[K, V](RB.rangeImpl(tree, from, until))
 

--- a/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/TreeSet.scala
@@ -37,17 +37,7 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
 
   def this()(implicit ordering: Ordering[A]) = this(null)(ordering)
 
-  def iterableFactory = Set
-
-  def sortedIterableFactory = TreeSet
-
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): TreeSet[A] =
-    TreeSet.from(coll)
-
-  protected[this] def sortedFromIterable[B : Ordering](coll: strawman.collection.Iterable[B]): TreeSet[B] =
-    TreeSet.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
+  override def sortedIterableFactory = TreeSet
 
   private def newSet(t: RB.Tree[A, Unit]) = new TreeSet[A](t)
 
@@ -118,10 +108,6 @@ final class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: O
     *  @return true, iff `elem` is contained in this set.
     */
   def contains(elem: A): Boolean = RB.contains(tree, elem)
-
-  /** A factory to create empty sets of the same type of keys.
-    */
-  def empty: TreeSet[A] = TreeSet.empty
 
   override def range(from: A, until: A): TreeSet[A] = newSet(RB.range(tree, from, until))
 

--- a/collections/src/main/scala/strawman/collection/immutable/Vector.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Vector.scala
@@ -70,11 +70,7 @@ final class Vector[+A] private[immutable] (private[collection] val startIndex: I
     with VectorPointer[A @uncheckedVariance]
     with Serializable { self =>
 
-  def iterableFactory: SeqFactory[Vector] = Vector
-
-  protected[this] def fromSpecificIterable(it: collection.Iterable[A]): Vector[A] = fromIterable(it)
-
-  protected[this] def newSpecificBuilder(): Builder[A, Vector[A]] = Vector.newBuilder()
+  override def iterableFactory: SeqFactory[Vector] = Vector
 
   private[immutable] var dirty = false
 

--- a/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/WrappedString.scala
@@ -24,10 +24,9 @@ final class WrappedString(val self: String) extends AbstractSeq[Char] with Index
 
   def apply(i: Int): Char = self.charAt(i)
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[Char]): WrappedString =
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[Char]): WrappedString =
     WrappedString.fromSpecific(coll)
-  protected[this] def newSpecificBuilder(): Builder[Char, WrappedString] = WrappedString.newBuilder()
-  def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
+  override protected[this] def newSpecificBuilder(): Builder[Char, WrappedString] = WrappedString.newBuilder()
 
   override def slice(from: Int, until: Int): WrappedString = {
     val start = if (from < 0) 0 else from

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -76,8 +76,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     mask = m; _size = sz; _vacant = vc; _hashes = hz; _keys = kz; _values = vz
   }
 
-  def mapFactory: strawman.collection.MapFactory[Map] = Map
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): AnyRefMap[K,V] = {
     var sz = coll.knownSize
     if(sz < 0) sz = 4
     val arm = new AnyRefMap[K, V](sz * 2)
@@ -85,7 +84,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     if (arm.size < (sz>>3)) arm.repack()
     arm
   }
-  protected[this] def newSpecificBuilder(): Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
+  override protected[this] def newSpecificBuilder(): Builder[(K, V), AnyRefMap[K,V]] = new AnyRefMapBuilder
 
   override def size: Int = _size
   override def empty: AnyRefMap[K,V] = new AnyRefMap(defaultEntry)

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayBuffer.scala
@@ -77,11 +77,7 @@ class ArrayBuffer[A] private (initElems: Array[AnyRef], initSize: Int)
 
   override def view: ArrayBufferView[A] = new ArrayBufferView(array, size0)
 
-  def iterableFactory: SeqFactory[ArrayBuffer] = ArrayBuffer
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ArrayBuffer[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, ArrayBuffer[A]] = ArrayBuffer.newBuilder()
+  override def iterableFactory: SeqFactory[ArrayBuffer] = ArrayBuffer
 
   def clear(): Unit = reduceToSize(0)
 

--- a/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/BitSet.scala
@@ -36,17 +36,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   def this() = this(0)
 
-  def iterableFactory = Set
-
-  def sortedIterableFactory = SortedSet
-
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): collection.mutable.SortedSet[B] =
-    collection.mutable.SortedSet.from(it)
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[Int]): BitSet =
-    BitSet.fromSpecific(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[Int, BitSet] = BitSet.newBuilder()
+  def bitSetFactory = BitSet
 
   protected[collection] final def nwords: Int = elems.length
 
@@ -96,8 +86,6 @@ class BitSet(protected[collection] final var elems: Array[Long])
   def get(elem: Int): Option[Int] = if (contains(elem)) Some(elem) else None
 
   def unconstrained: collection.Set[Int] = this
-
-  def empty: BitSet = BitSet.empty
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".
     *

--- a/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Buffer.scala
@@ -11,6 +11,8 @@ trait Buffer[A]
     with Growable[A]
     with Shrinkable[A] {
 
+  override def iterableFactory: SeqFactory[Buffer] = Buffer
+
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
     *

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -87,11 +87,6 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Cha
 
   // Methods required to make this an IndexedSeq:
   def apply(i: Int): Char = sb.charAt(i)
-  def iterableFactory: strawman.collection.SeqFactory[IndexedSeq] = IndexedSeq
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[Char]): IndexedSeq[Char] =
-    iterableFactory.from(coll)
-  protected[this] def newSpecificBuilder(): strawman.collection.mutable.Builder[Char, IndexedSeq[Char]] =
-    iterableFactory.newBuilder()
 
   //TODO In the old collections, StringBuilder extends Seq -- should it do the same here to get this method?
   def length: Int = sb.length()

--- a/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashMap.scala
@@ -27,7 +27,7 @@ class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, Default
     with StrictOptimizedIterableOps[(K, V), Iterable, HashMap[K, V]]
     with Serializable {
 
-  def mapFactory = HashMap
+  override def mapFactory = HashMap
 
   @transient private[this] var table: HashTable[K, V, DefaultEntry[K, V]] = newHashTable
   table.initWithContents(contents)
@@ -41,13 +41,7 @@ class HashMap[K, V] private[collection] (contents: HashTable.Contents[K, Default
       def createNewEntry(key: K, value: V): DefaultEntry[K, V] = new Entry(key, value)
     }
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): HashMap[K, V] = HashMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), HashMap[K, V]] =  HashMap.newBuilder()
-
   def iterator(): Iterator[(K, V)] = table.entriesIterator.map(e => (e.key, e.value))
-
-  def empty: HashMap[K, V] = HashMap.empty
 
   def get(key: K): Option[V] = {
     val e = table.findEntry(key)

--- a/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashSet.scala
@@ -31,11 +31,7 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
 
   override def iterator(): Iterator[A] = table.iterator
 
-  def iterableFactory = HashSet
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): HashSet[A] = fromIterable(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, HashSet[A]] = HashSet.newBuilder()
+  override def iterableFactory: IterableFactory[HashSet] = HashSet
 
   def addOne(elem: A): this.type = {
     table.addElem(elem)
@@ -49,8 +45,6 @@ final class HashSet[A](contents: FlatHashTable.Contents[A])
   def clear(): Unit = table.clearTable()
 
   def contains(elem: A): Boolean = table.containsElem(elem)
-
-  def empty: HashSet[A] = HashSet.empty
 
   def get(elem: A): Option[A] = table.findEntry(elem)
 

--- a/collections/src/main/scala/strawman/collection/mutable/IndexedSeq.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/IndexedSeq.scala
@@ -3,7 +3,10 @@ package mutable
 
 trait IndexedSeq[T] extends Seq[T]
   with strawman.collection.IndexedSeq[T]
-  with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+  with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]] {
+
+  override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
+}
 
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](ArrayBuffer)
 

--- a/collections/src/main/scala/strawman/collection/mutable/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Iterable.scala
@@ -7,7 +7,10 @@ import scala.{Boolean, deprecated, `inline`}
 
 trait Iterable[A]
   extends collection.Iterable[A]
-    with IterableOps[A, Iterable, Iterable[A]]
+    with IterableOps[A, Iterable, Iterable[A]] {
+
+  override def iterableFactory: IterableFactory[IterableCC] = Iterable
+}
 
 /**
   * @define coll mutable collection

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashMap.scala
@@ -83,11 +83,7 @@ class LinkedHashMap[K, V]
   @transient protected var firstEntry: Entry = null
   @transient protected var lastEntry: Entry = null
 
-  def mapFactory = LinkedHashMap
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]) = mapFactory.from(coll)
-
-  protected[this] def newSpecificBuilder() = mapFactory.newBuilder()
+  override def mapFactory: MapFactory[LinkedHashMap] = LinkedHashMap
 
   def get(key: K): Option[V] = {
     val e = table.findEntry(key)

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedHashSet.scala
@@ -28,7 +28,7 @@ class LinkedHashSet[A]
     with SetOps[A, LinkedHashSet, LinkedHashSet[A]]
     with Serializable {
 
-  def iterableFactory: IterableFactory[LinkedHashSet] = LinkedHashSet
+  override def iterableFactory: IterableFactory[LinkedHashSet] = LinkedHashSet
 
   type Entry = LinkedHashSet.Entry[A]
 
@@ -58,11 +58,6 @@ class LinkedHashSet[A]
     val entry = table.findEntry(elem)
     if (entry != null) Some(entry.key) else None
   }
-
-  def empty: LinkedHashSet[A] = LinkedHashSet.empty
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]) = fromIterable(coll)
-  protected[this] def newSpecificBuilder() = iterableFactory.newBuilder()
 
   override def size: Int = table.tableSize
 

--- a/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
@@ -49,9 +49,7 @@ private[mutable] final class LinkedList[A]() extends AbstractSeq[A]
   var elem: A = _
   var next: LinkedList[A] = this
 
-  def iterableFactory: SeqFactory[LinkedList] = LinkedList
-  protected[this] def newSpecificBuilder(): Builder[A, LinkedList[A]] = LinkedList.newBuilder()
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): LinkedList[A] = LinkedList.from(coll)
+  override def iterableFactory: SeqFactory[LinkedList] = LinkedList
 
   def clear(): Unit = {
     elem = null.asInstanceOf[A]

--- a/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListBuffer.scala
@@ -47,9 +47,7 @@ class ListBuffer[A]
 
   def iterator() = first.iterator()
 
-  def iterableFactory: SeqFactory[ListBuffer] = ListBuffer
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): ListBuffer[A] = fromIterable(coll)
+  override def iterableFactory: SeqFactory[ListBuffer] = ListBuffer
 
   @throws[IndexOutOfBoundsException]
   def apply(i: Int) = first.apply(i)
@@ -59,8 +57,6 @@ class ListBuffer[A]
 
   override def isEmpty: Boolean = len == 0
   override def nonEmpty: Boolean = len > 0
-
-  protected[this] def newSpecificBuilder(): Builder[A, ListBuffer[A]] = ListBuffer.newBuilder()
 
   private def copyElems(): Unit = {
     val buf = ListBuffer.from(this)

--- a/collections/src/main/scala/strawman/collection/mutable/ListMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ListMap.scala
@@ -31,12 +31,7 @@ class ListMap[K, V]
     with StrictOptimizedIterableOps[(K, V), Iterable, ListMap[K, V]]
     with Serializable {
 
-  def empty: ListMap[K, V] = ListMap.empty[K, V]
-
-  def mapFactory: MapFactory[ListMap] = ListMap
-
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): ListMap[K,V] = mapFactory.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[(K, V), ListMap[K,V]] = mapFactory.newBuilder()
+  override def mapFactory: MapFactory[ListMap] = ListMap
 
   private var elems: List[(K, V)] = List()
   private var siz: Int = 0

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -35,15 +35,14 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   def this() = this(LongMap.exceptionDefault, 16, true)
 
   def clear(): Unit = { keysIterator() foreach -= } // TODO optimize
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, V)]): LongMap[V] = {
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Long, V)]): LongMap[V] = {
     //TODO should this be the default implementation of this method in StrictOptimizedIterableOps?
     val b = newSpecificBuilder()
     b.sizeHint(coll)
     b.addAll(coll)
     b.result()
   }
-  protected[this] def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
-  def mapFactory: strawman.collection.MapFactory[Map] = Map
+  override protected[this] def newSpecificBuilder(): Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
 
   /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
   def this(defaultEntry: Long => V) = this(defaultEntry, 16, true)

--- a/collections/src/main/scala/strawman/collection/mutable/Map.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Map.scala
@@ -14,6 +14,8 @@ trait Map[K, V]
     with Growable[(K, V)]
     with Shrinkable[K] {
 
+  override def mapFactory: strawman.collection.MapFactory[MapCC] = Map
+
   /*
   //TODO consider keeping `remove` because it returns the removed entry
   @deprecated("Use subtract or -= instead of remove", "2.13.0")
@@ -57,8 +59,6 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
     with Cloneable[C]
     with Growable[(K, V)]
     with Shrinkable[K] {
-
-  def iterableFactory: IterableFactory[Iterable] = Iterable
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
     *  If the map already contains a
@@ -183,7 +183,7 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     def iterator(): strawman.collection.Iterator[(K, V)] = underlying.iterator()
 
-    def mapFactory: MapFactory[Map] = underlying.mapFactory
+    override def mapFactory: MapFactory[Map] = underlying.mapFactory
 
     def clear(): Unit = underlying.clear()
 
@@ -193,12 +193,12 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
     def addOne(elem: (K, V)): WithDefault.this.type = { underlying.addOne(elem); this }
 
-    def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
+    override def empty: WithDefault[K, V] = new WithDefault[K, V](underlying.empty, defaultValue)
 
-    protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): WithDefault[K, V] =
+    override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(K, V)]): WithDefault[K, V] =
       new WithDefault[K, V](mapFactory.from(coll), defaultValue)
 
-    protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
+    override protected[this] def newSpecificBuilder(): Builder[(K, V), WithDefault[K, V]] =
       Map.newBuilder().mapResult((p: Map[K, V]) => new WithDefault[K, V](p, defaultValue))
   }
 

--- a/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/MutableList.scala
@@ -39,9 +39,7 @@ private[mutable] class MutableList[A]
   protected var last0: LinkedList[A] = first0
   protected var len: Int = 0
 
-  def iterableFactory: SeqFactory[MutableList] = MutableList
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): MutableList[A] = iterableFactory.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[A, MutableList[A]] = iterableFactory.newBuilder()
+  override def iterableFactory: SeqFactory[MutableList] = MutableList
 
   def filterInPlace(p: A => Boolean): this.type = {
     var these = first0

--- a/collections/src/main/scala/strawman/collection/mutable/OpenHashMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/OpenHashMap.scala
@@ -70,12 +70,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
     */
   def this() = this(8)
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[(Key, Value)]): OpenHashMap[Key, Value] = mapFactory.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[(Key, Value), OpenHashMap[Key, Value]] = mapFactory.newBuilder()
-
-  def mapFactory: MapFactory[OpenHashMap] = OpenHashMap
-
-  override def empty: OpenHashMap[Key, Value] = OpenHashMap.empty[Key, Value]
+  override def mapFactory: MapFactory[OpenHashMap] = OpenHashMap
 
   private[this] val actualInitialSize = HashTable.nextPositivePowerOfTwo(initialSize)
 

--- a/collections/src/main/scala/strawman/collection/mutable/PriorityQueue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/PriorityQueue.scala
@@ -80,10 +80,8 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   override def size: Int = length
   override def isEmpty: Boolean = resarr.p_size0 < 2
 
-  def iterableFactory: IterableFactory[Iterable] = Iterable
-
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): PriorityQueue[A] = PriorityQueue.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder()
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[A]): PriorityQueue[A] = PriorityQueue.from(coll)
+  override protected[this] def newSpecificBuilder(): Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder()
 
   def mapInPlace(f: A => A): this.type = {
     resarr.mapInPlace(f)

--- a/collections/src/main/scala/strawman/collection/mutable/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Seq.scala
@@ -9,7 +9,10 @@ import scala.Predef.intWrapper
 trait Seq[A]
   extends Iterable[A]
     with collection.Seq[A]
-    with SeqOps[A, Seq, Seq[A]]
+    with SeqOps[A, Seq, Seq[A]] {
+
+  override def iterableFactory: SeqFactory[Seq] = Seq
+}
 
 /**
   * $factoryInfo

--- a/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/SortedMap.scala
@@ -12,6 +12,8 @@ trait SortedMap[K, V]
     with Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]] {
 
+  override def sortedMapFactory: SortedMapFactory[SortedMapCC] = SortedMap
+
   /** The same sorted map with a given default function.
     *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
     *  are not affected by `withDefault`.
@@ -48,7 +50,7 @@ object SortedMap extends SortedMapFactory.Delegate[SortedMap](TreeMap) {
       with SortedMapOps[K, V, SortedMap, WithDefault[K, V]]
       with Serializable {
 
-    def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
+    override def sortedMapFactory: SortedMapFactory[SortedMap] = underlying.sortedMapFactory
 
     def iteratorFrom(start: K): strawman.collection.Iterator[(K, V)] = underlying.iteratorFrom(start)
 

--- a/collections/src/main/scala/strawman/collection/mutable/SortedSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/SortedSet.scala
@@ -10,7 +10,10 @@ import scala.Ordering
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
-    with SortedSetOps[A, SortedSet, SortedSet[A]]
+    with SortedSetOps[A, SortedSet, SortedSet[A]] {
+
+  override def sortedIterableFactory: SortedIterableFactory[SortedIterableCC] = SortedSet
+}
 
 /**
   * @define coll mutable sorted set

--- a/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeMap.scala
@@ -28,8 +28,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     with StrictOptimizedIterableOps[(K, V), Iterable, TreeMap[K, V]]
     with Serializable {
 
-  def mapFactory = Map
-  def sortedMapFactory = TreeMap
+  override def sortedMapFactory = TreeMap
 
   /**
     * Creates an empty `TreeMap`.
@@ -38,10 +37,6 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(ord)
 
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[(K, V)]): TreeMap[K, V] = TreeMap.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[(K, V), TreeMap[K, V]] = TreeMap.newBuilder()
-
   def iterator(): Iterator[(K, V)] = RB.iterator(tree)
 
   def keysIteratorFrom(start: K): Iterator[K] = RB.keysIterator(tree, Some(start))
@@ -49,8 +44,6 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   def iteratorFrom(start: K): Iterator[(K, V)] = RB.iterator(tree, Some(start))
 
   override def valuesIteratorFrom(start: K): Iterator[V] = RB.valuesIterator(tree, Some(start))
-
-  def empty: TreeMap[K, V] = TreeMap.empty
 
   def addOne(elem: (K, V)): this.type = { RB.insert(tree, elem._1, elem._2); this }
 

--- a/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/TreeSet.scala
@@ -41,19 +41,9 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
 
   def iterator(): collection.Iterator[A] = RB.keysIterator(tree)
 
-  protected[this] def sortedFromIterable[B : Ordering](it: collection.Iterable[B]): TreeSet[B] = TreeSet.from(it)
-
-  protected[this] def fromSpecificIterable(coll: collection.Iterable[A]): TreeSet[A] = TreeSet.from(coll)
-
-  protected[this] def newSpecificBuilder(): Builder[A, TreeSet[A]] = TreeSet.newBuilder()
-
-  def iterableFactory = Set
-
-  def sortedIterableFactory = TreeSet
+  override def sortedIterableFactory: SortedIterableFactory[TreeSet] = TreeSet
 
   def iteratorFrom(start: A): collection.Iterator[A] = RB.keysIterator(tree, Some(start))
-
-  def empty: TreeSet[A] = TreeSet.empty
 
   def addOne(elem: A): this.type = {
     RB.insert(tree, elem, null)

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -65,10 +65,10 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   private[collection] def lastPtr_=(last: Unrolled[T]) = lastptr = last
   private[collection] def size_=(s: Int) = sz = s
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[T]) = UnrolledBuffer.from(coll)
-  protected[this] def newSpecificBuilder(): Builder[T, UnrolledBuffer[T]] = new UnrolledBuffer[T]
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[T]) = UnrolledBuffer.from(coll)
+  override protected[this] def newSpecificBuilder(): Builder[T, UnrolledBuffer[T]] = new UnrolledBuffer[T]
 
-  def iterableFactory: SeqFactory[UnrolledBuffer] = UnrolledBuffer.untagged
+  override def iterableFactory: SeqFactory[UnrolledBuffer] = UnrolledBuffer.untagged
 
   protected def newUnrolled = new Unrolled[T](this)
 

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -34,16 +34,16 @@ abstract class WrappedArray[T]
     with StrictOptimizedSeqOps[T, WrappedArray, WrappedArray[T]]
     with Serializable {
 
-  def iterableFactory: strawman.collection.SeqFactory[WrappedArray] = WrappedArray.untagged
+  override def iterableFactory: strawman.collection.SeqFactory[WrappedArray] = WrappedArray.untagged
 
-  protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[T]): WrappedArray[T] = {
+  override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[T]): WrappedArray[T] = {
     val b = ArrayBuilder.make()(elemTag)
     val s = coll.knownSize
     if(s > 0) b.sizeHint(s)
     b ++= coll
     WrappedArray.make(b.result())
   }
-  protected[this] def newSpecificBuilder(): Builder[T, WrappedArray[T]] = WrappedArray.newBuilder()(elemTag)
+  override protected[this] def newSpecificBuilder(): Builder[T, WrappedArray[T]] = WrappedArray.newBuilder()(elemTag)
 
   /** The tag of the element type */
   def elemTag: ClassTag[T]

--- a/test/junit/src/test/scala/strawman/collection/mutable/SetTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/SetTest.scala
@@ -10,14 +10,13 @@ import strawman.collection.IterableFactory
 class SetTest {
 
   class MySet(self: Set[String]) extends Set[String] with SetOps[String, Set, MySet] {
-    def iterableFactory: IterableFactory[Set] = Set
-    protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[String]): MySet = new MySet(fromIterable(coll))
-    protected[this] def newSpecificBuilder(): Builder[String, MySet] = iterableFactory.newBuilder[String]().mapResult(new MySet(_))
+    override protected[this] def fromSpecificIterable(coll: strawman.collection.Iterable[String]): MySet = new MySet(fromIterable(coll))
+    override protected[this] def newSpecificBuilder(): Builder[String, MySet] = iterableFactory.newBuilder[String]().mapResult(new MySet(_))
 
     def subtractOne(elem: String) = { self -= elem; this }
     def addOne(elem: String) = { self += elem; this }
 
-    def empty = new MySet(self.empty)
+    override def empty = new MySet(self.empty)
     def iterator() = self.iterator()
     def contains(elem: String) = self.contains(elem)
     def get(elem: String): Option[String] = self.get(elem)


### PR DESCRIPTION
- The respective `CC` types are exposed (to `protected[this]`) through
  aliases `IterableCC`, `SortedIterableCC`, `MapCC` and `SortedMapCC`
  in the respective `Ops` traits, plus a `BitSetC` for the shared
  `BitSetOps` trait.

- This allows defining `fromSpecificIterable`, `newSpecificBuilder`
  and `empty` (for all but `Iterable`) in the respective collection
  traits `Iterable`, `SortedSet`, `Map` and `SortedMap` (*not* in their
  `Ops` traits) where the `CC` type is visible and set to a concrete
  type but can still be refined in subtypes. This gives us a valid
  implementation until a concrete collection type with a refined `CC`
  gets defined. In this case the inherited implementations have the
  wrong type, so the user is forced to override them.

- Implementations of `fromSpecificIterable`, `newSpecificBuilder` and
  `empty` can be removed from almost all collection implementations
  except the ones where they need to be refined even further than what
  a factory can provide (e.g. `IntMap`, `PriorityQueue`).

- Factories are generally overridden in abstract collection types that
  refine a `CC` (e.g. `Iterable` -> `Seq` -> `immutable.Set` ->
  `immutable.IndexedSeq`) so that concrete implementations without
  further refinement do not need to override them.

- DefaultMap is deprecated because there is no more boilerplate left
  that it could implement.

- `sortedFromIterable`, `mapFromIterable` and `sortedMapFromIterable`
  are treated the same way as `fromIterable`. They are implemented as
  `inline final` calls to the respective factory method.

Fixes https://github.com/scala/collection-strawman/issues/335