### PR TITLE
Fix the iterableFactory of mutable Sets

### DIFF
--- a/collections/src/main/scala/strawman/collection/Set.scala
+++ b/collections/src/main/scala/strawman/collection/Set.scala
@@ -28,6 +28,8 @@ trait Set[A]
 
   override def hashCode(): Int = Set.setHash(toIterable)
 
+  override def iterableFactory: IterableFactory[IterableCC] = Set
+
   def empty: IterableCC[A] = iterableFactory.empty
 }
 

--- a/collections/src/main/scala/strawman/collection/immutable/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Seq.scala
@@ -10,7 +10,7 @@ trait Seq[+A] extends Iterable[A]
 
   override final def toSeq: this.type = this
 
-  override def iterableFactory: SeqFactory[Seq] = Seq
+  override def iterableFactory: SeqFactory[IterableCC] = Seq
 }
 
 /**
@@ -43,7 +43,7 @@ trait IndexedSeq[+A] extends Seq[A]
 
   final override def toIndexedSeq: IndexedSeq[A] = this
 
-  override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
+  override def iterableFactory: SeqFactory[IterableCC] = IndexedSeq
 }
 
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector)
@@ -57,7 +57,7 @@ trait LinearSeq[+A]
     with collection.LinearSeq[A]
     with LinearSeqOps[A, LinearSeq, LinearSeq[A]] {
 
-  override def iterableFactory: SeqFactory[LinearSeq] = LinearSeq
+  override def iterableFactory: SeqFactory[IterableCC] = LinearSeq
 }
 
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](List)

--- a/collections/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Set.scala
@@ -8,7 +8,7 @@ import scala.{Any, Boolean, Int, deprecatedName, `inline`, None, Option, Seriali
 
 /** Base trait for immutable set collections */
 trait Set[A] extends Iterable[A] with collection.Set[A] with SetOps[A, Set, Set[A]] {
-  override def iterableFactory: IterableFactory[Set] = Set
+  override def iterableFactory: IterableFactory[IterableCC] = Set
 }
 
 /** Base trait for immutable set operations

--- a/collections/src/main/scala/strawman/collection/mutable/IndexedSeq.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/IndexedSeq.scala
@@ -5,7 +5,7 @@ trait IndexedSeq[T] extends Seq[T]
   with strawman.collection.IndexedSeq[T]
   with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]] {
 
-  override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq
+  override def iterableFactory: SeqFactory[IterableCC] = IndexedSeq
 }
 
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](ArrayBuffer)

--- a/collections/src/main/scala/strawman/collection/mutable/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Seq.scala
@@ -11,7 +11,7 @@ trait Seq[A]
     with collection.Seq[A]
     with SeqOps[A, Seq, Seq[A]] {
 
-  override def iterableFactory: SeqFactory[Seq] = Seq
+  override def iterableFactory: SeqFactory[IterableCC] = Seq
 }
 
 /**

--- a/collections/src/main/scala/strawman/collection/mutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Set.scala
@@ -9,7 +9,10 @@ import scala.{Boolean, Int, None, Option, Some, Unit, `inline`, deprecated}
 trait Set[A]
   extends Iterable[A]
     with collection.Set[A]
-    with SetOps[A, Set, Set[A]]
+    with SetOps[A, Set, Set[A]] {
+
+  override def iterableFactory: IterableFactory[IterableCC] = Set
+}
 
 /**
   * @define coll mutable set


### PR DESCRIPTION
This points to a soundness bug in the compiler. These errors should be
caught. Omitting a necessary override leads to the expected errors in
some cases but not in all.