### PR TITLE
Make deprecated + work for generic Set and Map

### DIFF
--- a/collections/src/main/scala/strawman/collection/Set.scala
+++ b/collections/src/main/scala/strawman/collection/Set.scala
@@ -171,7 +171,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   def concat(that: collection.Iterable[A]): C = fromSpecificIterable(new View.Concat(toIterable, that))
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union ", "2.13.0")
-  @`inline` final def + [B >: A](elem: B): CC[B] = iterableFactory.from(new View.Appended(toIterable, elem))
+  def + (elem: A): C = fromSpecificIterable(new View.Appended(toIterable, elem))
   //TODO We should be able to use `fromIterable` here but Dotty complains about a variance problem with no apparent workaround
 
   /** Alias for `concat` */

--- a/collections/src/main/scala/strawman/collection/SortedMap.scala
+++ b/collections/src/main/scala/strawman/collection/SortedMap.scala
@@ -5,7 +5,7 @@ import strawman.collection.immutable.TreeMap
 import strawman.collection.mutable.Builder
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.{Boolean, Int, Option, Ordering, PartialFunction, Serializable, SerialVersionUID, `inline`, Any}
+import scala.{Boolean, Int, Option, Ordering, PartialFunction, Serializable, SerialVersionUID, `inline`, Any, deprecated}
 
 /** Base type of sorted sets */
 trait SortedMap[K, +V]
@@ -183,6 +183,9 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   /** Alias for `concat` */
   @`inline` final def ++ [K2 >: K, V2 >: V](xs: Iterable[(K2, V2)])(implicit ordering: Ordering[K2]): CC[K2, V2] = concat(xs)
+
+  @deprecated("Consider requiring an immutable SortedMap or fall back to SortedMap.concat ", "2.13.0")
+  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(toIterable, kv))
 
   // We override these methods to fix their return type (which would be `Map` otherwise)
   override def concat[V2 >: V](xs: collection.Iterable[(K, V2)]): CC[K, V2] = sortedMapFactory.from(new View.Concat(toIterable, xs))

--- a/collections/src/main/scala/strawman/collection/SortedSet.scala
+++ b/collections/src/main/scala/strawman/collection/SortedSet.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import scala.{Boolean, Ordering, `inline`, None, Option, Some, Any}
+import scala.{Boolean, Ordering, `inline`, None, Option, Some, Any, deprecated}
 import scala.annotation.unchecked.uncheckedVariance
 
 /** Base type of sorted sets */

--- a/collections/src/main/scala/strawman/collection/immutable/Set.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/Set.scala
@@ -29,7 +29,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   def incl(elem: A): C
 
   /** Alias for `incl` */
-  @`inline` final def + (elem: A): C = incl(elem)
+  override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
     *


### PR DESCRIPTION
We need to make Set.+ invariant to get the right (2.12-compatible)
behavior in SortedSet.

The deprecated collection.Map.+ was missing an override in
collection.SortedMap to get the correct result (like it was already
done for the non-deprecated immutable versions).