### PR TITLE
Fix build error: [error] (timeBenchmark/*:ssExtractDependencies) sbt.…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val collectionsScalaVersionSettings = Seq(
 val commonSettings = Seq(
   organization := "ch.epfl.scala",
   version := "0.10.0-SNAPSHOT",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.13.0-M2",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds"/*, "-opt:l:classpath"*/),
   scalacOptions ++= {
     if (!isDotty.value)


### PR DESCRIPTION
…ResolveException: unresolved dependency: ch.epfl.scala#collection-strawman_2.12;0.10.0-SNAPSHOT: not found

Error:Error while importing SBT project:<br/>...<br/><pre>[info] Resolving org.eclipse.jetty#jetty-server;8.1.16.v20140903 ...
[info] Resolving org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016 ...
[info] Resolving org.eclipse.jetty#jetty-continuation;8.1.16.v20140903 ...
[info] Resolving org.scala-js#scalajs-junit-test-plugin_2.13.0-M2;0.6.20 ...
[info] Done updating.
[info] Resolving org.scala-lang#scala-library;2.13.0-M2 ...
[info] Resolving ch.epfl.scala#collection-strawman_2.13.0-M2;0.10.0-SNAPSHOT ...
[info] Resolving org.scalacheck#scalacheck_2.13.0-M2;1.13.5 ...
[info] Resolving org.scala-sbt#test-interface;1.0 ...
[info] Resolving org.scala-lang#scala-compiler;2.13.0-M2 ...
[info] Resolving org.scala-lang#scala-reflect;2.13.0-M2 ...
[info] Resolving org.scala-lang.modules#scala-xml_2.13.0-M2;1.0.6 ...
[info] Resolving jline#jline;2.14.4 ...
[info] Done updating.
[trace] Stack trace suppressed: run 'last timeBenchmark/*:ssExtractDependencies' for the full output.
[trace] Stack trace suppressed: run 'last timeBenchmark/*:update' for the full output.
[error] (timeBenchmark/*:ssExtractDependencies) sbt.ResolveException: unresolved dependency: ch.epfl.scala#collection-strawman_2.12;0.10.0-SNAPSHOT: not found
[error] (timeBenchmark/*:update) sbt.ResolveException: unresolved dependency: ch.epfl.scala#collection-strawman_2.12;0.10.0-SNAPSHOT: not found
[error] Total time: 4 s, completed 2018-2-24 11:43:33
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=384M; support was removed in 8.0</pre><br/>See complete log in <a href="file:/C:/Users/zhaocong/.IntelliJIdea2017.1/system/log/sbt.last.log">file:/C:/Users/zhaocong/.IntelliJIdea2017.1/system/log/sbt.last.log</a>