### PR TITLE
 Override HashMap.default in Seq.occCounts instead of using Map.withDefaultValue

### DIFF
--- a/collections/src/main/scala/strawman/collection/Seq.scala
+++ b/collections/src/main/scala/strawman/collection/Seq.scala
@@ -769,7 +769,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     fromIterable(new View.Patched(this, from, other, replaced))
 
   private[this] def occCounts[B](sq: Seq[B]): mutable.Map[B, Int] = {
-    val occ = mutable.Map.empty[B, Int].withDefaultValue(0)
+    val occ = new mutable.HashMap[B, Int] { override def default(k: B) = 0 }
     for (y <- sq) occ(y) += 1
     occ
   }


### PR DESCRIPTION
Reverting a small change I made [here](https://github.com/scala/collection-strawman/pull/444/files#diff-d2679eddf2a5dee23263f82189f93c81). It was not needed for the purpose of that PR (turns out the anonymous class is only used internally) and can slightly increase the running time of `diff` and `intersect`. This is likely caused by the fact that `Map.withDefaultValue` wraps the default value in a function causing an additional dispatch every time a key is missing.

![image](https://user-images.githubusercontent.com/1107367/36631274-eac7e5b6-196c-11e8-9d14-dd4f4ee12775.png)


