### PR TITLE
Fixes #382 - several entries with the same key in mutable.HashMap

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/HashTable.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/HashTable.scala
@@ -158,13 +158,6 @@ private[mutable] abstract class HashTable[A, B, Entry >: Null <: HashEntry[A, En
       resize(2 * table.length)
   }
 
-  protected[collection] def addEntry2(e: Entry, h: Int): Unit = {
-    e.next = table(h).asInstanceOf[Entry]
-    table(h) = e
-    tableSize += 1
-    nnSizeMapAdd(h)
-  }
-
   /** Find entry with given key in table, or add new one if not found.
    *  May be somewhat faster then `findEntry`/`addEntry` pair as it
    *  computes entry's hash index only once.

--- a/test/junit/src/test/scala/strawman/collection/mutable/HashMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/HashMapTest.scala
@@ -47,6 +47,6 @@ class HashMapTest {
       "value2"
     })
 
-    assertEquals(List((key, "value2")), List.from(map.iterator()))
+    assertEquals(List((key, "value2")), map.toList)
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/mutable/HashMapTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/HashMapTest.scala
@@ -5,6 +5,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import strawman.collection.immutable.List
 
 @RunWith(classOf[JUnit4])
 class HashMapTest {
@@ -34,5 +35,18 @@ class HashMapTest {
     val hm = new mutable.HashMap[Int, Int]()
     hm.put(0, 0)
     hm.getOrElseUpdate(0, throw new AssertionError())
+  }
+
+  @Test
+  def getOrElseUpdate_keyIdempotence(): Unit = {
+    val map = mutable.HashMap[String, String]()
+
+    val key = "key"
+    map.getOrElseUpdate(key, {
+      map.getOrElseUpdate(key, "value1")
+      "value2"
+    })
+
+    assertEquals(List((key, "value2")), List.from(map.iterator()))
   }
 }


### PR DESCRIPTION
* Test `getOrElseUpdate`.
* Repeat search of key after evaluating default value to fix #382.
* Remove redundant code. Threshold check repeats code of `HashTable.addEntry0`. `HashTable.addEntry2` is unused.