### PR TITLE
Make MapWrapper.Entry's hashCode conform to the contract in java.util.Map.Entry's documentation

### DIFF
--- a/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
+++ b/collections/src/main/scala/strawman/collection/convert/Wrappers.scala
@@ -243,7 +243,16 @@ private[collection] trait Wrappers {
             def getKey = k
             def getValue = v
             def setValue(v1 : B) = self.put(k, v1)
-            override def hashCode = byteswap32(k.##) + (byteswap32(v.##) << 16)
+            
+            // It's important that this implementation conform to the contract
+            // specified in the javadocs of java.util.Map.Entry.hashCode
+            //
+            // See https://github.com/scala/bug/issues/10663
+            override def hashCode = {
+              (if (k == null) 0 else k.hashCode()) ^
+              (if (v == null) 0 else v.hashCode())
+            }
+
             override def equals(other: Any) = other match {
               case e: ju.Map.Entry[_, _] => k == e.getKey && v == e.getValue
               case _ => false

--- a/test/junit/src/test/scala/strawman/collection/convert/MapWrapperTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/convert/MapWrapperTest.scala
@@ -4,6 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util
 
 @RunWith(classOf[JUnit4])
 class MapWrapperTest {
@@ -49,11 +50,33 @@ class MapWrapperTest {
 
   // test for scala/bug#8504
   @Test
-  def testHashCode(): Unit = {
+  def testHashCodeNulls(): Unit = {
     import strawman.collection.JavaConverters._
     val javaMap = strawman.collection.immutable.Map(1 -> null).asJava
 
     // Before the fix for scala/bug#8504, this throws a NPE
     javaMap.hashCode
+  }
+  
+  // regression test for https://github.com/scala/bug/issues/10663
+  @Test
+  def testHashCodeEqualsMatchesJavaMap() {
+    import strawman.collection.JavaConverters._
+
+    val jmap = new util.HashMap[String, String]()
+    jmap.put("scala", "rocks")
+    jmap.put("java interop is fun!", "ya!")
+    jmap.put("Ĺởồҝ ïŧ\\'ş ūŋǐčōđẹ", "whyyyy")
+    jmap.put("nulls nooo", null)
+    jmap.put(null, "null keys are you serious??")
+
+    // manually convert to scala map
+    val scalaMap = jmap.entrySet().iterator().asScala.map { e => e.getKey -> e.getValue}.toMap
+
+    val mapWrapper = scalaMap.asJava
+
+    assertEquals(jmap.hashCode(), mapWrapper.hashCode())
+    assertTrue(jmap == mapWrapper)
+    assertTrue(mapWrapper == jmap)
   }
 }


### PR DESCRIPTION
This is a port of https://github.com/scala/scala/pull/6233 , which fixes scala/bug#10663

In the above PR, I also deleted a test (test/files/run/t5880.scala) that was testing for good spread in the (better but incorrect) hashcode implementation. I don't see that same test anywhere in this repo however.