### PR TITLE
Make LinkedList.from non recursive.

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LinkedList.scala
@@ -56,7 +56,7 @@ private[mutable] final class LinkedList[A]() extends AbstractSeq[A]
     next = this
   }
 
-  def addOne(elem: A): this.type = { append(LinkedList(elem)); this }
+  def addOne(elem: A): this.type = { append(new LinkedList(elem, LinkedList.empty[A])); this }
 
   // Members declared in strawman.collection.mutable.IterableOps
   def filterInPlace(p: A => Boolean): this.type = {

--- a/test/junit/src/test/scala/strawman/collection/mutable/LinkedListTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/LinkedListTest.scala
@@ -1,0 +1,14 @@
+package strawman.collection.mutable
+
+import strawman.collection.immutable.List
+
+import org.junit.Test
+
+class LinkedListTest {
+
+  @Test
+  def fromTerminates(): Unit = {
+    LinkedList.from(List(1)) // Doesn’t throw a StackOverflowException
+  }
+
+}


### PR DESCRIPTION
Fixes scala/collection-strawman#441

Not sure we are going to keep `LinkedList`, though… (see #490)