### PR TITLE
Add implicit BuildFrom and Factory instances for BitSets

### DIFF
--- a/collections/src/main/scala/strawman/collection/BuildFrom.scala
+++ b/collections/src/main/scala/strawman/collection/BuildFrom.scala
@@ -1,6 +1,6 @@
 package strawman.collection
 
-import scala.{Any, Array, Char, Ordering, `inline`, deprecated}
+import scala.{Any, Array, Char, Int, Ordering, `inline`, deprecated}
 import scala.Predef.String
 import strawman.collection.mutable.Builder
 import scala.annotation.implicitNotFound
@@ -58,10 +58,16 @@ object BuildFrom extends BuildFromLowPriority {
       def newBuilder(from: Array[_]): Builder[A, Array[A]] = Factory.arrayFactory[A].newBuilder()
     }
 
-  implicit def buildFrom[A, B]: BuildFrom[View[A], B, View[B]] =
+  implicit def buildFromView[A, B]: BuildFrom[View[A], B, View[B]] =
     new BuildFrom[View[A], B, View[B]] {
       def fromSpecificIterable(from: View[A])(it: Iterable[B]): View[B] = View.from(it)
       def newBuilder(from: View[A]): Builder[B, View[B]] = View.newBuilder()
+    }
+
+  implicit def buildFromBitSet[C <: BitSet with BitSetOps[C]]: BuildFrom[C, Int, C] =
+    new BuildFrom[C, Int, C] {
+      def fromSpecificIterable(from: C)(it: Iterable[Int]): C = from.bitSetFactory.fromSpecific(it)
+      def newBuilder(from: C): Builder[Int, C] = from.bitSetFactory.newBuilder()
     }
 
 }

--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -245,12 +245,6 @@ object IterableFactory {
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
 
-  implicit def toBuildFrom[A, CC[_]](factory: IterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
-    new BuildFrom[Any, A, CC[A]] {
-      def fromSpecificIterable(from: Any)(it: Iterable[A]) = factory.from(it)
-      def newBuilder(from: Any) = factory.newBuilder()
-    }
-
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
     def empty[A]: CC[A] = delegate.empty
     def from[E](it: IterableOnce[E]): CC[E] = delegate.from(it)
@@ -315,6 +309,8 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   def apply(xs: A*): C = fromSpecific(new View.Elems(xs: _*))
   def fill(n: Int)(elem: => A): C = fromSpecific(new View.Fill(n)(elem))
   def newBuilder(): Builder[A, C]
+
+  implicit def specificIterableFactory: Factory[A, C] = this
 }
 
 /**

--- a/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
@@ -151,4 +151,7 @@ class BuildFromTest {
 
   implicitly[BuildFrom[String, Char, String]]
   implicitly[BuildFrom[Array[Int], Char, Array[Char]]]
+  implicitly[BuildFrom[BitSet, Int, BitSet]]
+  implicitly[BuildFrom[immutable.BitSet, Int, immutable.BitSet]]
+  implicitly[BuildFrom[mutable.BitSet, Int, mutable.BitSet]]
 }

--- a/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/FactoriesTest.scala
@@ -99,5 +99,8 @@ class FactoriesTest {
 
   implicitly[Factory[Char, String]]
   implicitly[Factory[Char, Array[Char]]]
+  implicitly[Factory[Int, BitSet]]
+  implicitly[Factory[Int, mutable.BitSet]]
+  implicitly[Factory[Int, immutable.BitSet]]
 
 }


### PR DESCRIPTION
Fixes scala/collection-strawman#438

Also removes a unused implicit conversion from IterableFactory to BuildFrom.