### PR TITLE
More specific return type for transformation operations of IntMap, LongMap and AnyRefMap

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/IntMap.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package immutable
 
-import scala.{Int, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
+import scala.{Int, None, Boolean, Unit, Any, AnyRef, Nothing, Array, PartialFunction, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
 import java.lang.IllegalStateException
 import strawman.collection
 import strawman.collection.generic.BitOperations
@@ -307,8 +307,13 @@ sealed abstract class IntMap[+T] extends Map[Int, T]
 
   def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]): IntMap[V2] = intMapFromIterable(new View.FlatMap(toIterable, f))
 
-  override def concat [V1 >: T](that: collection.Iterable[(Int, V1)]): IntMap[V1] =
+  override def concat[V1 >: T](that: collection.Iterable[(Int, V1)]): IntMap[V1] =
     super.concat(that).asInstanceOf[IntMap[V1]] // Already has corect type but not declared as such
+
+  override def ++ [V1 >: T](that: collection.Iterable[(Int, V1)]): IntMap[V1] = concat(that)
+
+  def collect[V2](pf: PartialFunction[(Int, T), (Int, V2)]): IntMap[V2] =
+    flatMap(kv => if (pf.isDefinedAt(kv)) new View.Single(pf(kv)) else View.Empty)
 
   /**
     * Updates the map, using the provided function to resolve conflicts if the key is already present.

--- a/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LongMap.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package immutable
 
-import scala.{Int, Long, None, Boolean, Unit, Any, AnyRef, Nothing, Array, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
+import scala.{Int, Long, None, Boolean, Unit, Any, AnyRef, Nothing, Array, PartialFunction, Option, Serializable, SerialVersionUID, Some, IllegalArgumentException, `inline`}
 import java.lang.IllegalStateException
 import strawman.collection.generic.BitOperations
 import strawman.collection.mutable.{Builder, ImmutableBuilder, ListBuffer}
@@ -454,6 +454,12 @@ sealed abstract class LongMap[+T] extends Map[Long, T]
 
   def flatMap[V2](f: ((Long, T)) => IterableOnce[(Long, V2)]): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
-  override def concat [V1 >: T](that: strawman.collection.Iterable[(Long, V1)]): LongMap[V1] =
+  override def concat[V1 >: T](that: strawman.collection.Iterable[(Long, V1)]): LongMap[V1] =
     super.concat(that).asInstanceOf[LongMap[V1]] // Already has corect type but not declared as such
+
+  override def ++ [V1 >: T](that: strawman.collection.Iterable[(Long, V1)]): LongMap[V1] = concat(that)
+
+  def collect[V2](pf: PartialFunction[(Long, T), (Long, V2)]): LongMap[V2] =
+    flatMap(kv => if (pf.isDefinedAt(kv)) new View.Single(pf(kv)) else View.Empty)
+
 }

--- a/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/LongMap.scala
@@ -1,7 +1,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Long, AnyRef, Boolean, NoSuchElementException, Some, None, Option, Unit, Int, Array, Serializable, SerialVersionUID, Nothing, math, deprecated}
+import scala.{Long, AnyRef, Boolean, NoSuchElementException, PartialFunction, Some, None, Option, Unit, Int, Array, Serializable, SerialVersionUID, Nothing, math, deprecated}
 
 /** This class implements mutable maps with `Long` keys based on a hash table with open addressing.
   *
@@ -439,6 +439,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
     lm
   }
 
+  override def ++ [V1 >: V](xs: strawman.collection.Iterable[(Long, V1)]): LongMap[V1] = concat(xs)
+
   @deprecated("Use LongMap.from(m).add(k,v) instead of m.updated(k, v)", "2.13.0")
   def updated[V1 >: V](key: Long, value: V1): LongMap[V1] = {
     val lm = clone().asInstanceOf[LongMap[V1]]
@@ -520,6 +522,10 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
   def map[V2](f: ((Long, V)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
   def flatMap[V2](f: ((Long, V)) => IterableOnce[(Long, V2)]): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
+
+  def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
+    flatMap(kv => if (pf.isDefinedAt(kv)) new View.Single(pf(kv)) else View.Empty)
+
 }
 
 object LongMap {


### PR DESCRIPTION
Fixes scala/collection-strawman#403

Most of the operation had already been fixed by @szeiger in the meantime, but a few were missing.