### PR TITLE
Remove Traversable

### DIFF
--- a/collections/src/main/scala/strawman/collection/Iterable.scala
+++ b/collections/src/main/scala/strawman/collection/Iterable.scala
@@ -18,7 +18,7 @@ import java.lang.String
   * @define Coll `Iterable`
   * @define coll iterable collection
   */
-trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterable[A]] with Traversable[A] {
+trait Iterable[+A] extends IterableOnce[A] with IterableOps[A, Iterable, Iterable[A]] {
 
   // The collection itself
   final def toIterable: this.type = this

--- a/collections/src/main/scala/strawman/collection/Traversable.scala
+++ b/collections/src/main/scala/strawman/collection/Traversable.scala
@@ -1,8 +1,0 @@
-package strawman.collection
-
-import scala.{deprecated, Any}
-
-// We need this in scala-library because scala.reflect.internal.Types.shorthands forces initialization and
-// sequenceToArray in UnCurry uses Traversable's type parameter to determine a collection's element type
-@deprecated("Use Iterable instead of Traversable", "2.13.0")
-trait Traversable[+A] extends Any

--- a/collections/src/main/scala/strawman/collection/package.scala
+++ b/collections/src/main/scala/strawman/collection/package.scala
@@ -5,6 +5,8 @@ import scala.Predef.{String, ArrowAssoc}
 
 package object collection extends LowPriority {
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
+  type Traversable[+X] = Iterable[X]
+  @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
   @deprecated("Use SeqOps instead of SeqLike", "2.13.0")
   type SeqLike[A, T] = SeqOps[A, Seq, T]


### PR DESCRIPTION
It was only there to allow bootstrapping on top of 2.13.0-M3. It is no
longer necessary after https://github.com/scala/scala/pull/6364.