### PR TITLE
Make toString in LazyList consistent with other collections.

### DIFF
--- a/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/LazyList.scala
@@ -4,10 +4,11 @@ package immutable
 
 import strawman.collection.mutable.{ArrayBuffer, Builder}
 
-import scala.{Any, AnyRef, Boolean, Int, NoSuchElementException, None, Nothing, Option, PartialFunction, Some, StringContext, Unit, UnsupportedOperationException, deprecated, noinline}
+import scala.{Any, AnyRef, Boolean, Int, NoSuchElementException, None, Nothing, Option, PartialFunction, Some, StringBuilder, StringContext, Unit, UnsupportedOperationException, deprecated, noinline}
 import scala.Predef.String
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.mutable.StringBuilder
 
 /**  The class `LazyList` implements lazy lists where elements
   *  are only evaluated when they are needed. Here is an example:
@@ -220,6 +221,7 @@ sealed abstract class LazyList[+A] extends LinearSeq[A] with LazyListOps[A, Lazy
     if (this.isEmpty) z
     else tail.foldLeft(op(z, head))(op)
   }
+
 }
 
 sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with LazyListOps[X, CC, CC[X]], +C <: CC[A] with LazyListOps[A, CC, C]]
@@ -298,7 +300,7 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
   /** A FilterMonadic which allows GC of the head of stream during processing */
   @noinline // Workaround scala/bug#9137, see https://github.com/scala/scala/pull/4284#issuecomment-73180791
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, CC] =
-  iterableFactory.withFilter(coll, p)
+    iterableFactory.withFilter(coll, p)
 
   override final def prepended[B >: A](elem: B): CC[B] = cons(elem, coll)
 
@@ -327,26 +329,138 @@ sealed private[immutable] trait LazyListOps[+A, +CC[+X] <: LinearSeq[X] with Laz
   // optimisations are not for speed, but for functionality
   // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)
   override final def flatMap[B](f: A => IterableOnce[B]): CC[B] =
-  if (isEmpty) iterableFactory.empty
-  else {
-    // establish !prefix.isEmpty || nonEmptyPrefix.isEmpty
-    var nonEmptyPrefix: CC[A] = coll
-    var prefix = iterableFactory.from(f(nonEmptyPrefix.head))
-    while (!nonEmptyPrefix.isEmpty && prefix.isEmpty) {
-      nonEmptyPrefix = nonEmptyPrefix.tail
-      if(!nonEmptyPrefix.isEmpty)
-        prefix = iterableFactory.from(f(nonEmptyPrefix.head))
-    }
+    if (isEmpty) iterableFactory.empty
+    else {
+      // establish !prefix.isEmpty || nonEmptyPrefix.isEmpty
+      var nonEmptyPrefix: CC[A] = coll
+      var prefix = iterableFactory.from(f(nonEmptyPrefix.head))
+      while (!nonEmptyPrefix.isEmpty && prefix.isEmpty) {
+        nonEmptyPrefix = nonEmptyPrefix.tail
+        if(!nonEmptyPrefix.isEmpty)
+          prefix = iterableFactory.from(f(nonEmptyPrefix.head))
+      }
 
-    if (nonEmptyPrefix.isEmpty) iterableFactory.empty
-    else prefix.lazyAppendAll(nonEmptyPrefix.tail.flatMap(f))
-  }
+      if (nonEmptyPrefix.isEmpty) iterableFactory.empty
+      else prefix.lazyAppendAll(nonEmptyPrefix.tail.flatMap(f))
+    }
 
   override final def zip[B](that: collection.Iterable[B]): CC[(A, B)] =
     if (this.isEmpty || that.isEmpty) iterableFactory.empty
     else cons[(A, B)]((this.head, that.head), this.tail.zip(that.tail))
 
   override final def zipWithIndex: CC[(A, Int)] = this.zip(LazyList.from(0))
+
+  protected def headDefined: Boolean
+  protected def tailDefined: Boolean
+
+  /**
+    * @return a string representation of this collection. Undefined elements are
+    *         represented with `"_"`, an undefined tail is represented with `"?"`,
+    *         and cycles are represented with `"..."`
+    *
+    *         Examples:
+    *
+    *           - `"LazyList(_, ?)"`, a non-empty lazy list, whose head has not been
+    *             evaluated ;
+    *           - `"LazyList(_, 1, _, ?)"`, a lazy list with at least three elements,
+    *             the second one has been evaluated ;
+    *           - `"LazyList(1, 2, 3, ...)"`, an infinite lazy list that contains
+    *             a cycle at the fourth element.
+    */
+  override def toString: String = {
+    /** Write all defined elements of this iterable into given string builder.
+      *  The written text begins with the string `start` and is finished by the string
+      *  `end`. Inside, the string representations of defined elements (w.r.t.
+      *  the method `toString()`) are separated by the string `sep`. The method will
+      *  not force evaluation of undefined elements. Undefined heads will be represented
+      *  by a `"_"`. An undefined tail is
+      * represented by a `"?"`.  A cyclic stream is represented by a `"..."`
+      * at the point where the cycle repeats.
+      *
+      * @param b The [[collection.mutable.StringBuilder]] factory to which we need
+      * to add the string elements.
+      * @param start The prefix of the resulting string (e.g. "LazyList(")
+      * @param sep The separator between elements of the resulting string (e.g. ",")
+      * @param end The end of the resulting string (e.g. ")")
+      * @return The original [[collection.mutable.StringBuilder]] containing the
+      * resulting string.
+      */
+    def toStringBuilder(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+      b append start
+      if (nonEmpty) {
+        if (headDefined) b append head else b append "_"
+        var cursor = this
+        def appendCursorElement(): Unit = {
+          b append sep
+          if (cursor.headDefined) b append cursor.head else b append "_"
+        }
+        if (tailDefined) {  // If tailDefined, also !isEmpty
+          var scout = tail
+          if (cursor ne scout) {
+            cursor = scout
+            if (scout.tailDefined) {
+              scout = scout.tail
+              // Use 2x 1x iterator trick for cycle detection; slow iterator can add strings
+              while ((cursor ne scout) && scout.tailDefined) {
+                appendCursorElement()
+                cursor = cursor.tail
+                scout = scout.tail
+                if (scout.tailDefined) scout = scout.tail
+              }
+            }
+          }
+          if (!scout.tailDefined) {  // Not a cycle, scout hit an end
+            while (cursor ne scout) {
+              appendCursorElement()
+              cursor = cursor.tail
+            }
+            if (cursor.nonEmpty) {
+              appendCursorElement()
+            }
+          }
+          else {
+            // Cycle.
+            // If we have a prefix of length P followed by a cycle of length C,
+            // the scout will be at position (P%C) in the cycle when the cursor
+            // enters it at P.  They'll then collide when the scout advances another
+            // C - (P%C) ahead of the cursor.
+            // If we run the scout P farther, then it will be at the start of
+            // the cycle: (C - (P%C) + (P%C)) == C == 0.  So if another runner
+            // starts at the beginning of the prefix, they'll collide exactly at
+            // the start of the loop.
+            var runner = this
+            var k = 0
+            while (runner ne scout) {
+              runner = runner.tail
+              scout = scout.tail
+              k += 1
+            }
+            // Now runner and scout are at the beginning of the cycle.  Advance
+            // cursor, adding to string, until it hits; then we'll have covered
+            // everything once.  If cursor is already at beginning, we'd better
+            // advance one first unless runner didn't go anywhere (in which case
+            // we've already looped once).
+            if ((cursor eq scout) && (k > 0)) {
+              appendCursorElement()
+              cursor = cursor.tail
+            }
+            while (cursor ne scout) {
+              appendCursorElement()
+              cursor = cursor.tail
+            }
+          }
+        }
+        if (cursor.nonEmpty) {
+          // Either undefined or cyclic; we can check with tailDefined
+          if (!cursor.tailDefined) b append sep append "?"
+          else b append sep append "..."
+        }
+      }
+      b append end
+    }
+
+    s"$className${toStringBuilder(new StringBuilder, "(", ", ", ")").result()}"
+  }
 
 }
 
@@ -444,8 +558,9 @@ object LazyList extends LazyListFactory[LazyList] {
     override def head: Nothing = throw new NoSuchElementException("head of empty lazy list")
     override def tail: LazyList[Nothing] = throw new UnsupportedOperationException("tail of empty lazy list")
     def force: this.type = this
-    override def toString(): String = "Empty"
     override def knownSize: Int = 0
+    protected def tailDefined: Boolean = false
+    protected def headDefined: Boolean = false
   }
 
   final class Cons[A](hd: => A, tl: => LazyList[A]) extends LazyList[A] {
@@ -479,9 +594,9 @@ object LazyList extends LazyListFactory[LazyList] {
       }
       this
     }
-    override def toString(): String =
-      if (hdEvaluated) s"$head #:: ${if (tlEvaluated) tail.toString else "?"}"
-      else "LazyList(?)"
+
+    protected def tailDefined: Boolean = tlEvaluated
+    protected def headDefined: Boolean = hdEvaluated
   }
 
   /** An alternative way of building and matching Streams using LazyList.cons(hd, tl).
@@ -541,6 +656,8 @@ object LazyList extends LazyListFactory[LazyList] {
 sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream, Stream[A]] {
   override def iterableFactory: LazyListFactory[Stream] = Stream
 
+  override def className: String = "Stream"
+
   protected[this] def cons[T](hd: => T, tl: => Stream[T]): Stream[T] = new Stream.Cons(hd, tl)
 
   /** Apply the given function `f` to each element of this linear sequence
@@ -575,6 +692,7 @@ sealed abstract class Stream[+A] extends LinearSeq[A] with LazyListOps[A, Stream
     if (this.isEmpty) z
     else tail.foldLeft(op(z, head))(op)
   }
+
 }
 
 @deprecated("Use LazyList (which has a lazy head and tail) instead of Stream (which has a lazy tail only)", "2.13.0")
@@ -596,8 +714,9 @@ object Stream extends LazyListFactory[Stream] {
       *  @return The fully realized `Stream`.
       */
     def force: this.type = this
-    override def toString(): String = "Empty"
     override def knownSize: Int = 0
+    protected def headDefined: Boolean = false
+    protected def tailDefined: Boolean = false
   }
 
   final class Cons[A](override val head: A, tl: => Stream[A]) extends Stream[A] {
@@ -607,6 +726,8 @@ object Stream extends LazyListFactory[Stream] {
       tlEvaluated = true
       tl
     }
+    protected def headDefined: Boolean = true
+    protected def tailDefined: Boolean = tlEvaluated
     /** Forces evaluation of the whole `Stream` and returns it.
       *
       * @note Often we use `Stream`s to represent an infinite set or series.  If
@@ -630,8 +751,6 @@ object Stream extends LazyListFactory[Stream] {
       }
       this
     }
-    override def toString(): String =
-      s"$head #:: ${if (tlEvaluated) tail.toString else "?"}"
 
   }
 

--- a/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/immutable/StreamTest.scala
@@ -134,7 +134,7 @@ class StreamTest {
     assertEquals(3, i)
     // it's possible to implement `force` with incorrect string representation
     // (to forget about `tlEvaluated` update)
-    assertEquals( "1 #:: 2 #:: 3 #:: Empty", xs.toString())
+    assertEquals( "Stream(1, 2, 3)", xs.toString())
   }
 
   val cycle1: Stream[Int] = 1 #:: 2 #:: cycle1
@@ -149,5 +149,68 @@ class StreamTest {
     assert(!Stream(1).sameElements(Stream(2)))
     assert(!cycle1.sameElements(cycle2))
     assert(!cycle1.sameElements(cycle2))
+  }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailBothAreNotEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    assertEquals("Stream(1, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenOnlyHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    assertEquals("Stream(1, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    l.tail
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadAndTailHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.head
+    l.tail.head
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.tail
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+    val l = Stream(1, 2, 3, 4, 5)
+    l.tail.head
+    assertEquals("Stream(1, 2, ?)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenStreamIsForcedToList: Unit = {
+    val l = 1 #:: 2 #:: 3 #:: 4 #:: Stream.empty
+    l.toList
+    assertEquals("Stream(1, 2, 3, 4)", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenStreamIsEmpty: Unit = {
+    val l = Stream.empty
+    assertEquals("Stream()", l.toString)
+  }
+
+  @Test
+  def testStreamToStringWhenStreamHasCyclicReference: Unit = {
+    lazy val cyc: Stream[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
+    cyc.tail.tail.tail.tail
+    assertEquals("Stream(1, 2, 3, 4, ...)", cyc.toString)
   }
 }


### PR DESCRIPTION
Fixes scala/collection-strawman#376
Fixes scala/collection-strawman#420

This is a rebased and squashed version of #446 (authored by @dhanesharole).