### PR TITLE
Fix bounds checks, etc. in ArrayDeque

### DIFF
--- a/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
@@ -129,7 +129,7 @@ class ArrayDeque[A] protected (
   }
 
   def insert(idx: Int, elem: A): Unit = {
-    requireBounds(idx)
+    requireBounds(idx, length+1)
     val n = length
     if (idx == 0) {
       prepend(elem)
@@ -164,7 +164,7 @@ class ArrayDeque[A] protected (
   }
 
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
-    requireBounds(idx)
+    requireBounds(idx, length+1)
     val n = length
     if (idx == 0) {
       prependAll(elems)
@@ -428,8 +428,6 @@ class ArrayDeque[A] protected (
   override def copyToArray[B >: A](dest: Array[B], destStart: Int, len: Int): dest.type =
     copySliceToArray(srcStart = 0, dest = dest, destStart = destStart, maxItems = len)
 
-  override def className = "ArrayDeque"
-
   override def toArray[B >: A: ClassTag]: Array[B] =
     copySliceToArray(srcStart = 0, dest = new Array[B](length), destStart = 0, maxItems = length)
 
@@ -444,7 +442,7 @@ class ArrayDeque[A] protected (
     * @param maxItems
     */
   def copySliceToArray(srcStart: Int, dest: Array[_], destStart: Int, maxItems: Int): dest.type = {
-    requireBounds(destStart, 0, dest.length)
+    requireBounds(destStart, dest.length+1)
     val toCopy = Math.min(maxItems, Math.min(length - srcStart, dest.length - destStart))
     if (toCopy > 0) {
       requireBounds(srcStart)
@@ -483,8 +481,8 @@ class ArrayDeque[A] protected (
     reset(array = array2, start = 0, end = n)
   }
 
-  @inline private[this] def requireBounds(idx: Int, from: Int = 0, until: Int = length) =
-    if (idx < 0 || until <= idx) throw new IndexOutOfBoundsException(idx.toString)
+  @inline private[this] def requireBounds(idx: Int, until: Int = length) =
+    if (idx < 0 || idx >= until) throw new IndexOutOfBoundsException(idx.toString)
 }
 
 /**

--- a/test/junit/src/test/scala/strawman/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/mutable/ArrayDequeTest.scala
@@ -4,6 +4,7 @@ package collection.mutable
 import strawman.collection.immutable.List
 
 import org.junit.Test
+import org.junit.Assert._
 
 class ArrayDequeTest {
 
@@ -50,5 +51,19 @@ class ArrayDequeTest {
       assert(buffer.slice(i, j) == buffer2.slice(i, j))
       if (i > 0 && j > 0) assert(List.from(buffer.sliding(i, j)) == List.from(buffer2.sliding(i, j)))
     }
+  }
+
+  @Test
+  def queueBounds: Unit = {
+    import strawman.collection.mutable.Queue
+
+    val xs = Queue.empty[Int]
+    assertEquals("Queue()", xs.toString)
+
+    val a = xs.toArray
+    assertEquals(0, a.length)
+
+    xs.insert(0, 0)
+    assertEquals(Queue(0), xs)
   }
 }


### PR DESCRIPTION
This also affects subclasses like mutable.Queue.

- Remove unnecessary `from` paramter in `requireBounds`.
- Allow `copyToSlice` directly beyond the end of a target array for a
  no-op. This is required to make it work for empty arrays.
- Allow `insert` and `insertAll` directly beyond the end of the
  `ArrayDeque` for appending to the end.
- Remove explicit `className` in `ArrayDeque` to have it computed
  correctly for subclasses like `Queue`.

Fixes https://github.com/scala/collection-strawman/issues/506