### PR TITLE
More fixes from latest rebasing of Scala 2.13.x integration build

### DIFF
--- a/collections/src/main/scala/strawman/collection/ArrayOps.scala
+++ b/collections/src/main/scala/strawman/collection/ArrayOps.scala
@@ -135,7 +135,7 @@ object ArrayOps {
   }
 
   private class ReverseIterator[A](private[this] val xs: Array[A]) extends Iterator[A] {
-    private[this] var pos = length-1
+    private[this] var pos = xs.length-1
     def hasNext: Boolean = pos >= 0
     def next(): A = try {
       val r = xs(pos)

--- a/collections/src/main/scala/strawman/collection/Factory.scala
+++ b/collections/src/main/scala/strawman/collection/Factory.scala
@@ -245,6 +245,12 @@ object IterableFactory {
       def newBuilder(): Builder[A, CC[A]] = factory.newBuilder[A]()
     }
 
+  implicit def toBuildFrom[A, CC[_]](factory: IterableFactory[CC]): BuildFrom[Any, A, CC[A]] =
+    new BuildFrom[Any, A, CC[A]] {
+      def fromSpecificIterable(from: Any)(it: Iterable[A]) = factory.from(it)
+      def newBuilder(from: Any) = factory.newBuilder()
+    }
+
   class Delegate[CC[_]](delegate: IterableFactory[CC]) extends IterableFactory[CC] {
     def empty[A]: CC[A] = delegate.empty
     def from[E](it: IterableOnce[E]): CC[E] = delegate.from(it)

--- a/collections/src/main/scala/strawman/collection/StringOps.scala
+++ b/collections/src/main/scala/strawman/collection/StringOps.scala
@@ -20,7 +20,7 @@ object StringOps {
 
 import StringOps._
 
-final class StringOps(val s: String)
+final class StringOps(private val s: String)
   extends AnyVal
     with IterableOnce[Char]
     with collection.IndexedSeqOps[Char, immutable.IndexedSeq, String]

--- a/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/AnyRefMap.scala
@@ -431,10 +431,10 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   def flatMap[K2 <: AnyRef, V2](f: ((K with AnyRef, V)) => IterableOnce[(K2, V2)])(implicit ev: K2 <:< AnyRef): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.FlatMap(toIterable, f))
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K with AnyRef, V), (K2, V2)])(implicit ev: K2 <:< AnyRef): AnyRefMap[K2, V2] =
-    flatMap { kv =>
+    flatMap { kv: (K with AnyRef, V) =>
       if (pf.isDefinedAt(kv)) new View.Single(pf(kv))
       else View.Empty
-    }
+    }(ev)
 }
 
 object AnyRefMap {

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
@@ -330,6 +330,19 @@ class ArrayDeque[A] protected (
   }
 
   /**
+    * Remove all elements from this collection and return the elements in reverse while emptying this data structure
+    * @return
+    */
+  def removeAllReverse(): strawman.collection.immutable.Seq[A] = {
+    val elems = strawman.collection.immutable.Seq.newBuilder[A]()
+    elems.sizeHint(length)
+    while(nonEmpty) {
+      elems += removeLastAssumingNonEmpty()
+    }
+    elems.result()
+  }
+
+  /**
     * Returns and removes all elements from the left of this queue which satisfy the given predicate
     *
     *  @param f   the predicate used for choosing elements

--- a/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/ArrayDeque.scala
@@ -320,8 +320,8 @@ class ArrayDeque[A] protected (
     * Remove all elements from this collection and return the elements while emptying this data structure
     * @return
     */
-  def removeAll(): strawman.collection.Seq[A] = {
-    val elems = strawman.collection.Seq.newBuilder[A]()
+  def removeAll(): strawman.collection.immutable.Seq[A] = {
+    val elems = strawman.collection.immutable.Seq.newBuilder[A]()
     elems.sizeHint(length)
     while(nonEmpty) {
       elems += removeHeadAssumingNonEmpty()
@@ -335,8 +335,8 @@ class ArrayDeque[A] protected (
     *  @param f   the predicate used for choosing elements
     *  @return
     */
-  def removeHeadWhile(f: A => Boolean): strawman.collection.Seq[A] = {
-    val elems = strawman.collection.Seq.newBuilder[A]()
+  def removeHeadWhile(f: A => Boolean): strawman.collection.immutable.Seq[A] = {
+    val elems = strawman.collection.immutable.Seq.newBuilder[A]()
     while(headOption.exists(f)) {
       elems += removeHeadAssumingNonEmpty()
     }
@@ -349,8 +349,8 @@ class ArrayDeque[A] protected (
     *  @param f   the predicate used for choosing elements
     *  @return
     */
-  def removeLastWhile(f: A => Boolean): strawman.collection.Seq[A] = {
-    val elems = strawman.collection.Seq.newBuilder[A]()
+  def removeLastWhile(f: A => Boolean): strawman.collection.immutable.Seq[A] = {
+    val elems = strawman.collection.immutable.Seq.newBuilder[A]()
     while(lastOption.exists(f)) {
       elems += removeLastAssumingNonEmpty()
     }

--- a/collections/src/main/scala/strawman/collection/mutable/Builder.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Builder.scala
@@ -451,3 +451,8 @@ class StringBuilder(private val sb: java.lang.StringBuilder) extends Builder[Cha
    */
   def lastIndexOf(str: String, fromIndex: Int): Int = sb.lastIndexOf(str, fromIndex)
 }
+
+object StringBuilder {
+  @deprecated("Use `new StringBuilder()` instead of `StringBuilder.newBuilder`", "2.13.0")
+  def newBuilder = new StringBuilder
+}

--- a/collections/src/main/scala/strawman/collection/mutable/Queue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Queue.scala
@@ -97,14 +97,13 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @param f   the predicate used for choosing elements
     *  @return
     */
-  def dequeueAll(f: A => Boolean): strawman.collection.Seq[A] = removeHeadWhile(f)
+  def dequeueAll(f: A => Boolean): strawman.collection.immutable.Seq[A] = removeHeadWhile(f)
 
   /** Returns the first element in the queue, or throws an error if there
     *  is no element contained in the queue.
     *
     *  @return the first element.
     */
-  @deprecated("Use Queue.head instead of Queue.front", "2.13.0")
   @`inline` final def front: A = head
 
   override def clone(): Queue[A] = {

--- a/collections/src/main/scala/strawman/collection/mutable/Queue.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Queue.scala
@@ -9,7 +9,7 @@
 package strawman.collection
 package mutable
 
-import scala.{Array, AnyRef, Boolean, Int, Option, None, Some, SerialVersionUID, Serializable}
+import scala.{Array, AnyRef, Boolean, Int, Option, None, Some, SerialVersionUID, Serializable, `inline`, deprecated}
 
 import strawman.collection.toNewSeq
 
@@ -98,6 +98,14 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @return
     */
   def dequeueAll(f: A => Boolean): strawman.collection.Seq[A] = removeHeadWhile(f)
+
+  /** Returns the first element in the queue, or throws an error if there
+    *  is no element contained in the queue.
+    *
+    *  @return the first element.
+    */
+  @deprecated("Use Queue.head instead of Queue.front", "2.13.0")
+  @`inline` final def front: A = head
 
   override def clone(): Queue[A] = {
     val bf = newSpecificBuilder()

--- a/collections/src/main/scala/strawman/collection/mutable/Stack.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Stack.scala
@@ -20,6 +20,7 @@ import strawman.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory,
   *  @define willNotTerminateInf
   */
 @SerialVersionUID(3L)
+//TODO add in scala.collection namespace: @migration("Stack is now based on an ArrayDeque instead of a linked list", "2.13.0")
 class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   extends ArrayDeque[A](array, start, end)
     with IndexedSeqOps[A, Stack, Stack[A]]
@@ -38,7 +39,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     * @param elem
     * @return
     */
-  def push(elem: A): this.type = this += elem
+  def push(elem: A): this.type = prepend(elem)
 
   /** Push two or more elements onto the stack. The last element
     *  of the sequence will be on top of the new stack.
@@ -46,7 +47,11 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @param   elems      the element sequence.
     *  @return the stack with the new elements on top.
     */
-  def push(elem1: A, elem2: A, elems: A*): this.type = push(elem1).push(elem2).pushAll(elems.toStrawman)
+  def push(elem1: A, elem2: A, elems: A*): this.type = {
+    val k = elems.toStrawman.knownSize
+    ensureSize(length + (if(k >= 0) k + 2 else 3))
+    prepend(elem1).prepend(elem2).pushAll(elems.toStrawman)
+  }
 
   /** Push all elements in the given traversable object onto the stack. The
     *  last element in the traversable object will be on top of the new stack.
@@ -54,7 +59,11 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @param elems the traversable object.
     *  @return the stack with the new elements on top.
     */
-  def pushAll(elems: strawman.collection.IterableOnce[A]): this.type = this ++= elems
+  def pushAll(elems: strawman.collection.IterableOnce[A]): this.type =
+    prependAll(elems match {
+      case it: strawman.collection.Seq[A] => it.view.reverse
+      case it => IndexedSeq.from(it).view.reverse
+    })
 
   /**
     * Removes the top element from this stack and return it
@@ -62,14 +71,14 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     * @return
     * @throws java.util.NoSuchElementException when stack is empty
     */
-  def pop(): A = removeLast()
+  def pop(): A = removeHead()
 
   /**
     * Pop all elements from this stack and return it
     *
     * @return The removed elements
     */
-  def popAll(): strawman.collection.Seq[A] = removeAll()
+  def popAll(): strawman.collection.Seq[A] = removeAllReverse()
 
   /**
     * Returns and removes all elements from the top of this stack which satisfy the given predicate
@@ -77,7 +86,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @param f   the predicate used for choosing elements
     *  @return The removed elements
     */
-  def popWhile(f: A => Boolean): strawman.collection.Seq[A] = removeLastWhile(f)
+  def popWhile(f: A => Boolean): strawman.collection.Seq[A] = removeHeadWhile(f)
 
   /** Returns the top element of the stack. This method will not remove
     *  the element from the stack. An error is signaled if there is no
@@ -86,7 +95,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @throws java.util.NoSuchElementException
     *  @return the top element
     */
-  @`inline` final def top: A = last
+  @`inline` final def top: A = head
 
   override def clone(): Stack[A] = {
     val bf = newSpecificBuilder()

--- a/collections/src/main/scala/strawman/collection/mutable/Stack.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/Stack.scala
@@ -1,6 +1,6 @@
 package strawman.collection.mutable
 
-import scala.{AnyRef, Array, Boolean, Int, SerialVersionUID, Serializable}
+import scala.{AnyRef, Array, Boolean, Int, SerialVersionUID, Serializable, `inline`}
 import strawman.collection.{IterableOnce, SeqFactory, StrictOptimizedSeqFactory, StrictOptimizedSeqOps, toNewSeq}
 
 /** A stack implements a data structure which allows to store and retrieve
@@ -78,6 +78,15 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     *  @return The removed elements
     */
   def popWhile(f: A => Boolean): strawman.collection.Seq[A] = removeLastWhile(f)
+
+  /** Returns the top element of the stack. This method will not remove
+    *  the element from the stack. An error is signaled if there is no
+    *  element on the stack.
+    *
+    *  @throws java.util.NoSuchElementException
+    *  @return the top element
+    */
+  @`inline` final def top: A = last
 
   override def clone(): Stack[A] = {
     val bf = newSpecificBuilder()

--- a/collections/src/main/scala/strawman/collection/mutable/package.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/package.scala
@@ -11,6 +11,10 @@ package object mutable {
   type Traversable[X] = Iterable[X]
   @deprecated("Use Iterable instead of Traversable", "2.13.0")
   val Traversable = Iterable
+  @deprecated("Use Stack instead of ArrayStack; it now uses an array-based implementation", "2.13.0")
+  type ArrayStack[X] = Stack[X]
+  @deprecated("Use Stack instead of ArrayStack; it now uses an array-based implementation", "2.13.0")
+  val ArrayStack = Stack
 
   @deprecated("mutable.LinearSeq has been removed; use LinearSeq with mutable.Seq instead", "2.13.0")
   type LinearSeq[X] = Seq[X] with strawman.collection.LinearSeq[X]

--- a/test/junit/src/test/scala/strawman/collection/ArrayOpsTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/ArrayOpsTest.scala
@@ -1,12 +1,12 @@
 package strawman.collection
 
-import org.junit.Assert.{ assertArrayEquals,assertTrue }
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.Predef.{ refArrayOps => _, genericArrayOps => _, genericWrapArray => _, wrapRefArray => _, _ }
-import strawman.collection.arrayToArrayOps
+import scala.Predef.{ $conforms, classOf }
+import strawman.collection.immutable.List
 
 @RunWith(classOf[JUnit4])
 class ArrayOpsTest {
@@ -28,5 +28,11 @@ class ArrayOpsTest {
     assertArrayEquals(Array(1, 2, 3), a1)
     assertArrayEquals(Array('a', 'b', 'c'), a2)
     assertTrue(Array(true, false, true).sameElements(a3))
+  }
+
+  @Test
+  def reverseIterator: Unit = {
+    val a = Array(1,2,3)
+    assertEquals(List(3,2,1), a.reverseIterator.toList)
   }
 }

--- a/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
+++ b/test/junit/src/test/scala/strawman/collection/BuildFromTest.scala
@@ -154,4 +154,10 @@ class BuildFromTest {
   implicitly[BuildFrom[BitSet, Int, BitSet]]
   implicitly[BuildFrom[immutable.BitSet, Int, immutable.BitSet]]
   implicitly[BuildFrom[mutable.BitSet, Int, mutable.BitSet]]
+
+  // Check that collection companions can implicitly be converted to a `BuildFrom` instance
+  Iterable: BuildFrom[_, Int, Iterable[Int]]
+  Map: BuildFrom[_, (Int, String), Map[Int, String]]
+  SortedSet: BuildFrom[_, Int, SortedSet[Int]]
+  SortedMap: BuildFrom[_, (Int, String), SortedMap[Int, String]]
 }


### PR DESCRIPTION
- Restore `IterableFactory.toBuildFrom` which was erroneously removed
  in https://github.com/scala/collection-strawman/pull/495
- Fix `ArrayOps.ReverseIterator`
- More explicit syntax in `AnyRefMap.collect` implementation to make it
  compile with and without Predef
- Add a deprecated `front` method to `mutable.Queue`
