### PR TITLE
Reduce allocation and CPU usage in distinct

### DIFF
--- a/benchmarks/time/src/main/scala/strawman/collection/immutable/DistinctBenchmark.scala
+++ b/benchmarks/time/src/main/scala/strawman/collection/immutable/DistinctBenchmark.scala
@@ -1,0 +1,70 @@
+package scala.collection
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class DistinctBenchmark {
+  @Param(Array("0", "1", "2", "5", "10", "20", "50", "100", "1000"))
+  var size: Int = _
+
+  @Param(Array("List", "Vector"))
+  var collectionType: String = _
+
+  var distinctDataSet: Seq[String] = null
+  var lastDuplicatedDataSet: Seq[String] = null
+  var firstDuplicatedDataSet: Seq[String] = null
+  var interleavedDuplicationDataSet: Seq[String] = null
+  var sequentialDuplicationDataSet: Seq[String] = null
+
+  @Setup(Level.Trial) def init(): Unit = {
+    val b1 = List.newBuilder[String]
+    val b2 = List.newBuilder[String]
+    0 until size foreach { i =>
+      b1 += i.toString
+      b2 += i.toString
+      b2 += i.toString
+    }
+
+    val adjustCollectionType = collectionType match {
+      case "List" => (col: Seq[String]) => col.toList
+      case "Vector" => (col: Seq[String]) => col.toVector
+    }
+
+    distinctDataSet = adjustCollectionType(b1.result())
+    interleavedDuplicationDataSet = adjustCollectionType(b2.result())
+    sequentialDuplicationDataSet = adjustCollectionType(distinctDataSet ++ distinctDataSet)
+
+    if (size > 0) {
+      firstDuplicatedDataSet = adjustCollectionType(distinctDataSet.head +: distinctDataSet)
+      lastDuplicatedDataSet = adjustCollectionType(distinctDataSet :+ distinctDataSet.head)
+    }
+  }
+
+  @Benchmark def testDistinct: Any = {
+    distinctDataSet.distinct
+  }
+
+  @Benchmark def testFirstDuplicated: Any = {
+    firstDuplicatedDataSet.distinct
+  }
+
+  @Benchmark def testLastDuplicated: Any = {
+    lastDuplicatedDataSet.distinct
+  }
+
+  @Benchmark def testInterleavedDuplication: Any = {
+    interleavedDuplicationDataSet.distinct
+  }
+
+  @Benchmark def testSequentialDuplication: Any = {
+    sequentialDuplicationDataSet.distinct
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val collectionsScalaVersionSettings = Seq(
 val commonSettings = Seq(
   organization := "ch.epfl.scala",
   version := "0.10.0-SNAPSHOT",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.13.0-M2",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:higherKinds"/*, "-opt:l:classpath"*/),
   scalacOptions ++= {
     if (!isDotty.value)

--- a/collections/src/main/scala/strawman/collection/Iterator.scala
+++ b/collections/src/main/scala/strawman/collection/Iterator.scala
@@ -469,18 +469,12 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
         if (!self.hasNext) false
         else {
           nextElement = self.next()
-          val y = f(nextElement)
-          if (traversedValues.contains(y)) {
-            loop()
-          } else {
-            traversedValues += y
-            nextElementDefined = true
-            true
-          }
+          traversedValues.add(f(nextElement)) || loop()
         }
       }
 
-      nextElementDefined || loop()
+      nextElementDefined = nextElementDefined || loop()
+      nextElementDefined
     }
 
     def next(): A =


### PR DESCRIPTION
<sup>THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.</sup>

We can optimize algorithm by adding element to hashmap and checking if it was already present in one method call.

This is follow-up of https://github.com/scala/scala/pull/6316 to 2.13.
Not all optimizations from previous PR are used, look at comment on the code for details.

Benchmarks are coming very soon.
