### PR TITLE
Dotty #4013

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 jdk: oraclejdk8
 script:
-  - sbt ++2.12.4 memoryBenchmark/compile test ++2.13.0-M2 timeBenchmark/compile test ++0.7.0-RC1 test
+  - sbt ++2.12.4 memoryBenchmark/compile test ++2.13.0-M2 timeBenchmark/compile test ++0.8.0-bin-20180317-b499a9a-NIGHTLY test
   - sbt ++2.13.0-M2 collections-contribJVM/test junit/test scalacheck/test
   - sbt ++2.12.4 collectionsJS/test ++2.13.0-M2 collectionsJS/test collections-contribJS/test
 before_script:

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import org.scalajs.sbtplugin.cross.CrossProject
 
 // Convenient setting that allows writing `set scalaVersion := dotty.value` in sbt shell to switch from Scala to Dotty
 val dotty = settingKey[String]("dotty version")
-dotty in ThisBuild := "0.7.0-RC1"
+dotty in ThisBuild := "0.8.0-bin-20180317-b499a9a-NIGHTLY"
 
 val collectionsScalaVersionSettings = Seq(
   scalaVersion := "2.13.0-M2",

--- a/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
+++ b/collections/src/main/scala/strawman/collection/immutable/ImmutableArray.scala
@@ -125,8 +125,8 @@ sealed abstract class ImmutableArray[+A]
   * @define coll immutable array
   * @define Coll `ImmutableArray`
   */
-object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] { self =>
-  val untagged: SeqFactory[ImmutableArray] = new ClassTagSeqFactory.AnySeqDelegate(self)
+object ImmutableArray extends StrictOptimizedClassTagSeqFactory[ImmutableArray] {
+  val untagged: SeqFactory[ImmutableArray] = new ClassTagSeqFactory.AnySeqDelegate(this)
 
   private[this] lazy val emptyImpl = new ImmutableArray.ofRef[Nothing](new Array[Nothing](0))
 

--- a/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/UnrolledBuffer.scala
@@ -229,9 +229,9 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 }
 
 
-object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] { self =>
+object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] {
 
-  val untagged: SeqFactory[UnrolledBuffer] = new ClassTagSeqFactory.AnySeqDelegate(self)
+  val untagged: SeqFactory[UnrolledBuffer] = new ClassTagSeqFactory.AnySeqDelegate(this)
 
   def empty[A : ClassTag]: UnrolledBuffer[A] = new UnrolledBuffer[A]
 

--- a/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
+++ b/collections/src/main/scala/strawman/collection/mutable/WrappedArray.scala
@@ -78,8 +78,8 @@ abstract class WrappedArray[T]
 
 /** A companion object used to create instances of `WrappedArray`.
   */
-object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] { self =>
-  val untagged: SeqFactory[WrappedArray] = new ClassTagSeqFactory.AnySeqDelegate(self)
+object WrappedArray extends StrictOptimizedClassTagSeqFactory[WrappedArray] {
+  val untagged: SeqFactory[WrappedArray] = new ClassTagSeqFactory.AnySeqDelegate(this)
 
   // This is reused for all calls to empty.
   private val EmptyWrappedArray  = new ofRef[AnyRef](new Array[AnyRef](0))


### PR DESCRIPTION
This version of Dotty fixes several unsoundness issues and remove the unsound protected[this] escape hatch for variance checking. See lampepfl/dotty#4013

@julienrf You might want to play with this branch and make it compile with Dotty