### PR TITLE
Don’t replace Stream with LazyList

### DIFF
--- a/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
+++ b/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
@@ -4,7 +4,8 @@ rule = "scala:fix.Collectionstrawman_v0"
 package fix
 
 object Collectionstrawman_v0_Stream {
-  Stream(1, 2, 3)
+  val s = Stream(1, 2, 3)
+  s.append(List(4, 5, 6))
   1 #:: 2 #:: 3 #:: Stream.Empty
   val isEmpty: Stream[_] => Boolean = {
     case Stream.Empty => true

--- a/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
+++ b/scalafix/2.13/input/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
@@ -4,11 +4,5 @@ rule = "scala:fix.Collectionstrawman_v0"
 package fix
 
 object Collectionstrawman_v0_Stream {
-  val s = Stream(1, 2, 3)
-  s.append(List(4, 5, 6))
-  1 #:: 2 #:: 3 #:: Stream.Empty
-  val isEmpty: Stream[_] => Boolean = {
-    case Stream.Empty => true
-    case x #:: xs     => false
-  }
+  Stream(1, 2, 3).append(List(4, 5, 6))
 }

--- a/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
+++ b/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
@@ -1,7 +1,8 @@
 package fix
 
 object Collectionstrawman_v0_Stream {
-  LazyList(1, 2, 3)
+  val s = LazyList(1, 2, 3)
+  s.lazyAppendAll(List(4, 5, 6))
   1 #:: 2 #:: 3 #:: LazyList.Empty
   val isEmpty: LazyList[_] => Boolean = {
     case LazyList.Empty => true

--- a/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
+++ b/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_Stream.scala
@@ -1,11 +1,5 @@
 package fix
 
 object Collectionstrawman_v0_Stream {
-  val s = LazyList(1, 2, 3)
-  s.lazyAppendAll(List(4, 5, 6))
-  1 #:: 2 #:: 3 #:: LazyList.Empty
-  val isEmpty: LazyList[_] => Boolean = {
-    case LazyList.Empty => true
-    case x #:: xs     => false
-  }
+  Stream(1, 2, 3).lazyAppendAll(List(4, 5, 6))
 }

--- a/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
+++ b/scalafix/2.13/output/src/main/scala/fix/Collectionstrawman_v0_TupleNZipped.scala
@@ -11,7 +11,7 @@ object Collectionstrawman_v0_Tuple2Zipped {
       ys)
     /* a *//* b */ xs /* c */.lazyZip(/* d */ ys /* e */)/* f *//* g *//* h */
     coll(1).lazyZip(coll(2))
-    List(1, 2, 3).lazyZip(LazyList.from(1))
+    List(1, 2, 3).lazyZip(Stream.from(1))
   }
   def coll(x: Int): List[Int] = ???
 }
@@ -27,7 +27,7 @@ object Collectionstrawman_v0_Tuple3Zipped {
       zs)
     /* a *//* b */ xs /* c */.lazyZip(/* d */ ys /* e */).lazyZip(/* f */ zs /* g */)/* h *//* i *//* j */
     coll(1).lazyZip(coll(2)).lazyZip(coll(3))
-    List(1, 2, 3).lazyZip(Set(1, 2, 3)).lazyZip(LazyList.from(1))
+    List(1, 2, 3).lazyZip(Set(1, 2, 3)).lazyZip(Stream.from(1))
   }
   def coll(x: Int): List[Int] = ???
 }

--- a/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -96,10 +96,21 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
         ctx.replaceTree(t, q"$buffer ++= $collection".syntax)
     }.asPatch
 
+  val streamAppend = SymbolMatcher.normalized(
+    Symbol("_root_.scala.collection.immutable.Stream.append.")
+  )
+
+  def replaceStreamAppend(ctx: RuleCtx): Patch =
+    ctx.tree.collect {
+      case streamAppend(t: Name) =>
+        ctx.replaceTree(t, "lazyAppendAll")
+    }.asPatch
+
   override def fix(ctx: RuleCtx): Patch = {
     replaceToList(ctx) +
       replaceSymbols(ctx) +
       replaceTupleZipped(ctx) +
-      replaceCopyToBuffer(ctx)
+      replaceCopyToBuffer(ctx) +
+      replaceStreamAppend(ctx)
   }
 }

--- a/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
+++ b/scalafix/2.13/rules/src/main/scala/fix/Collectionstrawman_v0.scala
@@ -10,8 +10,6 @@ case class Collectionstrawman_v0(index: SemanticdbIndex)
 
   def replaceSymbols(ctx: RuleCtx): Patch = {
     ctx.replaceSymbols(
-      "scala.Stream" -> "scala.LazyList",
-      "scala.collection.immutable.Stream" -> "scala.collection.immutable.LazyList",
       "scala.Traversable" -> "scala.Iterable",
       "scala.collection.Traversable" -> "scala.collection.Iterable",
       "scala.TraversableOnce" -> "scala.IterableOnce",

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -58,8 +58,8 @@ lazy val `input-2_13` = project.in(file("2.13") / "input")
 
 lazy val `output-2_13` = project.in(file("2.13") / "output")
   .settings(
-    resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/",
-    scalaVersion := "2.13.0-pre-47ffa9c-SNAPSHOT"
+    resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
+    scalaVersion := "2.13.0-pre-c577876"
   )
 
 lazy val `tests-2_13` = project.in(file("2.13") / "tests")


### PR DESCRIPTION
Because their behaviour is not the same (`LazyList` has a lazy head) I think we should not rewrite `Stream` usage to `LazyList`. Note that `Stream` is deprecated in 2.13, though, that’s why I’m not totally sure what should be the right decision.

(this PR depends on #527)